### PR TITLE
Added --small select

### DIFF
--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -104,6 +104,20 @@ $include-html: false !default;
       margin-top: 1px;
       transform: translateY(-50%);
     }
+
+    &--small {
+      height: $layoutDefaultPadding/3*4;
+
+      &:before {
+        right: $layoutDefaultPadding/3;
+        margin-top: 0;
+      }
+      .mint-select__element {
+        height: $layoutDefaultPadding/3*4;
+        padding: 0 $layoutDefaultPadding/3*4 0 $layoutDefaultPadding/3*2;
+      }
+    }
+
     &--full {
       width: 100%;
     }

--- a/src/components/form-elements/form-elements.html
+++ b/src/components/form-elements/form-elements.html
@@ -23,6 +23,12 @@
                 <option selected>Select Selector</option>
             </select>
         </div>
+        <div class="mint-select mint-select--small">
+            <select class="mint-select__element">
+                <option>Option 1</option>
+                <option selected>Select Selector</option>
+            </select>
+        </div>
     </div>
 </section>
 <section class="docs-block">


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/274

<img width="991" alt="screen shot 2015-09-11 at 14 22 33" src="https://cloud.githubusercontent.com/assets/1231144/9814805/2d17c930-5891-11e5-9e0a-1c6ebc016ebf.png">

this small one is gonna be used instead of dropdown in the filters on small screens.