### PR TITLE
Fixed icon visibility in icon as button element on Firefox

### DIFF
--- a/src/sass/_buttons.scss
+++ b/src/sass/_buttons.scss
@@ -305,6 +305,8 @@ $buttonRoundLabelColor: $black;
   height: 40px;
   font-size: 0;
   line-height: 0;
+  overflow: visible;
+  text-align: center;
 
   &:before {
     color: $iconAsButtonColor;


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/169

before:
<img width="463" alt="screen shot 2015-08-27 at 10 39 26" src="https://cloud.githubusercontent.com/assets/1231144/9516299/163462c2-4ca8-11e5-9d20-f043ef2e1a5a.png">
after:
<img width="456" alt="screen shot 2015-08-27 at 10 39 06" src="https://cloud.githubusercontent.com/assets/1231144/9516304/1e639a76-4ca8-11e5-9a88-5d4b408e6c54.png">

:lollipop: 
