### PR TITLE
Remove path prefix from the _icons-embed-template.scss

### DIFF
--- a/src/sass/_icons-embed-template.scss
+++ b/src/sass/_icons-embed-template.scss
@@ -1,6 +1,6 @@
 @font-face {
   font-family: "brainly-icons";
-  src: url($mintFontsPath + "brainly-icons.woff") format("woff");
+  src: url("fonts/brainly-icons.woff") format("woff");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
This path prefix mangle up gulp step when it tries to embed the generated custom icons font.
Fixed.
