### PR TITLE
Fixed behaviour of dropdowns

### DIFF
--- a/src/components/dropdowns/_dropdowns.scss
+++ b/src/components/dropdowns/_dropdowns.scss
@@ -94,7 +94,7 @@ $include-html: false !default;
       background-color: $dropdownBackground;
       border-color: $dropdownOpenedBorderColor;
       overflow: visible;
-      border-radius: 16px 16px 0 0;
+      border-radius: $dropdownHeight / 2 $dropdownHeight / 2 0 0;
       border-bottom-color: transparent;
 
       &:hover,

--- a/src/components/dropdowns/_dropdowns.scss
+++ b/src/components/dropdowns/_dropdowns.scss
@@ -2,6 +2,10 @@
 $dropdownFontSize: 12px;
 $dropdownHeight: 32px;
 $dropdownBorderSize: 2px;
+$dropdownBackground: $white;
+$dropdownHoverColor: $graySecondary;
+$dropdownBorderColor: $grayAltLight;
+$dropdownOpenedBorderColor: $grayPrimary;
 
 $include-html: false !default;
 
@@ -13,8 +17,8 @@ $include-html: false !default;
     @extend .mint-icon-arrow_down;
     
     background-color: $grayAltLight;
-    border: $dropdownBorderSize solid $grayAltLight;
-    border-radius: 16px;
+    border: $dropdownBorderSize solid $dropdownBorderColor;
+    border-radius: $dropdownHeight / 2;
     min-height: $dropdownHeight;
     height: $dropdownHeight;
     cursor: pointer;
@@ -22,8 +26,8 @@ $include-html: false !default;
 
     &:hover,
     &:active {
-      background-color: $graySecondary;
-      border-color: $graySecondary;
+      background-color: $dropdownHoverColor;
+      border-color: $dropdownHoverColor;
     }
 
     &:before {
@@ -45,7 +49,7 @@ $include-html: false !default;
     &__hole {
       justify-content: flex-start;
       min-height: $dropdownHeight - (2 * $dropdownBorderSize);
-      margin: 0 $dropdownHeight 0 $dropdownHeight/2;
+      margin: 0 $dropdownHeight 0 $dropdownHeight / 2;
       white-space: nowrap;
       overflow: hidden;
       
@@ -58,12 +62,13 @@ $include-html: false !default;
       position: absolute;
       top: $dropdownHeight - 2* $dropdownBorderSize;
       visibility: hidden;
+      overflow: hidden;
       padding: 0;
-      margin: 0 0 $layoutDefaultPadding/2;
-      background-color: $white;
-      border: $dropdownBorderSize solid $grayPrimary;;
+      margin: 0 0 $layoutDefaultPadding / 2;
+      background-color: $dropdownBackground;
+      border: $dropdownBorderSize solid $dropdownOpenedBorderColor;
       border-top: none;
-      border-radius: 0 0 16px 16px;
+      border-radius: 0 0 $dropdownHeight / 2 $dropdownHeight / 2;
       left: -$dropdownBorderSize;
       right: -$dropdownBorderSize;
       z-index: 1;
@@ -74,28 +79,28 @@ $include-html: false !default;
       align-items: center;
       justify-content: flex-start;
       height: 100%;
-      padding: $layoutDefaultPadding/4 $dropdownHeight/2;
+      padding: $layoutDefaultPadding / 4 $dropdownHeight / 2;
       white-space: nowrap;
       overflow: hidden;
       text-decoration: none;
 
       &:hover,
       &:active {
-        background-color: $grayAltLight;
+        background-color: $dropdownBorderColor;
       }
     }
 
     &--opened {
-      background-color: $white;
-      border-color: $grayPrimary;
+      background-color: $dropdownBackground;
+      border-color: $dropdownOpenedBorderColor;
       overflow: visible;
       border-radius: 16px 16px 0 0;
       border-bottom-color: transparent;
 
       &:hover,
       &:active {
-        background-color: $white;
-        border-color: $grayPrimary;
+        background-color: $dropdownBackground;
+        border-color: $dropdownOpenedBorderColor;
         border-bottom-color: transparent;
       }
 

--- a/src/components/dropdowns/_dropdowns.scss
+++ b/src/components/dropdowns/_dropdowns.scss
@@ -23,6 +23,7 @@ $include-html: false !default;
     height: $dropdownHeight;
     cursor: pointer;
     user-select: none;
+    z-index: 1;
 
     &:hover,
     &:active {
@@ -38,7 +39,7 @@ $include-html: false !default;
       top: $dropdownHeight/4 - 2;
       right: $dropdownHeight / 2 - $iconSize / 2;
       color: $grayAlt;
-      z-index: 1;
+      z-index: 2;
       transition: transform 0.3s;
     }
 

--- a/src/components/dropdowns/_dropdowns.scss
+++ b/src/components/dropdowns/_dropdowns.scss
@@ -9,6 +9,7 @@ $include-html: false !default;
 
   .mint-dropdown {
     @include component;
+    @include hole;
     @extend .mint-icon-arrow_down;
     
     background-color: $grayAltLight;
@@ -17,7 +18,7 @@ $include-html: false !default;
     min-height: $dropdownHeight;
     height: $dropdownHeight;
     cursor: pointer;
-    @include hole;
+    user-select: none;
 
     &:hover,
     &:active {
@@ -54,9 +55,18 @@ $include-html: false !default;
     }
 
     &__items {
+      position: absolute;
+      top: $dropdownHeight - 2* $dropdownBorderSize;
       visibility: hidden;
       padding: 0;
       margin: 0 0 $layoutDefaultPadding/2;
+      background-color: $white;
+      border: $dropdownBorderSize solid $grayPrimary;;
+      border-top: none;
+      border-radius: 0 0 16px 16px;
+      left: -$dropdownBorderSize;
+      right: -$dropdownBorderSize;
+      z-index: 1;
     }
 
     &__item-hole {
@@ -78,12 +88,15 @@ $include-html: false !default;
     &--opened {
       background-color: $white;
       border-color: $grayPrimary;
-      height: auto;
+      overflow: visible;
+      border-radius: 16px 16px 0 0;
+      border-bottom-color: transparent;
 
       &:hover,
       &:active {
         background-color: $white;
         border-color: $grayPrimary;
+        border-bottom-color: transparent;
       }
 
       &:before {

--- a/src/components/dropdowns/dropdowns.html
+++ b/src/components/dropdowns/dropdowns.html
@@ -175,7 +175,6 @@
 
 <script>
     $('.js-mint-dropdown').on('click', function () {
-        $('.js-mint-dropdown').removeClass('mint-dropdown--opened');
-        $(this).addClass('mint-dropdown--opened');
+        $(this).toggleClass('mint-dropdown--opened');
     });
 </script>

--- a/src/components/dropdowns/dropdowns.html
+++ b/src/components/dropdowns/dropdowns.html
@@ -83,6 +83,9 @@
                 </div>
             </div>
         </div>
+        <br>
+        <br>
+        <br>
     </div>
 </section>
 

--- a/src/components/dropdowns/dropdowns.html
+++ b/src/components/dropdowns/dropdowns.html
@@ -175,6 +175,7 @@
 
 <script>
     $('.js-mint-dropdown').on('click', function () {
-        $(this).toggleClass('mint-dropdown--opened');
+        $('.js-mint-dropdown').removeClass('mint-dropdown--opened');
+        $(this).addClass('mint-dropdown--opened');
     });
 </script>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/281

<img width="1046" alt="screen shot 2015-09-14 at 14 08 25" src="https://cloud.githubusercontent.com/assets/1231144/9849321/19e938e8-5aea-11e5-8230-ddd6341c1a12.png">

its size is the same like small select:
<img width="361" alt="screen shot 2015-09-14 at 14 23 15" src="https://cloud.githubusercontent.com/assets/1231144/9849549/3d8ce52c-5aec-11e5-9fe9-703c69721309.png">
