### PR TITLE
Override the margin-right in the label for modifier

### DIFF
--- a/src/sass/_labels.scss
+++ b/src/sass/_labels.scss
@@ -105,6 +105,9 @@ $labelScaleFactor: 2/3;
       @include fixText($labelFontSizeSecondary);
       margin-right: $labelScaleFactor * $layoutDefaultPadding/4;
 
+      &:last-child {
+        margin-right: 0;
+      }
     }
 
     .mint-label__text {


### PR DESCRIPTION
There is a problem with **specificity** :fearful:  if I do not override it like that.
