### PR TITLE
Add hero search 

### DIFF
--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -8,17 +8,22 @@ $selectInvalidBorderColor: $peachSecondary;
 
 $inputHeight: 44px;
 $inputLowHeight: 36px;
+$inputLargeHeight: 64px;
 $inputBackground: $white;
 $inputBorderColor: $graySecondary;
 $inputTextColor: $black;
 $inputFontSize: 15px;
+$inputLargeFontSize: 19px;
 $inputFontFamily: $fontFamilyPrimary;
 $inputFocusBorderColor: $grayPrimary;
 $inputPlaceholderTextColor: $grayPrimary;
 $inputPlaceholderFontSize: 12px;
+$inputLargePlaceholderFontSize: 15px;
 $inputPlaceholderFontFamily: $fontFamilySecondary;
 $inputValidBorderColor: $mintSecondary;
+$inputFocusValidBorderColor: $mintPrimary;
 $inputInvalidBorderColor: $peachSecondary;
+$inputFocusInvalidBorderColor: $peachPrimary;
 $inputTransparentBorderColor: rgba($graySecondary, 0.7);
 $inputTransparentFocusBorderColor: rgba($grayPrimary, 0.7);
 
@@ -123,6 +128,7 @@ $include-html: false !default;
     height: $inputHeight;
     line-height: $inputHeight;
     appearance: none;
+    transition: border 300ms;
 
     &:focus {
       outline: none;
@@ -144,13 +150,13 @@ $include-html: false !default;
     &--valid {
       border-color: $inputValidBorderColor;
       &:focus {
-        border-color: $inputValidBorderColor;
+        border-color: $inputFocusValidBorderColor;
       }
     }
     &--invalid {
       border-color: $inputInvalidBorderColor;
       &:focus {
-        border-color: $inputInvalidBorderColor;
+        border-color: $inputFocusInvalidBorderColor;
       }
     }
     &--spaced {
@@ -158,6 +164,27 @@ $include-html: false !default;
     }
     &--full {
       width: 100%;
+    }
+    &--large {
+      @media (min-width: $breakpointTablet) {
+        height: $inputLargeHeight;
+        font-size: $inputLargeFontSize;
+        border-radius: $inputLargeHeight / 2;
+        padding: 0 $inputLargeHeight / 2;
+
+        &::placeholder {
+          font-size: $inputLargePlaceholderFontSize;
+        }
+      }
+    }
+    &--subtle-border {
+      border: none;
+      box-shadow: 0 0 10px rgba(0,0,0,0.2);
+      transition: box-shadow 300ms;
+
+      &:focus {
+        box-shadow: 0 0 10px rgba(0,0,0,0.4);
+      }
     }
     &--transparent-border {
       border-color: $inputTransparentBorderColor;

--- a/src/components/form-elements/form-elements.html
+++ b/src/components/form-elements/form-elements.html
@@ -37,7 +37,11 @@
         <br/>
         <input type="text" class="mint-input mint-input--spaced mint-input--full" placeholder="Placeholder">
         <br/>
+        <input type="text" class="mint-input mint-input--spaced mint-input--subtle-border" placeholder="Placeholder">
+        <br/>
         <input type="text" class="mint-input mint-input--spaced mint-input--low" placeholder="Placeholder">
+        <br/>
+        <input type="text" class="mint-input mint-input--spaced mint-input--large" placeholder="Placeholder">
     </div>
 </section>
 <section class="docs-block">

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -5,6 +5,7 @@ $include-html: false !default;
 
   .mint-search {
     @include component;
+    overflow: visible;
     width: 100%;
 
     &__button {

--- a/src/components/search/search.html
+++ b/src/components/search/search.html
@@ -14,3 +14,19 @@
         </div>
     </div>
 </section>
+<section class="docs-block">
+    <aside class="docs-block__info">
+        <h3 class="docs-block__header">Hero</h3>
+    </aside>
+    <div class="docs-block__content">
+        <div class="mint-search">
+            <input type="search" placeholder="Find all the answers..."
+                   class="mint-input mint-input--full mint-input--subtle-border mint-input--large mint-input--with-icon"/>
+
+            <div class="mint-search__button">
+                <button class="mint-icon-as-button mint-icon-search" type="submit">Submit
+                </button>
+            </div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
Closes #247

To recreate search from http://brainly.com/ I had to add two new modifiers to `mint-input`: mint-input--large and mint-input--subtle-border: 
 
<img width="419" alt="screen shot 2015-09-07 at 16 01 27" src="https://cloud.githubusercontent.com/assets/985504/9718179/cd83684a-5579-11e5-99ae-85bfe0b100e1.png">

"Hero search" looks like this on desktop:
<img width="1011" alt="screen shot 2015-09-07 at 16 01 50" src="https://cloud.githubusercontent.com/assets/985504/9718178/cd7f4864-5579-11e5-9682-739e9f6616d6.png">

And like this on mobile:
<img width="595" alt="screen shot 2015-09-07 at 16 02 01" src="https://cloud.githubusercontent.com/assets/985504/9718177/cd7eb688-5579-11e5-8d2d-f0b856aa18d2.png">
