### PR TITLE
Feature/vertical rhythm

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ The most often question related to BEM is "How do I actually **use** modifiers a
 Here is an example:
 
 ```scss
-$blockFont: $fontFamilyPrimary;
 $tintedElementColor: $graySecondary;
 $blockLightColor: $white;
 

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -4,7 +4,6 @@ $badgeDefaultColor: $white;
 $badgeLightBackgroundColor: $white;
 $badgeLightColor: $black;
 
-
 $include-html: false !default;
 
 @if ($include-html) {
@@ -13,10 +12,10 @@ $include-html: false !default;
     @include component;
 
     border-radius: $badgeFontSize;
-  	line-height: $badgeFontSize;
-  	font-size: $badgeFontSize;
-  	font-weight: bold;
-  	padding: 3px 6px;
+    line-height: $badgeFontSize;
+    font-size: $badgeFontSize;
+    font-weight: bold;
+    padding: 3px 6px;
 
     background-color: $badgeDefaultBackgroundColor;
     color: $badgeDefaultColor;

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -1,9 +1,9 @@
-$badgeFontFamily: $fontFamilySecondary;
 $badgeFontSize: 10px;
 $badgeDefaultBackgroundColor: $peachPrimary;
 $badgeDefaultColor: $white;
 $badgeLightBackgroundColor: $white;
 $badgeLightColor: $black;
+
 
 $include-html: false !default;
 
@@ -13,10 +13,10 @@ $include-html: false !default;
     @include component;
 
     border-radius: $badgeFontSize;
-    line-height: $badgeFontSize;
-    font-size: $badgeFontSize;
-    font-family: $badgeFontFamily;
-    padding: 3px 6px;
+  	line-height: $badgeFontSize;
+  	font-size: $badgeFontSize;
+  	font-weight: bold;
+  	padding: 3px 6px;
 
     background-color: $badgeDefaultBackgroundColor;
     color: $badgeDefaultColor;
@@ -43,5 +43,4 @@ $include-html: false !default;
       transform: scale(1);
     }
   }
-
 }

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -5,9 +5,6 @@ $buttonSecondarySmallHeight: 24px;
 $buttonPrimaryFontSize: 15px;
 $buttonSecondaryFontSize: 12px;
 
-$buttonPrimaryFontFamily: $fontFamilySecondary;
-$buttonSecondaryFontFamily: $fontFamilySecondary;
-
 $buttonPrimaryFontColor: $white;
 
 $buttonColor: $mintPrimary;
@@ -54,8 +51,7 @@ $iconAsButtonGrayColor: $grayPrimary;
 $buttonRoundAddSize: 50px;
 $buttonRoundAddFontSize: 18px;
 $buttonRoundAddColor: $white;
-$buttonRoundLabelFontFamily: $fontFamilySecondary;
-$buttonRoundLabelFontFamily: $fontFamilySecondary;
+
 $buttonRoundLabelFontSize: 10px;
 $buttonRoundLabelBackground: $mintSecondaryLight;
 $buttonRoundLabelColor: $black;
@@ -159,7 +155,7 @@ $include-html: false !default;
 }
 
 @if ($include-html) {
-
+  
   // Primary buttons
   .mint-button-primary {
     @include mint-button-basic-styles();
@@ -218,7 +214,7 @@ $include-html: false !default;
     }
     &__label {
       float: left;
-      font-family: $buttonRoundLabelFontFamily;
+      font-weight: bold;
       font-size: $buttonRoundLabelFontSize;
       border-radius: 4px;
       line-height: 12px;
@@ -244,7 +240,7 @@ $include-html: false !default;
     border-style: solid;
     background-color: transparent;
     font-size: $buttonSecondaryFontSize;
-    font-family: $buttonSecondaryFontFamily;
+    font-weight: bold;
     transition: background-color 0.3s ease-out, color 0.3s ease-out;
     &:hover, &:focus {
       outline: none;
@@ -366,5 +362,4 @@ $include-html: false !default;
       }
     }
   }
-
 }

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -51,7 +51,6 @@ $iconAsButtonGrayColor: $grayPrimary;
 $buttonRoundAddSize: 50px;
 $buttonRoundAddFontSize: 18px;
 $buttonRoundAddColor: $white;
-
 $buttonRoundLabelFontSize: 10px;
 $buttonRoundLabelBackground: $mintSecondaryLight;
 $buttonRoundLabelColor: $black;
@@ -122,7 +121,7 @@ $include-html: false !default;
 @mixin mint-button-primary-three-color-variant($buttonColor, $gradientColor, $buttonShadowColor: null) {
   background-color: $buttonColor;
   background: $gradientColor linear-gradient(170deg, $gradientColor 0%, $gradientColor 50%, $buttonColor 51%, $buttonColor 100%) no-repeat;
-  @if($buttonShadowColor) {
+  @if ($buttonShadowColor) {
     box-shadow: 0 -1px 0 $buttonShadowColor inset;
   }
   &:hover, &:focus {
@@ -155,7 +154,7 @@ $include-html: false !default;
 }
 
 @if ($include-html) {
-  
+
   // Primary buttons
   .mint-button-primary {
     @include mint-button-basic-styles();
@@ -166,7 +165,6 @@ $include-html: false !default;
 
     border: 0;
     font-size: $buttonPrimaryFontSize;
-    font-family: $buttonPrimaryFontFamily;
     @include mint-button-primary-active($buttonPrimaryFontColor);
 
     &--full {

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -2,7 +2,6 @@ $selectBackground: $grayAltLight;
 $selectTextColor: $grayAlt;
 $selectFontSize: 12px;
 $selectHeight: 44px;
-$selectFontFamily: $fontFamilySecondary;
 $selectHoverBackground: $graySecondary;
 $selectInvalidBorderColor: $peachSecondary;
 
@@ -12,11 +11,9 @@ $inputBackground: $white;
 $inputBorderColor: $graySecondary;
 $inputTextColor: $black;
 $inputFontSize: 15px;
-$inputFontFamily: $fontFamilyPrimary;
 $inputFocusBorderColor: $grayPrimary;
 $inputPlaceholderTextColor: $grayPrimary;
 $inputPlaceholderFontSize: 12px;
-$inputPlaceholderFontFamily: $fontFamilySecondary;
 $inputValidBorderColor: $mintSecondary;
 $inputInvalidBorderColor: $peachSecondary;
 $inputTransparentBorderColor: rgba($graySecondary, 0.7);
@@ -30,7 +27,6 @@ $crInputHoverBorderColor: $blueSecondaryLight;
 $crInputActiveBorderColor: $bluePrimary;
 $crInputCheckedColor: $bluePrimary;
 
-$crInputLabelFontFamily: $fontFamilySecondary;
 $crInputLabelFontSize: 12px;
 $crInputLabelLineHeight: 18px;
 $crInputLabelHeight: 16px;
@@ -40,7 +36,6 @@ $textareaBackground: $white;
 $textareaBorderColor: $graySecondary;
 $textareaBorderRadius: 11px;
 $textareaFontSize: 15px;
-$textareaFontFamily: $fontFamilyPrimary;
 $textareaLineHeight: 19px;
 $textareaTextColor: $black;
 $textareaPadding: 11px;
@@ -48,10 +43,8 @@ $textareaSmallPadding: 6px;
 $textareaFocusBorderColor: $grayPrimary;
 $textareaPlaceholderTextColor: $grayPrimary;
 $textareaPlaceholderFontSize: 12px;
-$textareaPlaceholderFontFamily: $fontFamilySecondary;
 $textareaValidBorderColor: $mintSecondary;
 $textareaInvalidBorderColor: $peachSecondary;
-
 
 $include-html: false !default;
 
@@ -69,7 +62,6 @@ $include-html: false !default;
       border: 0;
       cursor: pointer;
       font-size: inherit;
-      font-family: $selectFontFamily;
       font-weight: bold;
       color: inherit;
       display: inline-block;
@@ -117,8 +109,6 @@ $include-html: false !default;
     border-radius: $inputHeight/2;
     color: $inputTextColor;
     font-size: $inputFontSize;
-    font-family: $inputFontFamily;
-    font-weight: normal;
     padding: 0 $inputHeight/2;
     height: $inputHeight;
     line-height: $inputHeight;
@@ -131,7 +121,6 @@ $include-html: false !default;
     &::placeholder {
       color: $inputPlaceholderTextColor;
       text-transform: uppercase;
-      font-family: $inputPlaceholderFontFamily;
       font-size: $inputPlaceholderFontSize;
       font-weight: bold;
     }
@@ -142,8 +131,8 @@ $include-html: false !default;
       line-height: $inputLowHeight;
     }
     &--valid {
-      border-color: $inputValidBorderColor;
-      &:focus {
+      border-color:$inputValidBorderColor;
+        &:focus {
         border-color: $inputValidBorderColor;
       }
     }
@@ -211,7 +200,7 @@ $include-html: false !default;
   .mint-checkbox-label,
   .mint-radio-label {
     @include component;
-    font-family: $crInputLabelFontFamily;
+    font-weight: bold;
     font-size: $crInputLabelFontSize;
     line-height: $crInputLabelLineHeight;
     height: $crInputLabelHeight;
@@ -262,8 +251,6 @@ $include-html: false !default;
     border-radius: $textareaBorderRadius;
     color: $textareaTextColor;
     font-size: $textareaFontSize;
-    font-family: $textareaFontFamily;
-    font-weight: normal;
     line-height: $textareaLineHeight;
     padding: $textareaPadding;
     resize: none;
@@ -278,7 +265,6 @@ $include-html: false !default;
     &::placeholder {
       color: $textareaPlaceholderTextColor;
       text-transform: uppercase;
-      font-family: $textareaPlaceholderFontFamily;
       font-size: $textareaPlaceholderFontSize;
       font-weight: bold;
     }
@@ -305,5 +291,4 @@ $include-html: false !default;
       height: 178px;
     }
   }
-
 }

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -57,6 +57,7 @@ $include-html: false !default;
     font-size: $selectFontSize;
     color: $selectTextColor;
     height: $selectHeight;
+
     &__element {
       background: $selectBackground;
       border: 0;
@@ -72,13 +73,16 @@ $include-html: false !default;
       appearance: none;
       text-transform: uppercase;
       width: 100%;
+
       &::-ms-expand {
         display: none;
       }
+
       &:hover, &:focus, &:active {
         background: $selectHoverBackground;
       }
     }
+
     &:before {
       $iconSize: $selectFontSize + $iconBoostValue;
       font-size: $iconSize;
@@ -91,11 +95,14 @@ $include-html: false !default;
       margin-top: 1px;
       transform: translateY(-50%);
     }
+
     &--full {
       width: 100%;
     }
+
     &--invalid {
       border: 2px solid $selectInvalidBorderColor;
+
       .mint-select__element {
         padding: 0 $selectHeight/2+12px 0 ($selectHeight/2 - 2px);
       }
@@ -118,36 +125,45 @@ $include-html: false !default;
       outline: none;
       border-color: $inputFocusBorderColor;
     }
+
     &::placeholder {
       color: $inputPlaceholderTextColor;
       text-transform: uppercase;
       font-size: $inputPlaceholderFontSize;
       font-weight: bold;
     }
+
     &--low {
       border-radius: $inputLowHeight/2;
       padding: 0 $inputLowHeight/2;
       height: $inputLowHeight;
       line-height: $inputLowHeight;
     }
+
     &--valid {
-      border-color:$inputValidBorderColor;
-        &:focus {
+      border-color: $inputValidBorderColor;
+
+      &:focus {
         border-color: $inputValidBorderColor;
       }
     }
+
     &--invalid {
       border-color: $inputInvalidBorderColor;
+
       &:focus {
         border-color: $inputInvalidBorderColor;
       }
     }
+
     &--spaced {
       margin-bottom: $inputHeight/4;
     }
+
     &--full {
       width: 100%;
     }
+
     &--transparent-border {
       border-color: $inputTransparentBorderColor;
       background-clip: padding-box;
@@ -171,6 +187,7 @@ $include-html: false !default;
     width: $crInputSize;
     height: $crInputSize;
     font-size: $crInputFontSize;
+
     &__element {
       opacity: 0;
       position: absolute;
@@ -180,13 +197,16 @@ $include-html: false !default;
       cursor: pointer;
       z-index: 1;
     }
+
     &__element:active + &__ghost {
       border-color: $crInputActiveBorderColor;
     }
+
     &__element:checked + &__ghost {
       border-color: $crInputCheckedColor;
       background: $crInputCheckedColor;
     }
+
     &__ghost {
       box-sizing: border-box;
       background: $crInputColor;
@@ -221,6 +241,7 @@ $include-html: false !default;
   .mint-checkbox__ghost {
     @extend .mint-icon-check;
     border-radius: 25%;
+
     &:before {
       font-size: 137.5%;
       position: absolute;
@@ -232,6 +253,7 @@ $include-html: false !default;
 
   .mint-radio__ghost {
     border-radius: 50%;
+
     &:before {
       content: '';
       position: absolute;
@@ -262,31 +284,37 @@ $include-html: false !default;
       border-color: $textareaFocusBorderColor;
       outline: 0;
     }
+
     &::placeholder {
       color: $textareaPlaceholderTextColor;
       text-transform: uppercase;
       font-size: $textareaPlaceholderFontSize;
       font-weight: bold;
     }
+
     &--full {
       width: 100%;
     }
+
     &--valid {
       border-color: $textareaValidBorderColor;
       &:focus {
         border-color: $textareaValidBorderColor;
       }
     }
+
     &--invalid {
       border-color: $textareaInvalidBorderColor;
       &:focus {
         border-color: $textareaInvalidBorderColor;
       }
     }
+
     &--small {
       height: 36px;
       padding: $textareaSmallPadding $textareaPadding;
     }
+
     &--big {
       height: 178px;
     }

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -10,7 +10,7 @@ $labelScaleFactor: 2/3;
 
 $include-html: false !default;
 
-@mixin label-from-icon($name){
+@mixin label-from-icon($name) {
   &--#{$name}:before {
     @extend .mint-icon-#{$name}:before;
     display: block;
@@ -122,5 +122,5 @@ $include-html: false !default;
       }
     }
   }
-  
+
 }

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -1,6 +1,6 @@
 $labelPrimaryColor: $black;
 $labelSecondaryColor: $grayPrimary;
-$labelFont: $fontFamilyEmphasized;
+$labelFontWeight: $fontWeightBlack;
 $labelFontSizePrimary: 12px;
 $labelFontSizeSecondary: 10px;
 $labelIconSizePrimary: 16px;
@@ -31,7 +31,7 @@ $include-html: false !default;
       display: block;
       vertical-align: middle;
       color: $labelPrimaryColor;
-      font-family: $labelFont;
+      font-weight: $labelFontWeight;
       text-transform: uppercase;
       margin-right: $layoutDefaultPadding/4;
 
@@ -122,6 +122,5 @@ $include-html: false !default;
       }
     }
   }
-
+  
 }
-

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,6 +1,3 @@
-$listDefaultFont: $fontFamilyPrimary;
-
-$breadcrumbListFontFamily: $fontFamilySecondary;
 $breadcrumbListFontSize: 13px;
 $breadcrumbListSeparatorColor: $grayPrimary;
 $breadcrumbListBlueSeparatorColor: $blueSecondary;
@@ -9,7 +6,6 @@ $breadcrumbListLightBlueSeparatorColor: $blueSecondaryLight;
 $menuListColor: $bluePrimary;
 $menuListFontSize: 13px;
 $menuListBorderColor: $graySecondary;
-$listSmallFontFamily: $fontFamilySecondary;
 $listSmallIconColor: $graySecondary;
 
 $include-html: false !default;
@@ -26,7 +22,6 @@ $include-html: false !default;
 
   .mint-list {
     @include mint-list-basic-styles();
-    font-family: $listDefaultFont;
     font-size: 24px;
     line-height: 44px;
 
@@ -55,7 +50,6 @@ $include-html: false !default;
     &--small {
       font-size: 15px;
       line-height: 30px;
-      font-family: $listSmallFontFamily;
 
       .mint-list__element {
         &:before {
@@ -76,7 +70,6 @@ $include-html: false !default;
 
   .mint-menu-list {
     @include mint-list-basic-styles();
-    font-family: $listDefaultFont;
     &__element {
       box-sizing: border-box;
       height: 35px;
@@ -110,11 +103,10 @@ $include-html: false !default;
     @include mint-list-basic-styles();
     display: inline-block;
     vertical-align: inherit;
-    font-family: $breadcrumbListFontFamily;
     font-size: $breadcrumbListFontSize;
     line-height: $breadcrumbListFontSize * 1.5;
     color: $breadcrumbListSeparatorColor;
-
+  
     &__element {
       display: inline-block;
 
@@ -148,5 +140,5 @@ $include-html: false !default;
       }
     }
   }
-
+  
 }

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -106,7 +106,7 @@ $include-html: false !default;
     font-size: $breadcrumbListFontSize;
     line-height: $breadcrumbListFontSize * 1.5;
     color: $breadcrumbListSeparatorColor;
-  
+
     &__element {
       display: inline-block;
 
@@ -140,5 +140,5 @@ $include-html: false !default;
       }
     }
   }
-  
+
 }

--- a/src/components/promo-box/_promo-box.scss
+++ b/src/components/promo-box/_promo-box.scss
@@ -1,10 +1,9 @@
 $promoBoxBackgroundColor: $mintSecondary;
 $promoBoxHeaderColor: $white;
-$promoBoxHeaderPrimaryFontFamily: $fontFamilyEmphasized;
-$promoBoxHeaderPrimaryFontSize: 50px;
+$promoBoxHeaderFontWeight: $fontWeightBlack;
+$promoBoxHeaderFontSize: 50px;
 $promoBoxTextSize: 24px;
 $promoBoxLineHeight: 44px;
-$promoBoxFontFamily: $fontFamilyPrimary;
 
 $include-html: false !default;
 
@@ -17,8 +16,8 @@ $include-html: false !default;
 
     &__header {
       color: $promoBoxHeaderColor;
-      font-family: $promoBoxHeaderPrimaryFontFamily;
-      font-size: $promoBoxHeaderPrimaryFontSize;
+      font-weight: $promoBoxHeaderFontWeight;
+      font-size: $promoBoxHeaderFontSize;
       line-height: 1;
       margin: 0;
       text-transform: uppercase;
@@ -30,9 +29,8 @@ $include-html: false !default;
     &__content {
       font-size: $promoBoxTextSize;
       line-height: $promoBoxLineHeight;
-      font-family: $promoBoxFontFamily;
       padding: 5px 0 15px 0;
     }
   }
-  
+
 }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -72,5 +72,5 @@ $include-html: false !default;
       }
     }
   }
-  
+
 }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -4,7 +4,7 @@ $rateStarCheckedColor: $mustardPrimary;
 $rateStarActiveColor: $graySecondaryLight;
 $rateStarActiveCheckedColor: $mustardSecondary;
 $rateCounterColor: $grayPrimary;
-$rateCounterFont: $fontFamilyEmphasized;
+$rateCounterFontWeight: $fontWeightBlack;
 $rateStarFontSize: 12px;
 $rateStarSmallFontSize: 10px;
 $rateScaleFactor: 2/3;
@@ -53,7 +53,7 @@ $include-html: false !default;
 
     &__counter {
       @include fixText($rateStarFontSize, 2px);
-      font-family: $rateCounterFont;
+      font-weight: $rateCounterFontWeight;
       color: $rateCounterColor;
       margin: 0 0 0 $layoutDefaultPadding/2;
     }
@@ -72,5 +72,5 @@ $include-html: false !default;
       }
     }
   }
-
+  
 }

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -8,8 +8,6 @@ $tabHoverTextColor: $white;
 $tabHeight: 44px;
 $tabSmallHeight: 32px;
 $tabFontSize: 12px;
-$tabsFontFamily: $fontFamilySecondary;
-
 
 $include-html: false !default;
 
@@ -29,7 +27,7 @@ $include-html: false !default;
       border-right: 1px solid $tabSeparatorColor;
       color: $tabTextColor;
       cursor: pointer;
-      font-family: $tabsFontFamily;
+      font-weight: bold;
       float: left;
       padding: 0 $tabHeight/2;
       text-transform: uppercase;

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -14,7 +14,7 @@ $include-html: false !default;
     }
 
     &--light {
-      color: $white;;
+      color: $white;
     }
   }
 
@@ -33,7 +33,7 @@ $include-html: false !default;
     }
 
     &--light {
-      color: $white;;
+      color: $white;
     }
   }
 

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -10,14 +10,14 @@ $include-html: false !default;
     font-weight: $fontWeightBlack;
 
     &--small {
-      font-size: $headerPrimarySmallFontSize;
+      @include type-variant(1.75, 2, 1, 8/16);
     }
 
     &--light {
       color: $white;;
     }
-
   }
+
   .mint-header-secondary {
     @include component;
     @include type-variant(1, 0.667, 12/16, 20/16);
@@ -30,11 +30,11 @@ $include-html: false !default;
     &--small {
       @include type-variant(0.8125, 0.667, 13/16, 19/16);
       letter-spacing: 1px;
-      }
-  
+    }
+
     &--light {
       color: $white;;
     }
   }
-  
+
 }

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -1,7 +1,6 @@
 $headerColor: $black;
 $headerColorLight: $white;
-$headerPrimaryFontFamily: $fontFamilyEmphasized;
-$headerSecondaryFontFamily: $fontFamilySecondary;
+$headerPrimaryFontWeight: $fontWeightBlack;
 $headerPrimaryFontSize: 64px;
 $headerPrimarySmallFontSize: 48px;
 $headerSecondaryFontSize: 16px;
@@ -15,7 +14,7 @@ $include-html: false !default;
     @include component;
     display: block;
     color: $headerColor;
-    font-family: $headerPrimaryFontFamily;
+    font-weight: $headerPrimaryFontWeight;
     font-size: $headerPrimaryFontSize;
     line-height: 1;
     margin: 0;
@@ -33,7 +32,7 @@ $include-html: false !default;
     @include component;
     display: block;
     color: $headerColor;
-    font-family: $headerSecondaryFontFamily;
+    font-weight: bold;
     font-size: $headerSecondaryFontSize;
     line-height: 1;
     text-transform: uppercase;
@@ -47,5 +46,5 @@ $include-html: false !default;
       color: $headerColorLight;
     }
   }
-
+  
 }

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -1,49 +1,39 @@
-$headerColor: $black;
-$headerColorLight: $white;
-$headerPrimaryFontWeight: $fontWeightBlack;
-$headerPrimaryFontSize: 64px;
-$headerPrimarySmallFontSize: 48px;
-$headerSecondaryFontSize: 16px;
-$headerSecondarySmallFontSize: 12px;
-
 $include-html: false !default;
 
 @if ($include-html) {
 
   .mint-header-primary {
     @include component;
+    @include type-variant(3, 2, 11/16, 37/16);
     display: block;
-    color: $headerColor;
-    font-weight: $headerPrimaryFontWeight;
-    font-size: $headerPrimaryFontSize;
-    line-height: 1;
-    margin: 0;
+    color: $black;
+    font-weight: $fontWeightBlack;
 
     &--small {
       font-size: $headerPrimarySmallFontSize;
     }
 
     &--light {
-      color: $headerColorLight;
+      color: $white;;
     }
 
   }
   .mint-header-secondary {
     @include component;
+    @include type-variant(1, 0.667, 12/16, 20/16);
     display: block;
-    color: $headerColor;
+    color: $black;
     font-weight: bold;
-    font-size: $headerSecondaryFontSize;
-    line-height: 1;
+    letter-spacing: 0.03em;
     text-transform: uppercase;
-    margin: 0;
 
     &--small {
-      font-size: $headerSecondarySmallFontSize;
-    }
-
+      @include type-variant(0.8125, 0.667, 13/16, 19/16);
+      letter-spacing: 1px;
+      }
+  
     &--light {
-      color: $headerColorLight;
+      color: $white;;
     }
   }
   

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -3,6 +3,7 @@
   color: $bluePrimary;
   text-decoration: none;
   font-weight: bold;
+  line-height: 0.75rem; // forbid descenders overflow line-height
 
   &:hover, &:active {
     text-decoration: underline;
@@ -21,7 +22,7 @@
   }
 
   &--emphasised {
-    @include type-variant(0.8125, 1);
+    @include type-variant(0.8125, 0.75);
     text-transform: uppercase;
     letter-spacing: 0.01em;
   }

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -1,0 +1,36 @@
+.mint-link {
+  cursor: pointer;
+  color: $bluePrimary;
+  text-decoration: none;
+  font-weight: bold;
+
+  &:hover, &:active {
+    text-decoration: underline;
+  }
+
+  &--gray {
+    color: $grayPrimary;
+  }
+
+  &--for-fine-print {
+    color: $blueSecondary;
+  }
+
+  &--for-fine-print-light {
+    color: $blueSecondaryLight;
+  }
+
+  &--emphasised {
+    @include type-variant(0.8125, 1);
+    text-transform: uppercase;
+    letter-spacing: 0.01em;
+  }
+
+  &--disabled {
+    cursor: default;
+
+    &:hover, &:active {
+      text-decoration: none;
+    }
+  }
+}

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -1,0 +1,79 @@
+$textBitLogoSize: 84px;
+$textBitSmallLogoSize: 68px;
+
+.mint-text-bit {
+  color: $mintSecondary;
+  font-weight: $fontWeightBlack;
+  font-size: 3.625rem;
+  line-height: 2 * $baseline;
+  text-transform: uppercase;
+  word-wrap: break-word;
+  margin: 0;
+  position: relative;
+  letter-spacing: -1px;
+
+  &__logo {
+    @extend .mint-icon-logo;
+    text-decoration: none;
+    display: block;
+    position: absolute;
+    overflow: hidden;
+    top: -30px;
+    left: -13px;
+    height: $textBitLogoSize/2;
+    width: $textBitLogoSize;
+
+    &:before {
+      font-size: $textBitLogoSize;
+    }
+
+    &--small {
+      top: -25px;
+      left: -10px;
+      height: $textBitSmallLogoSize/2;
+      width: $textBitSmallLogoSize;
+
+      &:before {
+        font-size: $textBitSmallLogoSize;
+      }
+    }
+  }
+
+  &--alt {
+    color: $blueSecondary;
+  }
+
+  &--light {
+    color: $white;
+  }
+
+  &--warning {
+    color: $peachPrimary;
+  }
+
+  &--with-logo {
+    @extend .mint-icon-logo;
+
+    &:before {
+      position: absolute;
+      top: -30px;
+      font-size: $textBitLogoSize;
+      left: -13px;
+    }
+  }
+
+  &--with-small-logo {
+    @extend .mint-icon-logo;
+
+    &:before {
+      position: absolute;
+      top: -25px;
+      font-size: $textBitSmallLogoSize;
+      left: -10px;
+    }
+  }
+
+  &--small {
+    font-size: 3rem;
+  }
+}

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -43,5 +43,5 @@ $include-html: false !default;
       color: $blueSecondary;
     }
   }
-  
+
 }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -2,9 +2,8 @@ $linkColor: $bluePrimary;
 $linkGrayColor: $grayPrimary;
 $linkBlueColor: $blueSecondary;
 $linkLightBlueColor: $blueSecondaryLight;
-$linkFontFamily: $fontFamilySecondary;
 
-$textBitFontFamily: $fontFamilyEmphasized;
+$textBitFontWeight: $fontWeightBlack;
 $textBitFontSize: 58px;
 $textBitLineHeight: 0.9;
 $textBitColor: $mintSecondary;
@@ -16,7 +15,6 @@ $textBitSmallFontSize: 44px;
 $textBitLogoSize: 84px;
 $textBitSmallLogoSize: 68px;
 
-$textBlockFontFamily: $fontFamilySecondary;
 $textBlockFontSize: 13px;
 $textBlockLineHeight: 14px;
 $textBlockColor: $black;
@@ -25,7 +23,6 @@ $textBlockLightBlueColor: $blueSecondaryLight;
 $textBlockGrayColor: $grayPrimary;
 $textBlockLightColor: $white;
 
-$textDescriptionFontFamily: $fontFamilyPrimary;
 $textDescriptionColor: $black;
 $textDescriptionFontSize: 18px;
 $textDescriptionLineHeight: 21px;
@@ -34,15 +31,13 @@ $textDescriptionLargeLineHeight: 32px;
 $textDescriptionSmallFontSize: 15px;
 $textDescriptionSmallLineHeight: 19px;
 
-$textEmphasisedFontFamily: $fontFamilySecondary;
-
 $include-html: false !default;
 
 @if ($include-html) {
 
   .mint-text-bit {
     color: $textBitColor;
-    font-family: $textBitFontFamily;
+    font-weight: $textBitFontWeight;
     font-size: $textBitFontSize;
     line-height: $textBitLineHeight;
     text-transform: uppercase;
@@ -109,7 +104,7 @@ $include-html: false !default;
   }
 
   .mint-text-block {
-    font-family: $textBlockFontFamily;
+    font-weight: bold;
     font-size: $textBlockFontSize;
     line-height: $textBlockLineHeight;
     color: $textBlockColor;
@@ -134,13 +129,12 @@ $include-html: false !default;
   }
 
   .mint-text-description {
-    font-family: $textDescriptionFontFamily;
     font-size: $textDescriptionFontSize;
     line-height: $textDescriptionLineHeight;
     color: $textDescriptionColor;
     margin: 0;
     padding: 0;
-
+  
     &--large {
       font-size: $textDescriptionLargeFontSize;
       line-height: $textDescriptionLargeLineHeight;
@@ -152,14 +146,14 @@ $include-html: false !default;
   }
 
   .mint-text-emphasised {
-    font-family: $textEmphasisedFontFamily;
+    font-weight: bold;
   }
 
   .mint-link {
     cursor: pointer;
     color: $linkColor;
     text-decoration: none;
-    font-family: $linkFontFamily;
+    font-weight: bold;
 
     &:hover, &:active {
       text-decoration: underline;
@@ -189,5 +183,5 @@ $include-html: false !default;
       }
     }
   }
-
+  
 }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -1,186 +1,46 @@
-$linkColor: $bluePrimary;
-$linkGrayColor: $grayPrimary;
-$linkBlueColor: $blueSecondary;
-$linkLightBlueColor: $blueSecondaryLight;
-
-$textBitFontWeight: $fontWeightBlack;
-$textBitFontSize: 58px;
-$textBitLineHeight: 0.9;
-$textBitColor: $mintSecondary;
-$textBitAltColor: $blueSecondary;
-$textBitWarningColor: $peachPrimary;
-$textBitLightColor: $white;
-$textBitDarkColor: $black;
-$textBitSmallFontSize: 44px;
-$textBitLogoSize: 84px;
-$textBitSmallLogoSize: 68px;
-
-$textBlockFontSize: 13px;
-$textBlockLineHeight: 14px;
-$textBlockColor: $black;
-$textBlockBlueColor: $blueSecondary;
-$textBlockLightBlueColor: $blueSecondaryLight;
-$textBlockGrayColor: $grayPrimary;
-$textBlockLightColor: $white;
-
-$textDescriptionColor: $black;
-$textDescriptionFontSize: 18px;
-$textDescriptionLineHeight: 21px;
-$textDescriptionLargeFontSize: 32px;
-$textDescriptionLargeLineHeight: 32px;
-$textDescriptionSmallFontSize: 15px;
-$textDescriptionSmallLineHeight: 19px;
-
 $include-html: false !default;
 
 @if ($include-html) {
 
-  .mint-text-bit {
-    color: $textBitColor;
-    font-weight: $textBitFontWeight;
-    font-size: $textBitFontSize;
-    line-height: $textBitLineHeight;
-    text-transform: uppercase;
-    word-wrap: break-word;
-    margin: 0;
-    position: relative;
-    letter-spacing: -1px;
-    &__logo {
-      @extend .mint-icon-logo;
-      text-decoration: none;
-      display: block;
-      position: absolute;
-      overflow: hidden;
-      top: -30px;
-      left: -13px;
-      height: $textBitLogoSize/2;
-      width: $textBitLogoSize;
-      &:before {
-        font-size: $textBitLogoSize;
-      }
-      &--small {
-        top: -25px;
-        left: -10px;
-        height: $textBitSmallLogoSize/2;
-        width: $textBitSmallLogoSize;
-        &:before {
-          font-size: $textBitSmallLogoSize;
-        }
-      }
-    }
-    &--alt {
-      color: $textBitAltColor;
-    }
-    &--light {
-      color: $textBitLightColor;
-    }
-    &--dark {
-      color: $textBitDarkColor;
-    }
-    &--warning {
-      color: $textBitWarningColor;
-    }
-    &--with-logo {
-      @extend .mint-icon-logo;
-      &:before {
-        position: absolute;
-        top: -30px;
-        font-size: $textBitLogoSize;
-        left: -13px;
-      }
-    }
-    &--with-small-logo {
-      @extend .mint-icon-logo;
-      &:before {
-        position: absolute;
-        top: -25px;
-        font-size: $textBitSmallLogoSize;
-        left: -10px;
-      }
-    }
-    &--small {
-      font-size: $textBitSmallFontSize;
-    }
-  }
+  .mint-text {
+    @include type-variant(1, 1);
+    font-family: $fontFamilyPrimary;
+    color: $black;
 
-  .mint-text-block {
-    font-weight: bold;
-    font-size: $textBlockFontSize;
-    line-height: $textBlockLineHeight;
-    color: $textBlockColor;
-    margin: 0;
-    padding: 0;
-
-    &--gray {
-      color: $textBlockGrayColor;
-    }
-    &--light {
-      color: $textBlockLightColor;
-    }
-    &--for-fine-print-light {
-      color: $textBlockLightBlueColor;
-    }
-    &--for-fine-print {
-      color: $textBlockBlueColor;
-    }
-    &--emphasised {
-      text-transform: uppercase;
-    }
-  }
-
-  .mint-text-description {
-    font-size: $textDescriptionFontSize;
-    line-height: $textDescriptionLineHeight;
-    color: $textDescriptionColor;
-    margin: 0;
-    padding: 0;
-  
-    &--large {
-      font-size: $textDescriptionLargeFontSize;
-      line-height: $textDescriptionLargeLineHeight;
-    }
-    &--small {
-      font-size: $textDescriptionSmallFontSize;
-      line-height: $textDescriptionSmallLineHeight;
-    }
-  }
-
-  .mint-text-emphasised {
-    font-weight: bold;
-  }
-
-  .mint-link {
-    cursor: pointer;
-    color: $linkColor;
-    text-decoration: none;
-    font-weight: bold;
-
-    &:hover, &:active {
-      text-decoration: underline;
+    &--standout {
+      @include type-variant(1.125, 1);
+      font-size: 1.125rem;
     }
 
-    &--gray {
-      color: $linkGrayColor;
+    &--obscure {
+      @include type-variant(0.75, 1);
     }
 
-    &--for-fine-print {
-      color: $linkBlueColor;
-    }
-
-    &--for-fine-print-light {
-      color: $linkLightBlueColor;
+    &--headline {
+      @include type-variant(1.75, 1.334);
+      font-weight: normal;
+      margin: 0;
+      margin-bottom: $baseline;
     }
 
     &--emphasised {
-      text-transform: uppercase;
+      font-weight: bold;
     }
 
-    &--disabled {
-      cursor: default;
+    &--gray {
+      color: $grayPrimary;
+    }
 
-      &:hover, &:active {
-        text-decoration: none;
-      }
+    &--light {
+      color: $white;
+    }
+
+    &--for-fine-print-light {
+      color: $blueSecondaryLight;
+    }
+
+    &--for-fine-print {
+      color: $blueSecondary;
     }
   }
   

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -4,19 +4,23 @@
     </aside>
     <div class="docs-block__content">
         <h2 class="mint-header-primary">
-            Together we go far!
+            X Together we go far!
+            <br>
+            X2 Together we go far!
         </h2>
 
         <h2 class="mint-header-primary mint-header-primary--small">
-            We've got your back!
+            X We've got your back!
+            <br>
+            X2 We've got your back!
         </h2>
 
         <h2 class="mint-header-secondary">
-            We've got your back!
+            X We've got your back!
         </h2>
 
         <h2 class="mint-header-secondary mint-header-secondary--small">
-            We've got your back!
+            X We've got your back!
         </h2>
 
         <div class="docs-block__contrast-box">
@@ -41,54 +45,63 @@
 </section>
 <section class="docs-block">
     <aside class="docs-block__info">
-        <h3 class="docs-block__header">Text block</h3>
+        <h3 class="docs-block__header">Text</h3>
     </aside>
     <div class="docs-block__content">
-        <div class="mint-text-block">
-            Together we go far!
-        </div>
-        <div class="mint-text-block mint-text-block--emphasised">
-            Together we go far!
-        </div>
-        <div class="mint-text-block mint-text-block--gray">
-            Together we go far!
+        <div class="mint-text">
+            This is a default typeface for text everywhere.<br>
+            Here is <span class="mint-text mint-text--gray">gray text</span>
+            <br>
+            And <span class="mint-text mint-text--emphasised">emphasised text</span>
+            <br>
+            <span class="mint-text mint-text--gray">This text is gray</span>
+            <br>
+            and here
+            <br>
+            it is a multiline
+            <br>
+            to give vertical rhythm a shot
+            <br><br>
         </div>
         <div class="docs-block__contrast-box">
-            <div class="mint-text-block mint-text-block--light">
-                We've got your back
+            <div class="mint-text mint-text--light">
+                This text is light
             </div>
         </div>
-        <div class="mint-text-block mint-text-block--for-fine-print">
-            We've got your back!
+        <div class="mint-text mint-text--obscure">
+            <br>
+            This text is not really intended to be read
+            <br>
         </div>
-        <div class="mint-text-block mint-text-block--for-fine-print-light">
-            We've got your back!
+        <div class="mint-text mint-text--obscure mint-text--for-fine-print">
+            <br>
+            This is a fine print example
+            <br><br>
         </div>
-    </div>
-</section>
-<section class="docs-block">
-    <aside class="docs-block__info">
-        <h3 class="docs-block__header">Text description</h3>
-    </aside>
-    <div class="docs-block__content">
-        <div class="mint-text-description mint-text-description--large">
-            Together <a href="#" class="mint-link">we go</a> far!
-        </div>
-        <div class="mint-text-description">
-            Together <a href="#" class="mint-link">we go</a> far!
-        </div>
-        <div class="mint-text-description mint-text-description--small">
-            Together <a href="#" class="mint-link">we go</a> far!
+        <div class="docs-block__contrast-box">
+            <div class="mint-text mint-text--obscure mint-text--for-fine-print-light">
+                This is a very light fine print
+            </div>
         </div>
     </div>
 </section>
 <section class="docs-block">
     <aside class="docs-block__info">
-        <h3 class="docs-block__header">Emphasised text</h3>
+        <h3 class="docs-block__header">Text (headline + standout)</h3>
     </aside>
     <div class="docs-block__content">
-        <div class="mint-text-description">
-            Together we go <strong class="mint-text-emphasised">far</strong>!
+        <h2 class="mint-text mint-text--headline">
+            After President Nixon’s resignation,
+            <br>who became president
+            <br>of the United States?
+        </h2>
+
+        <div class="mint-text mint-text--standout">
+            President <strong class="mint-text mint-text--standout mint-text--emphasised">Richard Nixon</strong>
+            is the only president to resign from the office and was the 37th president of the
+            United States, serving from <span class="mint-text mint-text--standout mint-text--gray">1969 to 1974</span>.
+            Vice president Gerald R. Ford of Michigan took the office as the new president
+            to complete the remaining 2 1/2 years of Nixon's term.
         </div>
     </div>
 </section>
@@ -98,11 +111,21 @@
     </aside>
     <div class="docs-block__content">
         <div class="mint-text-description">
-            <a href="#" class="mint-link">Comments (9)</a><br/>
-            <span class="mint-link mint-link--gray mint-link--disabled">2 min ago</span><br/>
-            <a href="#" class="mint-link mint-link--gray mint-link--emphasised">Math</a><br/>
-            <a href="#" class="mint-link mint-link--for-fine-print mint-link--emphasised">Terms of use</a><br/>
-            <a href="#" class="mint-link mint-link--for-fine-print-light">zadane.pl</a><br/>
+            <div>
+                Some texts and a link <a href="#" class="mint-link">Comments (9)</a><br/>
+            </div>
+            <div>
+                Some texts and a disabled link <span class="mint-link mint-link--gray mint-link--disabled">2 min ago</span><br/>
+            </div>
+            <div>
+                An emphasized link <a href="#" class="mint-link mint-link--gray mint-link--emphasised">Math</a><br/>
+            </div>
+            <div>
+                Fine print link <a href="#" class="mint-link mint-link--for-fine-print-light">zadane.pl</a><br/>
+            </div>
+            <div>
+                Fine print emphasised link <a href="#" class="mint-link mint-link--for-fine-print mint-link--emphasised">Terms of use</a><br/>
+            </div>
         </div>
     </div>
 </section>

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -1,6 +1,6 @@
 <section class="docs-block">
     <aside class="docs-block__info">
-        <h3 class="docs-block__header">Heading</h3>
+        <h3 class="docs-block__header">Headers</h3>
     </aside>
     <div class="docs-block__content">
         <h2 class="mint-header-primary">

--- a/src/docs/_data/navigation.yml
+++ b/src/docs/_data/navigation.yml
@@ -5,6 +5,8 @@
       location: colors/colors
     - name: Text
       location: text/text
+    - name: Text Bit
+      location: text/text-bit
     - name: Icons
       location: icons/icons
     - name: Subject Icons
@@ -15,8 +17,6 @@
 - name: Components
   location: components
   elements:
-    - name: Text Bit
-      location: text/text-bit
     - name: Lists
       location: list/list
     - name: Badges

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -1,6 +1,7 @@
 .docs-block {
   margin: 50px 0 0;
   display: flex;
+
   &__header {
     color: $grayPrimary;
     display: block;
@@ -8,43 +9,66 @@
     font-weight: normal;
     margin: 0;
   }
+
   &__info {
     flex: 0 1 auto;
     box-sizing: border-box;
     padding: 0 20px 0 0;
     width: 230px;
   }
+
   &__content {
     flex: 1 1 auto;
+
     &--logo-preview {
       font-size: 150px;
     }
+
     &--centered {
       display: flex;
       align-items: center
     }
+
     &--align-top {
       & > * {
         vertical-align: top;
       }
     }
+
     &:hover {
+      position: relative;
+
       .docs-highlight-placeholder {
         outline: 2px dashed white;
         box-shadow: black 0 0 10px 0;
       }
+
+      &:before {
+        z-index: 1;
+        content: '';
+        background: linear-gradient(to bottom, #0ff 0, rgba(255, 255, 255, 0) 1px) repeat-y;
+        background-size: 100% 1rem;
+        height: 100%;
+        width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        padding: 1px;
+      }
     }
+
   }
+
   &__contrast-box {
     background-color: $grayPrimary;
     padding: 10px;
     display: inline-block;
   }
+
   &__content-box {
     padding: 10px;
     display: inline-block;
   }
-
 }
 
 .mint-bubble,

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -61,12 +61,12 @@
 
   &__contrast-box {
     background-color: $grayPrimary;
-    padding: 10px;
+    padding: $baseline;
     display: inline-block;
   }
 
   &__content-box {
-    padding: 10px;
+    padding: $baseline;
     display: inline-block;
   }
 }

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -47,7 +47,7 @@
         z-index: 1;
         content: '';
         background: linear-gradient(to bottom, #0ff 0, rgba(255, 255, 255, 0) 1px) repeat-y;
-        background-size: 100% 1rem;
+        background-size: 100% $baseline;
         height: 100%;
         width: 100%;
         position: absolute;

--- a/src/docs/css/main.scss
+++ b/src/docs/css/main.scss
@@ -13,9 +13,6 @@
 html, body {
   margin: 0;
   padding: 0;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-family: "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 body {

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -5,6 +5,9 @@ $include-html: false !default;
   body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+
+    font-size: $base-font;
+    line-height: $baseline;
   }
 
 }

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -7,6 +7,7 @@ $include-html: false !default;
     -moz-osx-font-smoothing: grayscale;
 
     font-size: $base-font;
+    font-family: $fontFamilyPrimary;
     line-height: $baseline;
   }
 

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -45,9 +45,8 @@ $grayAltLight: #E9ECEE;
 $defaultBottomShadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.25);
 
 // Fonts
-$fontFamilyPrimary: 'ProximaNovaRegular', 'Helvetica', 'Arial', sans-serif;
-$fontFamilySecondary: 'ProximaNovaExtrabold', 'Helvetica', 'Arial', sans-serif;
-$fontFamilyEmphasized: 'ProximaNovaBlack', 'Helvetica', 'Arial', sans-serif;
+$fontFamilyPrimary: 'ProximaNova', 'Helvetica', 'Arial', sans-serif;
+$fontWeightBlack: 500;
 
 // Icons
 $iconBoostValue: 4px;

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -52,6 +52,10 @@ $fontFamilyEmphasized: 'ProximaNovaBlack', 'Helvetica', 'Arial', sans-serif;
 // Icons
 $iconBoostValue: 4px;
 
+// Vertical rhythm
+$base-font: 16px;
+$baseline: 1.5rem;
+
 // Layout
 $layoutMaximumWidth: 960px;
 $layoutDefaultPadding: 24px;

--- a/src/sass/_fonts.scss
+++ b/src/sass/_fonts.scss
@@ -3,24 +3,24 @@ $include-html: false !default;
 @if ($include-html) {
 
   @font-face {
-    font-family: 'ProximaNovaRegular';
+    font-family: 'ProximaNova';
     src: url($mintFontsPath + 'ProximaNova-Regular.woff') format('woff');
     font-weight: normal;
     font-style: normal;
   }
 
   @font-face {
-    font-family: 'ProximaNovaExtrabold';
+    font-family: 'ProximaNova';
     src: url($mintFontsPath + 'ProximaNova-Extrabold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
   }
 
   @font-face {
-    font-family: 'ProximaNovaBlack';
+    font-family: 'ProximaNova';
     src: url($mintFontsPath + 'ProximaNova-Black.woff') format('woff');
-    font-weight: bold;
+    font-weight: $fontWeightBlack;
     font-style: normal;
   }
-
+  
 }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -12,6 +12,7 @@
   position: relative;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0;
 }
 
 @mixin hole(){
@@ -36,4 +37,25 @@
   &:before {
     display: inline-block;
   }
+}
+
+// Used for messing with fonts and baseline
+// Sets the font size and line height
+// fontsize - rem
+// line-height - rem
+@mixin type-variant($fontsize, $line-height, $shift: 0, $push: 0){
+
+  $rem-fontsize: $fontsize * 1rem;
+  $rem-lineheight: $line-height * $baseline;
+
+  font-size: $rem-fontsize;
+  line-height: $rem-lineheight;
+  padding-top: $shift * 1rem;
+  margin-bottom: $push * 1rem;
+}
+
+
+// set a value as a multiple of baselines
+@function rhythm($baselines){
+  @return $baselines * $baseline;
 }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -17,6 +17,8 @@ $mintFontsPath: 'fonts/' !default;
 @import "../components/form-elements/form-elements";
 @import "../components/text/text";
 @import "../components/text/headers";
+@import "../components/text/text-bits";
+@import "../components/text/links";
 @import "../components/bubble/bubble";
 @import "../components/search/search";
 @import "../components/avatar/avatar";


### PR DESCRIPTION
**WIP: will not be merged to master**
I will proceed with the changes as soon as the feature-branch will be merged to dev-branch

Old text styles:
![](https://i.gyazo.com/fd77399b9507cc9463cbba8d9640fb94.png)

New styles:

- Headers
![](https://i.gyazo.com/94b8ec0bbc8b82d7882c70260f982888.png)

- Text & links
![](https://i.gyazo.com/ef5a0aff15bf8abf4f73a06b4c9fd857.png)
![](https://i.gyazo.com/693828e5b82043af59e54d392e6079a6.png)


### Mockup

http://typecast.com/QhQQkkddGr/share/87eeaf5d967424f871d1236edad36ee3d46a85b6KrPQgjrbw

### Changes 
In this set of changes I have introduced the changes to headers + text.

It relates to #13, closes #192 and closes #230.
Please, see #192 for some important info and decisions.

These are **breaking changes** already.

These things MUST be refactored across all the projects:

```
mint-text-block -> mint-text--obscure
mint-text-description -> mint-text--standout
mint-text-description--large -> mint-headline
mint-text-description--large + bold -> mint-header-primary--small
```

These things have changed it dimensions and MAY need refactoring:

```
mint-header-primary -> mint-text-bit
mint-header-primary--small -> mint-text-bit--small
mint-text-emphasised -> mint-text--emphasised
```

### Things that failed

#### baseline push
I've tried to *push text to the baseline*, but it does not really worked out:

1. It's a bit ugly in containers
2. The push amount is inconsistent (need manual tweaking), even when `cap-height` equation is used

Tried the things described here:

1. https://medium.com/written-in-code/aligning-type-to-baseline-the-right-way-using-sass-e258fce47a9b
2. https://gist.github.com/razwan/10662500
3. https://jakegiltsoff.co.uk/posts/sassline-v2-0

I tried `cap-height=0.57` (taken from sassline) and `cap-height=0.67` (measured manually). Neither has worked out well for both text and headers simultaneously.

The problem IMO is that those articles assume that `line-height` for EVERY text element is **exact natural multiplier** of `$baseline` (1,2,3,4 ...), which is not true in many cases.

#### Headeline + secondary headers break rhythm

To have a good-looking **wrapped** header we MUST have non-natural multipliers for `line-height` for some header sizes. 

**This is a thing, which breaks the rhythm.**

I am planning to address this issue directly in containers by introducing the `min-height` property for header-related holes.

Any other suggestions?

### Open questions

#### Shall we remove `mint-text--emphasised` et al.? 

The reason is that we can actually make an exception and treat text as `user-generated content`. 
So, we will have **scoped** styles inside mint-text block: `<strong>`, `<em>`, `<i>`, `<b>`...

It makes sense for me, but WDYT?

#### Non pixel-perfect links

`<a>` seems to add some pixels to line box. You can see this in links example it docs - the latter lines are offseted from baseline.

I think we can live with this issue for now, as I have not figured out the reason for this behavior and how to fix it properly.