### PR TITLE
Remove cursor:pointer from form elements 

### DIFF
--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -72,7 +72,6 @@ $include-html: false !default;
     &__element {
       background: $selectBackground;
       border: 0;
-      cursor: pointer;
       font-size: inherit;
       font-family: $selectFontFamily;
       font-weight: bold;
@@ -229,7 +228,6 @@ $include-html: false !default;
       margin: 0;
       width: 100%;
       height: 100%;
-      cursor: pointer;
       z-index: 1;
     }
     &__element:active + &__ghost {


### PR DESCRIPTION
(default form elements don't have that). Fixes issue with Opera Mini. Closes #246