### PR TITLE
Build SCSS using gulp instead of jekyll

### DIFF
--- a/scripts/watch.sh
+++ b/scripts/watch.sh
@@ -9,4 +9,4 @@ docker run -t --rm \
   -v $PROJECT_DIR/src:/style-guide/src \
   -v $PROJECT_DIR/dist:/style-guide/dist \
   -v $PROJECT_DIR/gulpfile.js:/style-guide/gulpfile.js \
-  brainly/style-guide node_modules/.bin/gulp watch:docs watch:sass
+  brainly/style-guide node_modules/.bin/gulp watch

--- a/src/docs/_config.yml
+++ b/src/docs/_config.yml
@@ -2,6 +2,8 @@
 title: Brainly Style Guide
 description: Brainly Front-End Style Guide Documentation
 baseurl: "."
+keep_files:
+  - "css/main.css"
 
 # Build settings
 markdown: kramdown

--- a/src/docs/_layouts/default.html
+++ b/src/docs/_layouts/default.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="../style-guide.css">
     <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.11.3/jquery.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.js"></script>
 </head>
 <body>
 {% include navigation.html %}

--- a/src/docs/_sass/main.scss
+++ b/src/docs/_sass/main.scss
@@ -1,4 +1,3 @@
-// these dashes here are needed, so that jekyll knows that it has to process this file
 @charset "utf-8";
 
 @import "../../sass/config"; //style guide variables

--- a/src/docs/_sass/main.scss
+++ b/src/docs/_sass/main.scss
@@ -1,5 +1,3 @@
----
----
 // these dashes here are needed, so that jekyll knows that it has to process this file
 @charset "utf-8";
 


### PR DESCRIPTION
Jekyll has a build-in SCSS compiler, it worked fine but wasn't flexible enough for our needs (no autoprefixer). We decided to reuse the same workflow that we use for building style guide SCSS.

Fixes #287