### PR TITLE
Remove unnecessary white-space:nowrap from mint-header

### DIFF
--- a/src/sass/_header.scss
+++ b/src/sass/_header.scss
@@ -38,7 +38,6 @@
 
   &__right {
     margin-left: 20px;
-    white-space: nowrap;
     display: flex;
     align-items: center;
   }


### PR DESCRIPTION
It does nothing useful, but screws up my katie popup. I think it should have been removed together  with `vertical-align:inherit`.
