### PR TITLE
Added parameters to skip rdoc installation for ruby gems in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get -y install fontforge
 RUN apt-get install unzip
 RUN wget http://people.mozilla.com/~jkew/woff/woff-code-latest.zip
 RUN unzip woff-code-latest.zip -d sfnt2woff && cd sfnt2woff && make && mv sfnt2woff /usr/local/bin/
-RUN gem install fontcustom
-RUN gem install s3_website
-RUN gem install jekyll
+RUN gem install fontcustom --no-rdoc --no-ri
+RUN gem install s3_website --no-rdoc --no-ri
+RUN gem install jekyll --no-rdoc --no-ri
 
 RUN npm install gulp -g
 RUN npm install http-server -g


### PR DESCRIPTION
... so that we do not download and build docsets during image creation