### PR TITLE
make headers display:block

### DIFF
--- a/src/sass/_headers.scss
+++ b/src/sass/_headers.scss
@@ -1,5 +1,6 @@
 .mint-header-primary {
   @include component;
+  display: block;
   color: $headerColor;
   font-family: $headerPrimaryFontFamily;
   font-size: $headerPrimaryFontSize;
@@ -11,6 +12,7 @@
 }
 .mint-header-secondary {
   @include component;
+  display: block;
   color: $headerColor;
   font-family: $headerSecondaryFontFamily;
   font-size: $headerSecondaryFontSize;


### PR DESCRIPTION
After `@include component;` was added, headers became `display: inline-block`. They should be `display: block` IMO
