### PR TITLE
Remove vertical align from mint badge

### DIFF
--- a/src/sass/_badges.scss
+++ b/src/sass/_badges.scss
@@ -6,7 +6,6 @@
   font-size: $badgeFontSize;
   font-family: $badgeFontFamily;
   padding: 3px 6px;
-  vertical-align: inherit;
 
   background-color: $badgeDefaultBackgroundColor;
   color: $badgeDefaultColor;


### PR DESCRIPTION
closes #126
I'v checked symfony, web-client and style guide and looks like removing this property does not break anything.
