### PR TITLE
Added --full-width modifiers to labels and added fix for dropdowns

### DIFF
--- a/src/components/dropdowns/_dropdowns.scss
+++ b/src/components/dropdowns/_dropdowns.scss
@@ -45,6 +45,8 @@ $include-html: false !default;
       justify-content: flex-start;
       min-height: $dropdownHeight - (2 * $dropdownBorderSize);
       margin: 0 $dropdownHeight 0 $dropdownHeight/2;
+      white-space: nowrap;
+      overflow: hidden;
       
       &--active {
         display: none;
@@ -63,6 +65,8 @@ $include-html: false !default;
       justify-content: flex-start;
       height: 100%;
       padding: $layoutDefaultPadding/4 $dropdownHeight/2;
+      white-space: nowrap;
+      overflow: hidden;
       text-decoration: none;
 
       &:hover,

--- a/src/components/dropdowns/dropdowns.html
+++ b/src/components/dropdowns/dropdowns.html
@@ -41,7 +41,7 @@
             </div>
             <div class="mint-dropdown__items">
                 <div class="mint-dropdown__item-hole">
-                    <div href="#" class="mint-label">
+                    <div href="#" class="mint-label mint-label--full-width">
                         <div class="mint-label__text">
                             Option 1
                         </div>

--- a/src/components/dropdowns/dropdowns.html
+++ b/src/components/dropdowns/dropdowns.html
@@ -5,7 +5,7 @@
     <div class="docs-block__content">
         <div class="mint-dropdown">
             <div class="mint-dropdown__hole">
-                <div class="mint-label">
+                <div class="mint-label mint-label--full-width">
                     <div class="mint-label__text">
                         Default label
                     </div>
@@ -16,7 +16,7 @@
     <div class="docs-block__content">
         <div class="mint-dropdown mint-dropdown--full">
             <div class="mint-dropdown__hole">
-                <div class="mint-label">
+                <div class="mint-label mint-label--full-width">
                     <div class="mint-label__text">
                         Default label
                     </div>
@@ -33,7 +33,7 @@
     <div class="docs-block__content">
         <div class="mint-dropdown mint-dropdown--opened">
             <div class="mint-dropdown__hole">
-                <div class="mint-label">
+                <div class="mint-label mint-label--full-width">
                     <div class="mint-label__text">
                         Default label
                     </div>
@@ -48,7 +48,7 @@
                     </div>
                 </div>
                 <div class="mint-dropdown__item-hole">
-                    <div href="#" class="mint-label">
+                    <div href="#" class="mint-label mint-label--full-width">
                         <div class="mint-label__text">
                             Option 2
                         </div>
@@ -60,7 +60,7 @@
     <div class="docs-block__content">
         <div class="mint-dropdown mint-dropdown--full mint-dropdown--opened">
             <div class="mint-dropdown__hole">
-                <div class="mint-label">
+                <div class="mint-label mint-label--full-width">
                     <div class="mint-label__text">
                         Default label
                     </div>
@@ -68,14 +68,14 @@
             </div>
             <div class="mint-dropdown__items">
                 <div class="mint-dropdown__item-hole">
-                    <div href="#" class="mint-label">
+                    <div href="#" class="mint-label mint-label--full-width">
                         <div class="mint-label__text">
                             Option 1
                         </div>
                     </div>
                 </div>
                 <div class="mint-dropdown__item-hole">
-                    <div href="#" class="mint-label">
+                    <div href="#" class="mint-label mint-label--full-width">
                         <div class="mint-label__text">
                             Option 2
                         </div>
@@ -93,14 +93,14 @@
     <div class="docs-block__content">
         <div class="mint-dropdown js-mint-dropdown">
             <div class="mint-dropdown__hole mint-dropdown__hole--inactive">
-                <div class="mint-label mint-label--inactive">
+                <div class="mint-label mint-label--inactive mint-label--full-width">
                     <div class="mint-label__text">
                         Default label
                     </div>
                 </div>
             </div>
             <div class="mint-dropdown__hole mint-dropdown__hole--active">
-                <div class="mint-label">
+                <div class="mint-label mint-label--full-width">
                     <div class="mint-label__text">
                         Choose option
                     </div>
@@ -108,14 +108,14 @@
             </div>
             <div class="mint-dropdown__items">
                 <a href="#" class="mint-dropdown__item-hole">
-                    <div href="#" class="mint-label mint-label--inactive">
+                    <div href="#" class="mint-label mint-label--inactive mint-label--full-width">
                         <div class="mint-label__text">
                             Option 1
                         </div>
                     </div>
                 </a>
                 <a href="#" class="mint-dropdown__item-hole">
-                    <div href="#" class="mint-label mint-label--inactive">
+                    <div href="#" class="mint-label mint-label--inactive mint-label--full-width">
                         <div class="mint-label__text">
                             Option 2
                         </div>
@@ -127,14 +127,14 @@
     <div class="docs-block__content">
         <div class="mint-dropdown mint-dropdown--full js-mint-dropdown">
             <div class="mint-dropdown__hole mint-dropdown__hole--inactive">
-                <div class="mint-label mint-label--inactive">
+                <div class="mint-label mint-label--inactive mint-label--full-width">
                     <div class="mint-label__text">
                         Default label
                     </div>
                 </div>
             </div>
             <div class="mint-dropdown__hole  mint-dropdown__hole--active">
-                <div class="mint-label">
+                <div class="mint-label mint-label--full-width">
                     <div class="mint-label__text">
                         Choose option
                     </div>
@@ -142,7 +142,7 @@
             </div>
             <div class="mint-dropdown__items">
                 <a href="#" class="mint-dropdown__item-hole">
-                    <div class="mint-label mint-label--inactive">
+                    <div class="mint-label mint-label--inactive mint-label--full-width">
                         <div class="mint-label__icon">
                             <div class="mint-subject-icon-box mint-dropdown__element-icon">
                                 <i class="mint-subject-icon mint-subject-icon--medium mint-subject-icon--life-science"></i>
@@ -154,7 +154,7 @@
                     </div>
                 </a>
                 <a href="#" class="mint-dropdown__item-hole">
-                    <div class="mint-label mint-label--inactive">
+                    <div class="mint-label mint-label--inactive mint-label--full-width">
                         <div class="mint-label__icon">
                             <div class="mint-subject-icon-box mint-dropdown__element-icon">
                                 <i class="mint-subject-icon mint-subject-icon--medium mint-subject-icon--life-science"></i>

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -107,6 +107,16 @@ $include-html: false !default;
       }
     }
 
+    &--full-width {
+      width: 100%;
+
+      .mint-label__text {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+      }
+    }
+
     &--small {
       min-height: $labelScaleFactor * $labelHeight;
 

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -43,6 +43,7 @@ $include-html: false !default;
 
     &__text {
       margin-right: $layoutDefaultPadding/2;
+      overflow: hidden;
     }
 
     &__icon {
@@ -111,7 +112,6 @@ $include-html: false !default;
       width: 100%;
 
       .mint-label__text {
-        overflow: hidden;
         text-overflow: ellipsis;
         max-width: 100%;
       }


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/272

below you can see behaviour when dropdown's width is limited.

<img width="164" alt="screen shot 2015-09-11 at 13 45 28" src="https://cloud.githubusercontent.com/assets/1231144/9814082/78bfde78-588b-11e5-9615-a0908513b92c.png">