### PR TITLE
Removed shadow on textarea on iOS

### DIFF
--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -265,6 +265,8 @@ $textareaScaleFactor: 2/3;
   resize: none;
   height: 100px;
   overflow-y: auto;
+  appearance: none;
+
   &:focus {
     border-color: $textareaFocusBorderColor;
     outline: 0;


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/206

before
![1](https://cloud.githubusercontent.com/assets/1231144/9539825/a6e4f764-4d57-11e5-8242-de7ac97ab191.png)


after
![2](https://cloud.githubusercontent.com/assets/1231144/9539829/a9f9dee2-4d57-11e5-91e8-449291ebb1e3.png)
