### PR TITLE
Remove line-height offset for ratebox

### DIFF
--- a/src/sass/_rating.scss
+++ b/src/sass/_rating.scss
@@ -52,7 +52,7 @@
     }
 
     .mint-rate-box__counter {
-      @include fixText($rateStarSmallFontSize, 2px);
+      @include fixText($rateStarSmallFontSize);
       margin-left: $layoutDefaultPadding/4;
     }
   }


### PR DESCRIPTION
A thing I've missed from the previously merged PR
