### PR TITLE
improved avatars

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -37,7 +37,6 @@ $avatarBackgroundColor: $white;
   &--small {
     width: $avatarSmallSize;
     height: $avatarSmallSize;
-    border-width: $avatarSmallBorderWidth;
 
     &:before {
       top: 3px - $avatarSmallBorderWidth;
@@ -48,7 +47,6 @@ $avatarBackgroundColor: $white;
   &--big {
     width: $avatarBigSize;
     height: $avatarBigSize;
-    border-width: $avatarBigBorderWidth;
 
     &:before {
       top: 5px - $avatarBigBorderWidth;
@@ -58,6 +56,7 @@ $avatarBackgroundColor: $white;
 
   &--with-border {
     border: solid $avatarBorderColor $avatarMediumBorderWidth;
+    border-width: $avatarMediumBorderWidth;
 
     &:before {
       left: -$avatarMediumBorderWidth;
@@ -66,6 +65,7 @@ $avatarBackgroundColor: $white;
 
   &--small-with-border {
     @extend .mint-avatar--with-border;
+    border-width: $avatarSmallBorderWidth;
 
     &:before {
       left: -$avatarMediumBorderWidth;

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -68,7 +68,7 @@ $avatarBackgroundColor: $white;
     border-width: $avatarSmallBorderWidth;
 
     &:before {
-      left: -$avatarMediumBorderWidth;
+      left: -$avatarSmallBorderWidth;
     }
   }
 

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -1,12 +1,13 @@
 $avatarDefaultBackgroundColor: $grayPrimary;
 $avatarDefaultPersonColor: $graySecondary;
-$avatarSmallSize: 28px;
-$avatarMediumSize: 34px;
-$avatarBigSize: 40px;
+$avatarSmallSize: 24px;
+$avatarMediumSize: 32px;
+$avatarBigSize: 48px;
 $avatarSmallBorderWidth: 1px;
 $avatarMediumBorderWidth: 1px;
 $avatarBigBorderWidth: 2px;
 $avatarBorderColor: $white;
+$avatarBackgroundColor: $white;
 
 .mint-avatar {
   @include component;
@@ -14,9 +15,8 @@ $avatarBorderColor: $white;
 
   width: $avatarMediumSize;
   height: $avatarMediumSize;
-  border-radius: $avatarMediumSize/2;
+  border-radius: 50%;
   background: $avatarDefaultBackgroundColor;
-  border: solid $avatarBorderColor $avatarMediumBorderWidth;
   vertical-align: inherit;
 
   &__image {
@@ -24,36 +24,60 @@ $avatarBorderColor: $white;
     top: 0;
     left: 0;
     width: 100%;
+    background-color: $avatarBackgroundColor;
   }
 
   &:before {
     position: relative;
     top: 4px - $avatarMediumBorderWidth;
     color: $avatarDefaultPersonColor;
-    font-size: $avatarMediumSize - $avatarMediumBorderWidth*2;
+    font-size: $avatarMediumSize;
   }
 
   &--small {
     width: $avatarSmallSize;
     height: $avatarSmallSize;
-    border-radius: $avatarSmallSize/2;
     border-width: $avatarSmallBorderWidth;
 
     &:before {
       top: 3px - $avatarSmallBorderWidth;
-      font-size: $avatarSmallSize - $avatarSmallBorderWidth*2;
+      font-size: $avatarSmallSize;
     }
   }
 
   &--big {
     width: $avatarBigSize;
     height: $avatarBigSize;
-    border-radius: $avatarBigSize/2;
-    border-width: 2px;
+    border-width: $avatarBigBorderWidth;
 
     &:before {
       top: 5px - $avatarBigBorderWidth;
-      font-size: $avatarBigSize - $avatarBigBorderWidth*2;
+      font-size: $avatarBigSize;
+    }
+  }
+
+  &--with-border {
+    border: solid $avatarBorderColor $avatarMediumBorderWidth;
+
+    &:before {
+      left: -$avatarMediumBorderWidth;
+    }
+  }
+
+  &--small-with-border {
+    @extend .mint-avatar--with-border;
+
+    &:before {
+      left: -$avatarMediumBorderWidth;
+    }
+  }
+
+  &--big-with-border {
+    @extend .mint-avatar--with-border;
+    border-width: $avatarBigBorderWidth;
+
+    &:before {
+      left: -$avatarBigBorderWidth;
     }
   }
 }

--- a/src/docs/components.html
+++ b/src/docs/components.html
@@ -277,6 +277,18 @@
         </section>
         <section class="docs-block">
             <aside class="docs-block__info">
+                <h3 class="docs-block__header">Default avatars with border</h3>
+            </aside>
+            <div class="docs-block__content">
+                <div class="docs-block__contrast-box">
+                    <div class="mint-avatar mint-avatar--small mint-avatar--small-with-border"></div>
+                    <div class="mint-avatar mint-avatar--with-border"></div>
+                    <div class="mint-avatar mint-avatar--big mint-avatar--big-with-border"></div>
+                </div>
+            </div>
+        </section>
+        <section class="docs-block">
+            <aside class="docs-block__info">
                 <h3 class="docs-block__header">Avatars with image</h3>
             </aside>
             <div class="docs-block__content">
@@ -293,20 +305,17 @@
         </section>
         <section class="docs-block">
             <aside class="docs-block__info">
-                <h3 class="docs-block__header">Avatars - contrast</h3>
+                <h3 class="docs-block__header">Avatars with image and border</h3>
             </aside>
             <div class="docs-block__content">
                 <div class="docs-block__contrast-box">
-                    <div class="mint-avatar mint-avatar--small"></div>
-                    <div class="mint-avatar"></div>
-                    <div class="mint-avatar mint-avatar--big"></div>
-                    <div class="mint-avatar mint-avatar--small">
+                    <div class="mint-avatar mint-avatar--small mint-avatar--small-with-border">
                         <img class="mint-avatar__image mint-avatar__image--small" src="http://lorempixel.com/52/52/"/>
                     </div>
-                    <div class="mint-avatar">
+                    <div class="mint-avatar mint-avatar--with-border">
                         <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
                     </div>
-                    <div class="mint-avatar mint-avatar--big">
+                    <div class="mint-avatar mint-avatar--big mint-avatar--big-with-border">
                         <img class="mint-avatar__image mint-avatar__image--big" src="http://lorempixel.com/76/76/"/>
                     </div>
                 </div>


### PR DESCRIPTION
Implemented improved avatars that component size is set according to vertical rhythm
closes https://github.com/brainly/style-guide/issues/154

before:
<img width="595" alt="screen shot 2015-08-27 at 13 39 27" src="https://cloud.githubusercontent.com/assets/1231144/9519697/318e3962-4cc1-11e5-896a-1955586b56f7.png">

after:
<img width="423" alt="screen shot 2015-08-27 at 13 38 59" src="https://cloud.githubusercontent.com/assets/1231144/9519702/37025482-4cc1-11e5-965e-65714034cf66.png">
