### PR TITLE
More icons as a button (--small --with-border --gray)

### DIFF
--- a/docs/basics.html
+++ b/docs/basics.html
@@ -240,6 +240,9 @@
                     <li class="icons-list__element mint-icon-answered">- mint-icon-answered</li>
                     <li class="icons-list__element mint-icon-answering">- mint-icon-answering</li>
                     <li class="icons-list__element mint-icon-arrow_down">- mint-icon-arrow_down</li>
+                    <li class="icons-list__element mint-icon-arrow_left">- mint-icon-arrow_left</li>
+                    <li class="icons-list__element mint-icon-arrow_right">- mint-icon-arrow_right</li>
+                    <li class="icons-list__element mint-icon-arrow_up">- mint-icon-arrow_up</li>
                     <li class="icons-list__element mint-icon-check">- mint-icon-check</li>
                     <li class="icons-list__element mint-icon-comment">- mint-icon-comment</li>
                     <li class="icons-list__element mint-icon-excellent">- mint-icon-excellent</li>

--- a/docs/components.html
+++ b/docs/components.html
@@ -188,6 +188,9 @@
                     <div class="mint-sticker mint-sticker--answered"></div>
                     <div class="mint-sticker mint-sticker--answering"></div>
                     <div class="mint-sticker mint-sticker--arrow_down"></div>
+                    <div class="mint-sticker mint-sticker--arrow_left"></div>
+                    <div class="mint-sticker mint-sticker--arrow_right"></div>
+                    <div class="mint-sticker mint-sticker--arrow_up"></div>
                     <div class="mint-sticker mint-sticker--attachment"></div>
                     <div class="mint-sticker mint-sticker--bold"></div>
                     <div class="mint-sticker mint-sticker--check"></div>
@@ -399,6 +402,12 @@
                 <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--with-crown-icon">
                     <span class="mint-button-secondary__text">Mark as best</span>
                 </button>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--gray mint-button-secondary--with-icon-only">
+                    <i class="mint-icon-arrow_left"></i>
+                </button>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--gray mint-button-secondary--with-icon-only">
+                    <i class="mint-icon-arrow_right"></i>
+                </button>
             </div>
         </section>
         <section class="docs-block">
@@ -415,7 +424,25 @@
             <aside class="docs-block__info">
                 <h3 class="docs-block__header">Icon as a button</h3>
             </aside>
-            <button class="mint-icon-as-button mint-icon-comment">Invisible text</button>
+            <div class="docs-block__content">
+                <button class="mint-icon-as-button mint-icon-comment">Invisible text</button>
+                <button class="mint-icon-as-button mint-icon-as-button--gray mint-icon-profile">Invisible text</button>
+                <div class="docs-block__content docs-block__contrast-box">
+                    <button class="mint-icon-as-button mint-icon-as-button--light mint-icon-arrow_right">Invisible text</button>
+                </div>
+
+                <button class="mint-icon-as-button mint-icon-as-button--with-border mint-icon-comment">Invisible text</button>
+                <button class="mint-icon-as-button mint-icon-as-button--gray mint-icon-as-button--with-border mint-icon-profile">Invisible text</button>
+                <div class="docs-block__content docs-block__contrast-box">
+                    <button class="mint-icon-as-button mint-icon-as-button--light mint-icon-as-button--with-border mint-icon-arrow_right">Invisible text</button>
+                </div>
+
+                <button class="mint-icon-as-button mint-icon-as-button--small mint-icon-comment">Invisible text</button>
+                <button class="mint-icon-as-button mint-icon-as-button--gray mint-icon-as-button--small mint-icon-profile">Invisible text</button>
+                <div class="docs-block__content docs-block__contrast-box">
+                    <button class="mint-icon-as-button mint-icon-as-button--small mint-icon-as-button--light mint-icon-as-button--with-border mint-icon-arrow_right">Invisible text</button>
+                </div>
+            </div>
         </section>
     </article>
     <article>

--- a/src/sass/_buttons.scss
+++ b/src/sass/_buttons.scss
@@ -282,7 +282,6 @@
 
   &:before {
     color: $iconAsButtonColor;
-    line-height: 40px;
     font-size: 26px;
   }
 
@@ -290,13 +289,41 @@
     color: rgba($iconAsButtonColor, 0.7);
   }
 
+  &--small {
+    width: 24px;
+    height: 24px;
+
+    &:before {
+      font-size: 18px;
+    }
+  }
+
+  &--with-border {
+    border: solid $iconAsButtonColor 2px;
+    border-radius: 50%;
+  }
+
   &--light {
+    border-color: $iconAsButtonLightColor;
+
     &:before {
       color: $iconAsButtonLightColor;
     }
 
     &:active:before {
       color: rgba($iconAsButtonLightColor, 0.7);
+    }
+  }
+
+  &--gray {
+    border-color: $iconAsButtonGrayColor;
+
+    &:before {
+      color: $iconAsButtonGrayColor;
+    }
+
+    &:active:before {
+      color: rgba($iconAsButtonGrayColor, 0.7);
     }
   }
 }

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -121,6 +121,7 @@ $buttonSecondaryBestTextColor: $black;
 
 $iconAsButtonColor: $bluePrimary;
 $iconAsButtonLightColor: $white;
+$iconAsButtonGrayColor: $grayPrimary;
 
 // Tabs
 $tabBackground: $graySecondaryLight;

--- a/src/sass/_icons-transformed.scss
+++ b/src/sass/_icons-transformed.scss
@@ -1,0 +1,15 @@
+.mint-icon-arrow_right:before,
+.mint-icon-arrow_left:before,
+.mint-icon-arrow_up:before {
+  @extend .mint-icon-arrow_down:before;
+}
+
+.mint-icon-arrow_right:before {
+  transform: rotate(-90deg);
+}
+.mint-icon-arrow_left:before {
+  transform: rotate(90deg);
+}
+.mint-icon-arrow_up:before {
+  transform: rotate(180deg);
+}

--- a/src/sass/_stickers.scss
+++ b/src/sass/_stickers.scss
@@ -38,6 +38,9 @@
   @include from-icon(answering);
   @include from-icon(answered);
   @include from-icon(arrow_down);
+  @include from-icon(arrow_left);
+  @include from-icon(arrow_right);
+  @include from-icon(arrow_up);
   @include from-icon(attachment);
   @include from-icon(bold);
   @include from-icon(check);

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -6,6 +6,7 @@ $mintFontsPath: '../fonts/' !default;
 @import "fonts";
 @import "icons-embed";
 @import "icons-data";
+@import "icons-transformed";
 @import "subjects-icons";
 @import "subject-icon";
 @import "subject-icon-box";


### PR DESCRIPTION
I had to do these:

<img width="133" alt="screen shot 2015-08-03 at 14 55 20" src="https://cloud.githubusercontent.com/assets/985504/9037865/ae0efbe6-39ef-11e5-9a58-870670eb2d0b.png">

so I extended icon-as-a-button with some new modifiers like so:

<img width="459" alt="screen shot 2015-08-03 at 14 54 08" src="https://cloud.githubusercontent.com/assets/985504/9037872/bb7067ac-39ef-11e5-9de9-6d65f5b6d661.png">

But in the process I had to add rotated arrows:

<img width="88" alt="screen shot 2015-08-03 at 14 23 38" src="https://cloud.githubusercontent.com/assets/985504/9037885/c99d9322-39ef-11e5-8800-6cb4f9241577.png">
<img width="624" alt="screen shot 2015-08-03 at 14 18 32" src="https://cloud.githubusercontent.com/assets/985504/9037886/c99f5a5e-39ef-11e5-9b69-14d80209a1c8.png">
