### PR TITLE
Change mint-text-description - it was too small + '--large' version was missing

### DIFF
--- a/docs/basics.html
+++ b/docs/basics.html
@@ -204,6 +204,9 @@
                 <div class="mint-text-description">
                     Together <a href="#" class="mint-text-description__link">we go</a> far!
                 </div>
+                <div class="mint-text-description mint-text-description--small">
+                    Together <a href="#" class="mint-text-description__link">we go</a> far!
+                </div>
             </div>
         </section>
         <section class="docs-block">

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -236,6 +236,8 @@ $textDescriptionFontSize: 18px;
 $textDescriptionLineHeight: 21px;
 $textDescriptionLargeFontSize: 32px;
 $textDescriptionLargeLineHeight: 32px;
+$textDescriptionSmallFontSize: 15px;
+$textDescriptionSmallLineHeight: 19px;
 $textDescriptionLinkColor: $bluePrimary;
 $mintTextEmphasisedFontFamily: $fontFamilySecondary;
 

--- a/src/sass/_text.scss
+++ b/src/sass/_text.scss
@@ -107,6 +107,10 @@
     font-size: $textDescriptionLargeFontSize;
     line-height: $textDescriptionLargeLineHeight;
   }
+  &--small {
+    font-size: $textDescriptionSmallFontSize;
+    line-height: $textDescriptionSmallLineHeight;
+  }
 }
 
 .mint-text-emphasised {


### PR DESCRIPTION
These are sizes that we are actually using. mint-text-description was much smaller, no idea why.

<img width="672" alt="screen shot 2015-07-30 at 16 56 59" src="https://cloud.githubusercontent.com/assets/985504/8986344/0a1450d8-36dc-11e5-97a0-fa15a58a5043.png">
