### PR TITLE
Feature/vertical rhythm elements

### DIFF
--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -22,7 +22,7 @@ $include-html: false !default;
     height: $avatarMediumSize;
     border-radius: 50%;
     background: $avatarDefaultBackgroundColor;
-    vertical-align: inherit;
+    vertical-align: bottom;
 
     &__image {
       position: absolute;

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -1,4 +1,4 @@
-$badgeFontSize: 10px;
+$badgeFontSize: fontSize(tiny);
 $badgeDefaultBackgroundColor: $peachPrimary;
 $badgeDefaultColor: $white;
 $badgeLightBackgroundColor: $white;
@@ -10,10 +10,9 @@ $include-html: false !default;
 
   .mint-badge {
     @include component;
+    @include fixText($badgeFontSize);
 
     border-radius: $badgeFontSize;
-    line-height: $badgeFontSize;
-    font-size: $badgeFontSize;
     font-weight: bold;
     padding: 3px 6px;
 

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -1,4 +1,4 @@
-$badgeFontSize: fontSize(tiny);
+$badgeFontSize: tiny;
 $badgeDefaultBackgroundColor: $peachPrimary;
 $badgeDefaultColor: $white;
 $badgeLightBackgroundColor: $white;
@@ -10,9 +10,11 @@ $include-html: false !default;
 
   .mint-badge {
     @include component;
-    @include fixText($badgeFontSize);
+    @include typeVariant($badgeFontSize);
+    line-height: fontSize($badgeFontSize);
+    min-height: auto;
 
-    border-radius: $badgeFontSize;
+    border-radius: fontSize($badgeFontSize);
     font-weight: bold;
     padding: 3px 6px;
 

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -1,9 +1,9 @@
-$buttonPrimaryHeight: 44px;
-$buttonSecondaryHeight: 32px;
-$buttonSecondarySmallHeight: 24px;
+$buttonPrimaryHeight: 2.75rem; // 44px;
+$buttonSecondaryHeight: 2rem;
+$buttonSecondarySmallHeight: 1.5rem;
 
-$buttonPrimaryFontSize: 15px;
-$buttonSecondaryFontSize: 12px;
+$buttonPrimaryFontSize: fontSize(medium);
+$buttonSecondaryFontSize: fontSize(obscure);
 
 $buttonPrimaryFontColor: $white;
 
@@ -48,10 +48,10 @@ $iconAsButtonColor: $bluePrimary;
 $iconAsButtonLightColor: $white;
 $iconAsButtonGrayColor: $grayPrimary;
 
-$buttonRoundAddSize: 50px;
-$buttonRoundAddFontSize: 18px;
+$buttonRoundAddSize: 3.125rem;
+$buttonRoundAddFontSize: 1.125rem;
 $buttonRoundAddColor: $white;
-$buttonRoundLabelFontSize: 10px;
+$buttonRoundLabelFontSize: fontSize(tiny);
 $buttonRoundLabelBackground: $mintSecondaryLight;
 $buttonRoundLabelColor: $black;
 
@@ -141,13 +141,13 @@ $include-html: false !default;
 
 @mixin mint-button-secondary-three-color-variant($bgColor, $textColor, $hoverTextColor) {
   border: 0;
-  padding: 0 $buttonSecondaryHeight /2 + 2px;
+  padding: 0 $buttonSecondaryHeight /2 + 0.125rem;
   @include mint-button-basic-colors($bgColor, $textColor, $bgColor);
   @include mint-button-secondary-active($textColor, $hoverTextColor, $textColor);
 
   &-inverse {
     border: 0;
-    padding: 0 $buttonSecondaryHeight /2 + 2px;
+    padding: 0 $buttonSecondaryHeight /2 + 0.125rem;
     @include mint-button-basic-colors($textColor, $hoverTextColor, $textColor);
     @include mint-button-secondary-active($bgColor, $textColor, $bgColor);
   }
@@ -215,7 +215,7 @@ $include-html: false !default;
       font-weight: bold;
       font-size: $buttonRoundLabelFontSize;
       border-radius: 4px;
-      line-height: 12px;
+      line-height: rhythm(1/2);
       background: $buttonRoundLabelBackground;
       color: $buttonRoundLabelColor;
       text-transform: uppercase;

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -28,7 +28,7 @@ $crInputActiveBorderColor: $bluePrimary;
 $crInputCheckedColor: $bluePrimary;
 
 $crInputLabelFontSize: fontSize(obscure);
-$crInputLabelLineHeight: rhythm(0.9);
+$crInputLabelLineHeight: rhythm(0.933);
 $crInputLabelHeight: rhythm(0.666);
 $crInputLabelColor: $grayPrimary;
 

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -1,48 +1,48 @@
 $selectBackground: $grayAltLight;
 $selectTextColor: $grayAlt;
-$selectFontSize: 12px;
-$selectHeight: 44px;
+$selectFontSize: fontSize(obscure);
+$selectHeight: rhythm(1.833);
 $selectHoverBackground: $graySecondary;
 $selectInvalidBorderColor: $peachSecondary;
 
-$inputHeight: 44px;
-$inputLowHeight: 36px;
+$inputHeight: rhythm(1.833);
+$inputLowHeight: rhythm(1.5);
 $inputBackground: $white;
 $inputBorderColor: $graySecondary;
 $inputTextColor: $black;
-$inputFontSize: 15px;
+$inputFontSize: fontSize(medium);
 $inputFocusBorderColor: $grayPrimary;
 $inputPlaceholderTextColor: $grayPrimary;
-$inputPlaceholderFontSize: 12px;
+$inputPlaceholderFontSize: fontSize(obscure);
 $inputValidBorderColor: $mintSecondary;
 $inputInvalidBorderColor: $peachSecondary;
 $inputTransparentBorderColor: rgba($graySecondary, 0.7);
 $inputTransparentFocusBorderColor: rgba($grayPrimary, 0.7);
 
-$crInputSize: 16px;
-$crInputFontSize: 16px;
+$crInputSize: fontSize(default);
+$crInputFontSize: fontSize(default);
 $crInputColor: $white;
 $crInputBorderColor: $graySecondary;
 $crInputHoverBorderColor: $blueSecondaryLight;
 $crInputActiveBorderColor: $bluePrimary;
 $crInputCheckedColor: $bluePrimary;
 
-$crInputLabelFontSize: 12px;
-$crInputLabelLineHeight: 18px;
-$crInputLabelHeight: 16px;
+$crInputLabelFontSize: fontSize(obscure);
+$crInputLabelLineHeight: rhythm(0.9);
+$crInputLabelHeight: rhythm(0.666);
 $crInputLabelColor: $grayPrimary;
 
 $textareaBackground: $white;
 $textareaBorderColor: $graySecondary;
 $textareaBorderRadius: 11px;
-$textareaFontSize: 15px;
-$textareaLineHeight: 19px;
+$textareaFontSize: fontSize(default);
+$textareaLineHeight: rhythm(0.792);
 $textareaTextColor: $black;
 $textareaPadding: 11px;
 $textareaSmallPadding: 6px;
 $textareaFocusBorderColor: $grayPrimary;
 $textareaPlaceholderTextColor: $grayPrimary;
-$textareaPlaceholderFontSize: 12px;
+$textareaPlaceholderFontSize: fontSize(obscure);
 $textareaValidBorderColor: $mintSecondary;
 $textareaInvalidBorderColor: $peachSecondary;
 
@@ -68,7 +68,7 @@ $include-html: false !default;
       display: inline-block;
       height: $selectHeight;
       position: relative;
-      padding: 0 $selectHeight/2+14px 0 $selectHeight/2;
+      padding: 0 $selectHeight/2 + rhythm(0.56) 0 $selectHeight/2;
       outline: 0;
       appearance: none;
       text-transform: uppercase;
@@ -104,7 +104,7 @@ $include-html: false !default;
       border: 2px solid $selectInvalidBorderColor;
 
       .mint-select__element {
-        padding: 0 $selectHeight/2+12px 0 ($selectHeight/2 - 2px);
+        padding: 0 $selectHeight/2 rhythm(0.5) 0 ($selectHeight/2 - rhythm(1/12));
       }
     }
   }
@@ -118,7 +118,6 @@ $include-html: false !default;
     font-size: $inputFontSize;
     padding: 0 $inputHeight/2;
     height: $inputHeight;
-    line-height: $inputHeight;
     appearance: none;
 
     &:focus {
@@ -184,8 +183,10 @@ $include-html: false !default;
   .mint-checkbox,
   .mint-radio {
     @include component;
+    overflow: visible;
     width: $crInputSize;
     height: $crInputSize;
+    min-height: $crInputSize;
     font-size: $crInputFontSize;
 
     &__element {
@@ -220,6 +221,7 @@ $include-html: false !default;
   .mint-checkbox-label,
   .mint-radio-label {
     @include component;
+    overflow: visible;
     font-weight: bold;
     font-size: $crInputLabelFontSize;
     line-height: $crInputLabelLineHeight;
@@ -243,10 +245,10 @@ $include-html: false !default;
     border-radius: 25%;
 
     &:before {
-      font-size: 137.5%;
+      font-size: 1.375rem;
       position: absolute;
-      left: -18.75%;
-      top: -18.75%;
+      left: -18%;
+      top: -8%;
       color: $crInputColor;
     }
   }
@@ -261,7 +263,7 @@ $include-html: false !default;
       background-color: $crInputColor;
       width: 50%;
       height: 50%;
-      top: 25%;
+      top: 35%;
       left: 25%;
     }
   }

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -10,7 +10,7 @@ $labelScaleFactor: 2/3;
 
 $include-html: false !default;
 
-@mixin label-from-icon($name) {
+@mixin label-from-icon($name){
   &--#{$name}:before {
     @extend .mint-icon-#{$name}:before;
     display: block;

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -1,8 +1,8 @@
 $labelPrimaryColor: $black;
 $labelSecondaryColor: $grayPrimary;
 $labelFontWeight: $fontWeightBlack;
-$labelFontSizePrimary: 12px;
-$labelFontSizeSecondary: 10px;
+$labelFontSizePrimary: fontSize(obscure);
+$labelFontSizeSecondary: fontSize(tiny);
 $labelIconSizePrimary: 16px;
 $labelIconSizeSecondary: 14px;
 $labelHeight: $defaultComponentHeight;
@@ -27,7 +27,7 @@ $include-html: false !default;
     height: $labelHeight;
 
     &__text, &__number {
-      @include fixText($labelFontSizePrimary, 2px);
+      @include fixText($labelFontSizePrimary, 2/16);
       display: block;
       vertical-align: middle;
       color: $labelPrimaryColor;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,4 +1,3 @@
-$breadcrumbListFontSize: 13px;
 $breadcrumbListSeparatorColor: $grayPrimary;
 $breadcrumbListBlueSeparatorColor: $blueSecondary;
 $breadcrumbListLightBlueSeparatorColor: $blueSecondaryLight;
@@ -12,6 +11,7 @@ $include-html: false !default;
 
 @mixin mint-list-basic-styles() {
   @include component;
+  overflow: visible; // move baseline from margin to the last line box
   display: block;
   margin: 0;
   padding: 0;
@@ -22,8 +22,7 @@ $include-html: false !default;
 
   .mint-list {
     @include mint-list-basic-styles();
-    font-size: 24px;
-    line-height: 44px;
+    line-height: 2*$baseline;
 
     .mint-list__element {
       @extend .mint-icon-arrow_down;
@@ -33,14 +32,14 @@ $include-html: false !default;
         color: white;
         transform: rotate(-90deg);
         font-size: 38px;
-        vertical-align: -6px;
+        vertical-align: -5px;
         margin-right: 10px;
       }
 
       &--with-plus {
         &:before {
           font-size: 24px;
-          vertical-align: 0;
+          vertical-align: -4px;
           color: $listSmallIconColor;
           @extend .mint-icon-plus;
         }
@@ -48,9 +47,7 @@ $include-html: false !default;
     }
 
     &--small {
-      font-size: 15px;
-      line-height: 30px;
-
+      line-height: $baseline;
       .mint-list__element {
         &:before {
           font-size: 24px;
@@ -61,7 +58,7 @@ $include-html: false !default;
         &--with-plus {
           &:before {
             font-size: 14px;
-            vertical-align: 0;
+            vertical-align: 1px;
           }
         }
       }
@@ -72,10 +69,10 @@ $include-html: false !default;
     @include mint-list-basic-styles();
     &__element {
       box-sizing: border-box;
-      height: 35px;
-      line-height: 35px;
+      height: 2 * $baseline;
+      line-height: 2 * $baseline;
       border-bottom: 1px dashed $menuListBorderColor;
-      font-family: inherit;
+
       &:last-child {
         border: 0;
       }
@@ -88,7 +85,6 @@ $include-html: false !default;
       text-decoration: none;
       display: block;
       font-size: $menuListFontSize;
-      font-family: inherit;
       white-space: nowrap;
       &:hover {
         text-decoration: underline;
@@ -103,15 +99,13 @@ $include-html: false !default;
     @include mint-list-basic-styles();
     display: inline-block;
     vertical-align: inherit;
-    font-size: $breadcrumbListFontSize;
-    line-height: $breadcrumbListFontSize * 1.5;
     color: $breadcrumbListSeparatorColor;
 
     &__element {
       display: inline-block;
 
       &:after {
-        content: '·';
+        content: '•';
         display: inline-block;
         color: $breadcrumbListSeparatorColor;
         padding: 0 2px;
@@ -123,6 +117,7 @@ $include-html: false !default;
     }
 
     &--for-fine-print {
+      font-size: 0.8125rem;
       color: $breadcrumbListBlueSeparatorColor;
       .mint-breadcrumb-list__element {
         &:after {
@@ -132,6 +127,7 @@ $include-html: false !default;
     }
 
     &--for-fine-print-light {
+      font-size: 0.8125rem;
       color: $breadcrumbListLightBlueSeparatorColor;
       .mint-breadcrumb-list__element {
         &:after {

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -22,7 +22,7 @@ $include-html: false !default;
 
   .mint-list {
     @include mint-list-basic-styles();
-    line-height: 2*$baseline;
+    line-height: rhythm(2);
 
     .mint-list__element {
       @extend .mint-icon-arrow_down;
@@ -47,7 +47,7 @@ $include-html: false !default;
     }
 
     &--small {
-      line-height: $baseline;
+      line-height: rhythm(1);
       .mint-list__element {
         &:before {
           font-size: 24px;
@@ -69,8 +69,8 @@ $include-html: false !default;
     @include mint-list-basic-styles();
     &__element {
       box-sizing: border-box;
-      height: 2 * $baseline;
-      line-height: 2 * $baseline;
+      height: rhythm(2);
+      line-height: rhythm(2);
       border-bottom: 1px dashed $menuListBorderColor;
 
       &:last-child {

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,9 +1,12 @@
+$listFontSize: fontSize(headline);
+$smallListFontSize: fontSize(default);
+
 $breadcrumbListSeparatorColor: $grayPrimary;
 $breadcrumbListBlueSeparatorColor: $blueSecondary;
 $breadcrumbListLightBlueSeparatorColor: $blueSecondaryLight;
 
 $menuListColor: $bluePrimary;
-$menuListFontSize: 13px;
+$menuListFontSize: fontSize(small);
 $menuListBorderColor: $graySecondary;
 $listSmallIconColor: $graySecondary;
 
@@ -22,6 +25,7 @@ $include-html: false !default;
 
   .mint-list {
     @include mint-list-basic-styles();
+    font-size: $listFontSize;
     line-height: rhythm(2);
 
     .mint-list__element {
@@ -39,7 +43,7 @@ $include-html: false !default;
       &--with-plus {
         &:before {
           font-size: 24px;
-          vertical-align: -4px;
+          vertical-align: 0;
           color: $listSmallIconColor;
           @extend .mint-icon-plus;
         }
@@ -48,6 +52,9 @@ $include-html: false !default;
 
     &--small {
       line-height: rhythm(1);
+      font-weight: bold;
+      font-size: $smallListFontSize;
+
       .mint-list__element {
         &:before {
           font-size: 24px;

--- a/src/components/list/list.html
+++ b/src/components/list/list.html
@@ -17,35 +17,35 @@
             </ul>
             <ul class="mint-breadcrumb-list">
                 <li class="mint-breadcrumb-list__element">
-                    <a class="mint-link mint-link--gray mint-link--emphasised" href="#">English</a>
+                    <a class="mint-link mint-link--small mint-link--gray mint-link--emphasised" href="#">English</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    <a class="mint-link mint-link--gray" href="#">Katie</a>
+                    <a class="mint-link mint-link--small mint-link--gray" href="#">Katie</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    <span class="mint-link mint-link--gray mint-link--disabled">Answerer</span>
+                    <span class="mint-link mint-link--small mint-link--gray mint-link--disabled">Answerer</span>
                 </li>
             </ul>
             <ul class="mint-breadcrumb-list mint-breadcrumb-list--for-fine-print">
                 <li class="mint-breadcrumb-list__element">
-                    Poland: <a class="mint-link mint-link--for-fine-print-light" href="#">Zadane.pl</a>
+                    Poland: <a class="mint-link mint-link--small mint-link--for-fine-print-light" href="#">Zadane.pl</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    Russia: <a class="mint-link mint-link--for-fine-print-light" href="#">Znanija.com</a>
+                    Russia: <a class="mint-link mint-link--small mint-link--for-fine-print-light" href="#">Znanija.com</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    Spain: <a class="mint-link mint-link--for-fine-print-light">Misdeberes.es</a>
+                    Spain: <a class="mint-link mint-link--small mint-link--for-fine-print-light">Misdeberes.es</a>
                 </li>
             </ul>
             <ul class="mint-breadcrumb-list mint-breadcrumb-list--for-fine-print-light">
                 <li class="mint-breadcrumb-list__element">
-                    Poland: <a class="mint-link mint-link--for-fine-print" href="#">Zadane.pl</a>
+                    Poland: <a class="mint-link mint-link--small mint-link--for-fine-print" href="#">Zadane.pl</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    Russia: <a class="mint-link mint-link--for-fine-print" href="#">Znanija.com</a>
+                    Russia: <a class="mint-link mint-link--small mint-link--for-fine-print" href="#">Znanija.com</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    Spain: <a class="mint-link mint-link--for-fine-print">Misdeberes.es</a>
+                    Spain: <a class="mint-link mint-link--small mint-link--for-fine-print">Misdeberes.es</a>
                 </li>
             </ul>
         </div>

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -5,8 +5,8 @@ $rateStarActiveColor: $graySecondaryLight;
 $rateStarActiveCheckedColor: $mustardSecondary;
 $rateCounterColor: $grayPrimary;
 $rateCounterFontWeight: $fontWeightBlack;
-$rateStarFontSize: 12px;
-$rateStarSmallFontSize: 10px;
+$rateStarFontSize: fontSize(obscure);
+$rateStarSmallFontSize: fontSize(tiny);
 $rateScaleFactor: 2/3;
 
 $include-html: false !default;
@@ -52,7 +52,7 @@ $include-html: false !default;
     }
 
     &__counter {
-      @include fixText($rateStarFontSize, 2px);
+      @include fixText($rateStarFontSize, 0.125rem);
       font-weight: $rateCounterFontWeight;
       color: $rateCounterColor;
       margin: 0 0 0 $layoutDefaultPadding/2;

--- a/src/components/separators/_horizontal-separator.scss
+++ b/src/components/separators/_horizontal-separator.scss
@@ -1,4 +1,4 @@
-$horizontalSeparatorHeight: 1px;
+$horizontalSeparatorHeight: 0.0625rem;
 $horizontalSeparatorColor: $grayPrimary;
 
 $include-html: false !default;
@@ -7,13 +7,14 @@ $include-html: false !default;
 
   .mint-horizontal-separator {
     @include component();
+    min-height: auto;
     display: block;
     height: $horizontalSeparatorHeight;
     border-bottom: $horizontalSeparatorHeight dotted $horizontalSeparatorColor;
     width: 100%;
 
     &--spaced {
-      margin: $layoutDefaultPadding - $horizontalSeparatorHeight 0 $layoutDefaultPadding 0;
+      margin: rhythm(1) - $horizontalSeparatorHeight 0 rhythm(1) 0;
     }
   }
 

--- a/src/components/separators/_separators.scss
+++ b/src/components/separators/_separators.scss
@@ -1,7 +1,7 @@
 $separatorColor: $grayPrimary;
-$separatorHeight: 18px;
+$separatorHeight: rhythm(0.75);
 $separatorSpacing: 15px;
-$separatorHeightSmall: 10px;
+$separatorHeightSmall: rhythm(0.417);
 $separatorSpacingSmall: 10px;
 
 $include-html: false !default;
@@ -10,6 +10,7 @@ $include-html: false !default;
 
   .mint-separator {
     @include component;
+    min-height: auto;
 
     margin-right: $separatorSpacing;
     border-right: solid $separatorColor 1px;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -5,9 +5,9 @@ $tabActiveBackground: $bluePrimary;
 $tabActiveTextColor: $white;
 $tabHoverBackground: $blueSecondary;
 $tabHoverTextColor: $white;
-$tabHeight: 44px;
-$tabSmallHeight: 32px;
-$tabFontSize: 12px;
+$tabHeight: rhythm(1.833);
+$tabSmallHeight: rhythm(1.5);
+$tabFontSize: fontSize(obscure);
 
 $include-html: false !default;
 

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -4,13 +4,13 @@ $include-html: false !default;
 
   .mint-header-primary {
     @include component;
-    @include typeVariant(header, 2, 11/16, 37/16);
+    @include typeVariant(header, 2);
     display: block;
     color: $black;
     font-weight: $fontWeightBlack;
 
     &--small {
-      @include typeVariant(headline, 2, 1, 8/16);
+      @include typeVariant(headline);
     }
 
     &--light {
@@ -20,7 +20,7 @@ $include-html: false !default;
 
   .mint-header-secondary {
     @include component;
-    @include typeVariant(default, 0.667, 12/16, 20/16);
+    @include typeVariant(default, 0.667);
     display: block;
     color: $black;
     font-weight: bold;
@@ -28,7 +28,7 @@ $include-html: false !default;
     text-transform: uppercase;
 
     &--small {
-      @include typeVariant(small, 0.667, 13/16, 19/16);
+      @include typeVariant(small, 0.667);
       letter-spacing: 1px;
     }
 

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -4,13 +4,13 @@ $include-html: false !default;
 
   .mint-header-primary {
     @include component;
-    @include type-variant(3, 2, 11/16, 37/16);
+    @include typeVariant(header, 2, 11/16, 37/16);
     display: block;
     color: $black;
     font-weight: $fontWeightBlack;
 
     &--small {
-      @include type-variant(1.75, 2, 1, 8/16);
+      @include typeVariant(headline, 2, 1, 8/16);
     }
 
     &--light {
@@ -20,7 +20,7 @@ $include-html: false !default;
 
   .mint-header-secondary {
     @include component;
-    @include type-variant(1, 0.667, 12/16, 20/16);
+    @include typeVariant(default, 0.667, 12/16, 20/16);
     display: block;
     color: $black;
     font-weight: bold;
@@ -28,7 +28,7 @@ $include-html: false !default;
     text-transform: uppercase;
 
     &--small {
-      @include type-variant(0.8125, 0.667, 13/16, 19/16);
+      @include typeVariant(small, 0.667, 13/16, 19/16);
       letter-spacing: 1px;
     }
 

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -13,6 +13,10 @@
     color: $grayPrimary;
   }
 
+  &--small {
+    @include type-variant(0.8125, 0.75);
+  }
+
   &--for-fine-print {
     color: $blueSecondary;
   }
@@ -22,7 +26,6 @@
   }
 
   &--emphasised {
-    @include type-variant(0.8125, 0.75);
     text-transform: uppercase;
     letter-spacing: 0.01em;
   }

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -14,7 +14,7 @@
   }
 
   &--small {
-    @include type-variant(0.8125, 0.75);
+    @include typeVariant(small, 0.75);
   }
 
   &--for-fine-print {

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -2,10 +2,9 @@ $textBitLogoSize: 84px;
 $textBitSmallLogoSize: 68px;
 
 .mint-text-bit {
+  @include typeVariant(large, 2);
   color: $mintSecondary;
   font-weight: $fontWeightBlack;
-  font-size: 3.625rem;
-  line-height: 2 * $baseline;
   text-transform: uppercase;
   word-wrap: break-word;
   margin: 0;
@@ -74,6 +73,6 @@ $textBitSmallLogoSize: 68px;
   }
 
   &--small {
-    font-size: 3rem;
+    @include typeVariant(header);
   }
 }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -3,24 +3,23 @@ $include-html: false !default;
 @if ($include-html) {
 
   .mint-text {
-    @include type-variant(1, 1);
+    @include typeVariant(default, 1);
     font-family: $fontFamilyPrimary;
     color: $black;
 
     &--standout {
-      @include type-variant(1.125, 1);
-      font-size: 1.125rem;
+      @include typeVariant(standout, 1);
     }
 
     &--obscure {
-      @include type-variant(0.75, 1);
+      @include typeVariant(obscure, 1);
     }
 
     &--headline {
-      @include type-variant(1.75, 1.334);
+      @include typeVariant(headline, 1.334);
       font-weight: normal;
       margin: 0;
-      margin-bottom: $baseline;
+      margin-bottom: rhythm(1);
     }
 
     &--emphasised {

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -118,7 +118,7 @@
                 Some texts and a disabled link <span class="mint-link mint-link--gray mint-link--disabled">2 min ago</span><br/>
             </div>
             <div>
-                An emphasized link <a href="#" class="mint-link mint-link--gray mint-link--emphasised">Math</a><br/>
+                An emphasized link <a href="#" class="mint-link mint-link--gray mint-link--small mint-link--emphasised">Math</a><br/>
             </div>
             <div>
                 Fine print link <a href="#" class="mint-link mint-link--for-fine-print-light">zadane.pl</a><br/>

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -6,7 +6,7 @@ $include-html: false !default;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
-    font-size: $base-font;
+    font-size: $baseFont;
     font-family: $fontFamilyPrimary;
     line-height: $baseline;
   }

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -52,10 +52,23 @@ $fontWeightBlack: 500;
 $iconBoostValue: 4px;
 
 // Vertical rhythm
-$base-font: 16px;
+$baseFont: 16px;
 $baseline: 1.5rem;
 
-// Layout
+// Typo
+$fontSizes: (
+  default: 1rem,      // 16px
+  tiny: 0.625rem,     // 10px
+  obscure: 0.75rem,   // 12px
+  small: 0.8125rem,   // 13px
+  large: 3.625rem,    // 58px
+  standout: 1.125rem, // 18px
+  headline: 1.75rem,  // 28px
+  header: 3rem        // 48px
+);
+
+
+  // Layout
 $layoutMaximumWidth: 960px;
 $layoutDefaultPadding: 24px;
 $breakpointTablet: 768px;

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -49,7 +49,7 @@ $fontFamilyPrimary: 'ProximaNova', 'Helvetica', 'Arial', sans-serif;
 $fontWeightBlack: 500;
 
 // Icons
-$iconBoostValue: 4px;
+$iconBoostValue: 0.25rem;
 
 // Vertical rhythm
 $baseFont: 16px;
@@ -59,9 +59,10 @@ $baseline: 1.5rem;
 $fontSizes: (
   default: 1rem,      // 16px
   tiny: 0.625rem,     // 10px
-  obscure: 0.75rem,   // 12px
   small: 0.8125rem,   // 13px
+  medium: 0.9375rem,  // 15px
   large: 3.625rem,    // 58px
+  obscure: 0.75rem,   // 12px
   standout: 1.125rem, // 18px
   headline: 1.75rem,  // 28px
   header: 3rem        // 48px

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -12,6 +12,7 @@
   position: relative;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 0.8 * $baseline; // take descenders into account for small inline-block elements
   margin: 0;
 }
 

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -1,4 +1,4 @@
-@mixin image-2x($image, $width:"auto", $height:"auto") {
+@mixin image-2x($image, $width: "auto", $height: "auto") {
   @media (min-resolution: 144dpi) {
     /* on retina, use image that's scaled by 2 */
     background-image: url($image);
@@ -16,7 +16,7 @@
   margin: 0;
 }
 
-@mixin hole(){
+@mixin hole() {
   &__hole {
     display: flex;
     align-items: center;
@@ -25,38 +25,52 @@
   }
 }
 
-// $line-height-offset is a way to fix font issue with the baseline
+// $lineHeight-offset is a way to fix font issue with the baseline
 // the issue is visible when centering the text of at least 12px
-@mixin fixText($fontSize, $lineHeightOffset: 0){
+@mixin fixText($fontSize, $lineHeightOffset: 0) {
   font-size: $fontSize;
   height: $fontSize;
   line-height: $fontSize + $lineHeightOffset;
 }
 
-@mixin icon($name){
+@mixin icon($name) {
   @extend .mint-icon-#{$name};
   &:before {
     display: inline-block;
   }
 }
 
-// Used for messing with fonts and baseline
-// Sets the font size and line height
-// fontsize - rem
-// line-height - rem
-@mixin type-variant($fontsize, $line-height, $shift: 0, $push: 0){
-
-  $rem-fontsize: $fontsize * 1rem;
-  $rem-lineheight: $line-height * $baseline;
-
-  font-size: $rem-fontsize;
-  line-height: $rem-lineheight;
-  padding-top: $shift * 1rem;
-  margin-bottom: $push * 1rem;
+@function fontSize($fontsizeKey) {
+  @return map-get($fontSizes, $fontsizeKey);
 }
 
+// Used for messing with fonts and baseline
+// Sets the font size and line height
+// fontsizeName - string
+// lineHeight - int, number of baselines
+@mixin typeVariant($fontsizeName, $lineHeight: null, $shift: null, $push: null) {
+
+  $remFontsize: fontSize($fontsizeName);
+
+  @if $remFontsize != null {
+    font-size: $remFontsize;
+  }
+
+  @if $lineHeight != null {
+    $remLineHeight: rhythm($lineHeight);
+    line-height: $remLineHeight;
+  }
+
+  @if $shift != null {
+    padding-top: $shift * 1rem;
+  }
+
+  @if $push != null {
+    margin-bottom: $push * 1rem;
+  }
+}
 
 // set a value as a multiple of baselines
-@function rhythm($baselines){
+@function rhythm($baselines) {
   @return $baselines * $baseline;
 }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -62,11 +62,11 @@
   }
 
   @if $shift != null {
-    padding-top: $shift * 1rem;
+    padding-top: rhythm($shift);
   }
 
   @if $push != null {
-    margin-bottom: $push * 1rem;
+    margin-bottom: rhythm($push);
   }
 }
 

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -12,7 +12,8 @@
   position: relative;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 0.8 * $baseline; // take descenders into account for small inline-block elements
+  line-height: rhythm(1);
+  min-height: rhythm(1);
   margin: 0;
 }
 


### PR DESCRIPTION
**WIP: will be merged in `dev/vertical-rhythm`. Not rebased to latest changes.**

### Changes

#### Font map
`$fontSizes` - a map of available font sizes. 
There are 2 dimension axes right now:

* `tiny`, `small`, `default`, `medium`, `large` - used mostly for components (e.g as labels)
* `default`, `small`, `obscure`, `standout`, `headline`, `header` - used for texts/headers

`fontSize` function used for setting font-size in all components and text:
```
font-size: fontSize(default);
```

#### Rhythm

`rhythm` function is used to set the vertical dimensions proportional to `$baseline`:

```
line-height: rhythm(1/2);
```

#### Component mixin

* `min-height: rhythm(1)` - added to align small components to vertical rhythm
* `line-height: rhythm(1)` - fixes #112 

#### Sizes

Basic components sizes are migrated to use `fontSize` and `rhythm` mixins. 

All components are updated to remain the same proportions and centering as it used to be (compared to style-guide v6.0.0)

### Breaking changes

* `.mint-breadcrumb-list` lost its specific text styles. Now it is more like a container - you can put arbitrary text blocks inside.
* `.mint-checkbox` need to be reimplemented (maybe in the same way as `mint-label`). Right now all the calculations inside chechbox/radio + label are unsustainable.

