### PR TITLE
Vertical rhythm

### DIFF
--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -22,7 +22,6 @@ $include-html: false !default;
     height: $avatarMediumSize;
     border-radius: 50%;
     background: $avatarDefaultBackgroundColor;
-    vertical-align: bottom;
 
     &__image {
       position: absolute;

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -22,7 +22,7 @@ $include-html: false !default;
     height: $avatarMediumSize;
     border-radius: 50%;
     background: $avatarDefaultBackgroundColor;
-    vertical-align: inherit;
+    vertical-align: bottom;
 
     &__image {
       position: absolute;

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -14,6 +14,7 @@ $include-html: false !default;
     @include component;
     @include fixText($badgeFontSize);
     min-height: auto;
+    height: auto;
 
     border-radius: $badgeFontSize;
     font-weight: bold;
@@ -27,7 +28,7 @@ $include-html: false !default;
       background-color: $badgeErrorBackgroundColor;
       color: $badgeErrorColor;
     }
-    
+
     &--warning {
       background-color: $badgeWarningBackgroundColor;
       color: $badgeWarningColor;
@@ -50,4 +51,5 @@ $include-html: false !default;
       transform: scale(1);
     }
   }
+
 }

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -1,4 +1,4 @@
-$badgeFontSize: fontSize(tiny);
+$badgeFontSize: fontSize(xsmall);
 $badgeDefaultBackgroundColor: $white;
 $badgeDefaultColor: $black;
 $badgeErrorBackgroundColor: $peachPrimary;

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -13,6 +13,7 @@ $include-html: false !default;
   .mint-badge {
     @include component;
     @include fixText($badgeFontSize);
+    overflow: visible; // allow badges align as text
     min-height: auto;
     height: auto;
 

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -1,4 +1,4 @@
-$badgeFontSize: 10px;
+$badgeFontSize: fontSize(tiny);
 $badgeDefaultBackgroundColor: $white;
 $badgeDefaultColor: $black;
 $badgeErrorBackgroundColor: $peachPrimary;
@@ -6,20 +6,18 @@ $badgeErrorColor: $white;
 $badgeWarningBackgroundColor: $mustardPrimary;
 $badgeWarningColor: $white;
 
-
 $include-html: false !default;
 
 @if ($include-html) {
 
   .mint-badge {
     @include component;
+    @include fixText($badgeFontSize);
 
     overflow: visible;
     border-radius: $badgeFontSize;
-  	line-height: $badgeFontSize;
-  	font-size: $badgeFontSize;
-  	padding: 3px 6px;
     font-weight: bold;
+    padding: 3px 6px;
     text-transform: uppercase;
 
     background-color: $badgeDefaultBackgroundColor;

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -13,8 +13,8 @@ $include-html: false !default;
   .mint-badge {
     @include component;
     @include fixText($badgeFontSize);
+    min-height: auto;
 
-    overflow: visible;
     border-radius: $badgeFontSize;
     font-weight: bold;
     padding: 3px 6px;

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -1,4 +1,3 @@
-$badgeFontFamily: $fontFamilySecondary;
 $badgeFontSize: 10px;
 $badgeDefaultBackgroundColor: $white;
 $badgeDefaultColor: $black;
@@ -6,6 +5,7 @@ $badgeErrorBackgroundColor: $peachPrimary;
 $badgeErrorColor: $white;
 $badgeWarningBackgroundColor: $mustardPrimary;
 $badgeWarningColor: $white;
+
 
 $include-html: false !default;
 
@@ -16,10 +16,10 @@ $include-html: false !default;
 
     overflow: visible;
     border-radius: $badgeFontSize;
-    line-height: $badgeFontSize;
-    font-size: $badgeFontSize;
-    font-family: $badgeFontFamily;
-    padding: 3px 6px;
+  	line-height: $badgeFontSize;
+  	font-size: $badgeFontSize;
+  	padding: 3px 6px;
+    font-weight: bold;
     text-transform: uppercase;
 
     background-color: $badgeDefaultBackgroundColor;
@@ -52,5 +52,4 @@ $include-html: false !default;
       transform: scale(1);
     }
   }
-
 }

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -1,14 +1,19 @@
 $boxBorderColor: $graySecondary;
 $boxBorderRadius: 22px;
+$boxBorderSize: rhythm(1/8);
 
 @if ($include-html) {
 
   .mint-box {
     @include component;
-
+    min-height: rhythm(3);
     border-radius: $boxBorderRadius;
-    padding: $layoutDefaultPadding;
-    border: 2px solid $boxBorderColor;
+    border: $boxBorderSize solid $boxBorderColor;
+    padding: (rhythm(1/2) - $borderSize) 0 (rhythm(1/2) - $borderSize) 1/2 * $layoutDefaultPadding;
+
+    &__hole {
+      margin: rhythm(1/2) 1/2 * $layoutDefaultPadding rhythm(1/2) 0;
+    }
 
     &--full {
       width: 100%;

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -6,6 +6,9 @@ $boxBorderSize: rhythm(1/8);
 
   .mint-box {
     @include component;
+    display: inline-flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
     min-height: rhythm(3);
     border-radius: $boxBorderRadius;
     border: $boxBorderSize solid $boxBorderColor;

--- a/src/components/box/box.html
+++ b/src/components/box/box.html
@@ -4,7 +4,9 @@
     </aside>
     <div class="docs-block__content">
         <div class="mint-box">
-            This is a box.
+            <div class="mint-box__hole">
+                This is a box.
+            </div>
         </div>
     </div>
 </section>
@@ -14,7 +16,9 @@
     </aside>
     <div class="docs-block__content">
         <div class="mint-box mint-box--full">
-            This is a box.
+            <div class="mint-box__hole">
+                This is a box.
+            </div>
         </div>
     </div>
 </section>
@@ -24,16 +28,18 @@
     </aside>
     <div class="docs-block__content">
         <div class="mint-box">
-            <div class="mint-content-box">
-                <div class="mint-content-box__header">
-                    <h3 class="mint-header-secondary">Ask a question about a school subject</h3>
-                </div>
-                <div class="mint-content-box__footer">
-                    <button class="mint-button-primary mint-button-primary--full">
-                        <div class="mint-button-primary__hole">
-                            Ask your question
-                        </div>
-                    </button>
+            <div class="mint-box__hole">
+                <div class="mint-content-box">
+                    <div class="mint-content-box__header">
+                        <h3 class="mint-header-secondary">Ask a question about a school subject</h3>
+                    </div>
+                    <div class="mint-content-box__footer">
+                        <button class="mint-button-primary mint-button-primary--full">
+                            <div class="mint-button-primary__hole">
+                                Ask your question
+                            </div>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/components/bubble/_bubble.scss
+++ b/src/components/bubble/_bubble.scss
@@ -4,9 +4,10 @@ $bubbleBorderColor: $graySecondary;
 $bubbleBorderRadius: 10px;
 $bubbleBoxShadow: $defaultBottomShadow;
 
-$borderSize: 3px;
-$triangleSize: 12px;
-$innerTriangleSize: $triangleSize - 2 * $borderSize + 1;
+$borderSize: rhythm(1/8);
+$triangleSize: rhythm(1/2);
+$innerTriangleSize: rhythm(0.366);     // hand-picked value, checked against basic font-size changes, scales 11px - 30px
+$innerTriangleOffset: rhythm(-0.666);  // hand-picked value, checked against basic font-size changes, scales 11px - 30px
 
 $include-html: false !default;
 
@@ -14,12 +15,17 @@ $include-html: false !default;
 
   .mint-bubble {
     @include component;
+    display: inline-flex;
+    align-items: flex-start;
+    flex-wrap: wrap;
+    min-height: rhythm(3);
     overflow: visible;
     background: $bubbleBackground;
     border: $borderSize solid $bubbleBorderColor;
     border-radius: $bubbleBorderRadius;
-    padding: 15px;
     box-shadow: $bubbleBoxShadow;
+    padding: (rhythm(1/2) - $borderSize) 0 (rhythm(1/2) - $borderSize) 1/2 * $layoutDefaultPadding;
+    margin-bottom: rhythm(1);
 
     &:before {
       content: "";
@@ -38,11 +44,15 @@ $include-html: false !default;
       border: $innerTriangleSize solid transparent;
       border-bottom-color: $bubbleBackground;
       position: absolute;
-      top: -(2 * $innerTriangleSize);
+      top: $innerTriangleOffset;
       right: 0;
       left: 0;
       width: 0;
       margin: 0 auto;
+    }
+
+    &__hole {
+      margin: rhythm(1/2) 1/2 * $layoutDefaultPadding rhythm(1/2) 0;
     }
 
     &--dark {

--- a/src/components/bubble/bubble.html
+++ b/src/components/bubble/bubble.html
@@ -4,7 +4,9 @@
     </aside>
     <div class="docs-block__content">
         <div class="mint-bubble">
-            Bla bla some awesome cool text
+            <div class="mint-bubble__hole">
+                Bla bla some awesome cool text
+            </div>
         </div>
     </div>
 </section>
@@ -14,7 +16,9 @@
     </aside>
     <div class="docs-block__content">
         <div class="mint-bubble mint-bubble--dark">
-            Bla bla some awesome cool text
+            <div class="mint-bubble__hole">
+                Bla bla some awesome cool text
+            </div>
         </div>
     </div>
 </section>
@@ -24,31 +28,61 @@
     </aside>
     <div class="docs-block__content">
         <div class="mint-bubble">
-            <div class="mint-content-box mint-content-box">
-                <div class="mint-content-box__header">
-                    <div class="mint-avatar">
-                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/">
-                    </div>
-                    <ul class="mint-breadcrumb-list">
-                        <li class="mint-breadcrumb-list__element">
-                            <a class="mint-link mint-link--gray" href="#">Katie</a>
-                        </li>
-                        <li class="mint-breadcrumb-list__element">
-                            <a class="mint-link mint-link--gray" href="#">a few seconds ago</a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="mint-content-box__content">
-                    <div class="mint-text-description mint-text-description--small">
-                        Hi there!! Just wondering if you have any problems with your school work. We've got plenty of people who can help you here :) Also, my last question was answered in less than 10 minutes :D Anyway, you can just go ahead and try for yourself.
-                    </div>
-                </div>
-                <div class="mint-content-box__footer">
-                    <button class="mint-button-secondary mint-button-secondary--alt-inverse">
-                        <div class="mint-button-secondary__hole">
-                            Join us!
+            <div class="mint-bubble__hole">
+                Hi there!!
+                <br>
+                Just wondering if you have any problems with your school work.
+                <br>
+                <br>
+                We've got plenty of people who can help you here :)
+                <br>Also, my last question was answered in less than 10 minutes :D
+                <br>Anyway, you can just go ahead and try for yourself.
+            </div>
+        </div>
+
+        <div class="mint-bubble mint-bubble--dark">
+            <div class="mint-bubble__hole">
+                Bla bla some awesome cool text
+                <br>
+                <br>
+                with multiple lines
+            </div>
+            <div class="mint-bubble__hole">
+                Bla bla some awesome cool text
+            </div>
+            <div class="mint-bubble__hole">
+                Bla bla some awesome cool text
+            </div>
+        </div>
+
+        <div class="mint-bubble">
+            <div class="mint-bubble__hole">
+                <div class="mint-content-box mint-content-box">
+                    <div class="mint-content-box__header">
+                        <div class="mint-avatar">
+                            <img class="mint-avatar__image" src="http://lorempixel.com/64/64/">
                         </div>
-                    </button>
+                        <ul class="mint-breadcrumb-list">
+                            <li class="mint-breadcrumb-list__element">
+                                <a class="mint-link mint-link--gray" href="#">Katie</a>
+                            </li>
+                            <li class="mint-breadcrumb-list__element">
+                                <a class="mint-link mint-link--gray" href="#">a few seconds ago</a>
+                            </li>
+                        </ul>
+                    </div>
+                    <div class="mint-content-box__content">
+                        <div class="mint-text-description mint-text-description--small">
+                            Hi there!! Just wondering if you have any problems with your school work. We've got plenty of people who can help you here :) Also, my last question was answered in less than 10 minutes :D Anyway, you can just go ahead and try for yourself.
+                        </div>
+                    </div>
+                    <div class="mint-content-box__footer">
+                        <button class="mint-button-secondary mint-button-secondary--alt-inverse">
+                            <div class="mint-button-secondary__hole">
+                                Join us!
+                            </div>
+                        </button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -48,8 +48,8 @@ $iconAsButtonColor: $bluePrimary;
 $iconAsButtonLightColor: $white;
 $iconAsButtonGrayColor: $grayPrimary;
 
-$buttonRoundAddSize: 3.125rem;
-$buttonRoundAddFontSize: 1.125rem;
+$buttonRoundAddSize: rhythm(2.083);
+$buttonRoundAddFontSize: fontSize(standout);
 $buttonRoundAddColor: $white;
 $buttonRoundLabelFontSize: fontSize(tiny);
 $buttonRoundLabelBackground: $mintSecondaryLight;

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -1,6 +1,6 @@
-$buttonPrimaryHeight: 2.75rem; // 44px;
-$buttonSecondaryHeight: 2rem;
-$buttonSecondarySmallHeight: 1.5rem;
+$buttonPrimaryHeight: rhythm(1 + 5/6);
+$buttonSecondaryHeight: rhythm(1 + 1/3);
+$buttonSecondarySmallHeight: rhythm(1);
 
 $buttonPrimaryFontSize: fontSize(medium);
 $buttonSecondaryFontSize: fontSize(obscure);
@@ -48,7 +48,7 @@ $iconAsButtonColor: $bluePrimary;
 $iconAsButtonLightColor: $white;
 $iconAsButtonGrayColor: $grayPrimary;
 
-$buttonRoundAddSize: rhythm(2.083);
+$buttonRoundAddSize: rhythm(2 + 1/12);
 $buttonRoundAddFontSize: fontSize(standout);
 $buttonRoundAddColor: $white;
 $buttonRoundLabelFontSize: fontSize(tiny);

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -1,9 +1,9 @@
-$buttonPrimaryHeight: 44px;
-$buttonSecondaryHeight: 32px;
-$buttonSecondarySmallHeight: 24px;
+$buttonPrimaryHeight: 2.75rem; // 44px;
+$buttonSecondaryHeight: 2rem;
+$buttonSecondarySmallHeight: 1.5rem;
 
-$buttonPrimaryFontSize: 15px;
-$buttonSecondaryFontSize: 12px;
+$buttonPrimaryFontSize: fontSize(medium);
+$buttonSecondaryFontSize: fontSize(obscure);
 
 $buttonPrimaryFontColor: $white;
 
@@ -48,10 +48,10 @@ $iconAsButtonColor: $bluePrimary;
 $iconAsButtonLightColor: $white;
 $iconAsButtonGrayColor: $grayPrimary;
 
-$buttonRoundAddSize: 50px;
-$buttonRoundAddFontSize: 18px;
+$buttonRoundAddSize: 3.125rem;
+$buttonRoundAddFontSize: 1.125rem;
 $buttonRoundAddColor: $white;
-$buttonRoundLabelFontSize: 10px;
+$buttonRoundLabelFontSize: fontSize(tiny);
 $buttonRoundLabelBackground: $mintSecondaryLight;
 $buttonRoundLabelColor: $black;
 
@@ -141,13 +141,13 @@ $include-html: false !default;
 
 @mixin mint-button-secondary-three-color-variant($bgColor, $textColor, $hoverTextColor) {
   border: 0;
-  padding: 0 $buttonSecondaryHeight /2 + 2px;
+  padding: 0 $buttonSecondaryHeight /2 + 0.125rem;
   @include mint-button-basic-colors($bgColor, $textColor, $bgColor);
   @include mint-button-secondary-active($textColor, $hoverTextColor, $textColor);
 
   &-inverse {
     border: 0;
-    padding: 0 $buttonSecondaryHeight /2 + 2px;
+    padding: 0 $buttonSecondaryHeight /2 + 0.125rem;
     @include mint-button-basic-colors($textColor, $hoverTextColor, $textColor);
     @include mint-button-secondary-active($bgColor, $textColor, $bgColor);
   }
@@ -215,7 +215,7 @@ $include-html: false !default;
       font-weight: bold;
       font-size: $buttonRoundLabelFontSize;
       border-radius: 4px;
-      line-height: 12px;
+      line-height: rhythm(1/2);
       background: $buttonRoundLabelBackground;
       color: $buttonRoundLabelColor;
       text-transform: uppercase;

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -5,9 +5,6 @@ $buttonSecondarySmallHeight: 24px;
 $buttonPrimaryFontSize: 15px;
 $buttonSecondaryFontSize: 12px;
 
-$buttonPrimaryFontFamily: $fontFamilySecondary;
-$buttonSecondaryFontFamily: $fontFamilySecondary;
-
 $buttonPrimaryFontColor: $white;
 
 $buttonColor: $mintPrimary;
@@ -54,8 +51,7 @@ $iconAsButtonGrayColor: $grayPrimary;
 $buttonRoundAddSize: 50px;
 $buttonRoundAddFontSize: 18px;
 $buttonRoundAddColor: $white;
-$buttonRoundLabelFontFamily: $fontFamilySecondary;
-$buttonRoundLabelFontFamily: $fontFamilySecondary;
+
 $buttonRoundLabelFontSize: 10px;
 $buttonRoundLabelBackground: $mintSecondaryLight;
 $buttonRoundLabelColor: $black;
@@ -159,7 +155,7 @@ $include-html: false !default;
 }
 
 @if ($include-html) {
-
+  
   // Primary buttons
   .mint-button-primary {
     @include mint-button-basic-styles();
@@ -218,7 +214,7 @@ $include-html: false !default;
     }
     &__label {
       float: left;
-      font-family: $buttonRoundLabelFontFamily;
+      font-weight: bold;
       font-size: $buttonRoundLabelFontSize;
       border-radius: 4px;
       line-height: 12px;
@@ -244,7 +240,7 @@ $include-html: false !default;
     border-style: solid;
     background-color: transparent;
     font-size: $buttonSecondaryFontSize;
-    font-family: $buttonSecondaryFontFamily;
+    font-weight: bold;
     transition: background-color 0.3s ease-out, color 0.3s ease-out;
     &:hover, &:focus {
       outline: none;
@@ -366,5 +362,4 @@ $include-html: false !default;
       }
     }
   }
-
 }

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -51,7 +51,6 @@ $iconAsButtonGrayColor: $grayPrimary;
 $buttonRoundAddSize: 50px;
 $buttonRoundAddFontSize: 18px;
 $buttonRoundAddColor: $white;
-
 $buttonRoundLabelFontSize: 10px;
 $buttonRoundLabelBackground: $mintSecondaryLight;
 $buttonRoundLabelColor: $black;
@@ -122,7 +121,7 @@ $include-html: false !default;
 @mixin mint-button-primary-three-color-variant($buttonColor, $gradientColor, $buttonShadowColor: null) {
   background-color: $buttonColor;
   background: $gradientColor linear-gradient(170deg, $gradientColor 0%, $gradientColor 50%, $buttonColor 51%, $buttonColor 100%) no-repeat;
-  @if($buttonShadowColor) {
+  @if ($buttonShadowColor) {
     box-shadow: 0 -1px 0 $buttonShadowColor inset;
   }
   &:hover, &:focus {
@@ -155,7 +154,7 @@ $include-html: false !default;
 }
 
 @if ($include-html) {
-  
+
   // Primary buttons
   .mint-button-primary {
     @include mint-button-basic-styles();
@@ -166,7 +165,6 @@ $include-html: false !default;
 
     border: 0;
     font-size: $buttonPrimaryFontSize;
-    font-family: $buttonPrimaryFontFamily;
     @include mint-button-primary-active($buttonPrimaryFontColor);
 
     &--full {

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -360,4 +360,5 @@ $include-html: false !default;
       }
     }
   }
+
 }

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -51,7 +51,7 @@ $iconAsButtonGrayColor: $grayPrimary;
 $buttonRoundAddSize: rhythm(2 + 1/12);
 $buttonRoundAddFontSize: fontSize(standout);
 $buttonRoundAddColor: $white;
-$buttonRoundLabelFontSize: fontSize(tiny);
+$buttonRoundLabelFontSize: fontSize(xsmall);
 $buttonRoundLabelBackground: $mintSecondaryLight;
 $buttonRoundLabelColor: $black;
 

--- a/src/components/content-box/_content-box.scss
+++ b/src/components/content-box/_content-box.scss
@@ -3,24 +3,38 @@ $include-html: false !default;
 @if ($include-html) {
 
   .mint-content-box {
+
+    &__title {
+      min-height: rhythm(2);
+    }
+
+    &__title ~ &__title {
+      min-height: rhythm(1);
+    }
+
     &__header {
-      vertical-align: middle;
-      margin-bottom: 3px;
+      @include components-container;
+      height: rhythm(2);
+    }
+
+    &__title ~ &__header {
+      @include components-container;
+      height: rhythm(1);
     }
 
     &__content {
       word-wrap: break-word;
-      margin-bottom: 12px;
     }
 
     &__footer {
-      vertical-align: middle;
+      @include components-container;
+      min-height: rhythm(2);
     }
 
     &--spaced {
       .mint-content-box__content, .mint-content-box__footer {
         @media (min-width: $breakpointMedium) {
-          padding-left: 48px;
+          padding-left: 2 * $layoutDefaultPadding;
         }
       }
     }

--- a/src/components/content-box/_content-box.scss
+++ b/src/components/content-box/_content-box.scss
@@ -9,7 +9,8 @@ $include-html: false !default;
     }
 
     &__title ~ &__title {
-      min-height: rhythm(1);
+      margin-top: - rhythm(1/2);
+      margin-bottom: - rhythm(1/2);
     }
 
     &__header {
@@ -18,8 +19,8 @@ $include-html: false !default;
     }
 
     &__title ~ &__header {
-      @include components-container;
-      height: rhythm(1);
+      margin-top: - rhythm(1/2);
+      margin-bottom: rhythm(1/2);
     }
 
     &__content {

--- a/src/components/content-box/content-box.html
+++ b/src/components/content-box/content-box.html
@@ -1,10 +1,10 @@
 <section class="docs-block">
     <aside class="docs-block__info">
-        <h3 class="docs-block__header">Simple</h3>
+        <h3 class="docs-block__header">Simple with header</h3>
     </aside>
     <div class="docs-block__content">
         <div class="mint-content-box">
-            <div class="mint-content-box__header">
+            <div class="mint-content-box__title">
                 <ul class="mint-breadcrumb-list mint-breadcrumb-list--alt">
                     <li class="mint-breadcrumb-list__element">
                         <a class="mint-link mint-link--gray mint-link--emphasised" href="#">Math</a>
@@ -29,6 +29,197 @@
                 </div>
             </div>
             <div class="mint-content-box__footer">
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="docs-block">
+    <aside class="docs-block__info">
+        <h3 class="docs-block__header">Simple with title</h3>
+    </aside>
+    <div class="docs-block__content">
+        <div class="mint-content-box">
+            <div class="mint-content-box__title">
+                <h2 class="mint-header-secondary">This is a title for context box</h2>
+            </div>
+            <div class="mint-content-box__content">
+                <div class="mint-text-description">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel dui porttitor, tincidunt
+                    lorem quis, gravida ex. Phasellus semper orci nulla, sit amet egestas orci mattis sit amet.
+                    Aenean laoreet, dolor ac aliquet porta, velit libero euismod purus, quis dignissim ante sem
+                    vel eros.
+                </div>
+            </div>
+            <div class="mint-content-box__footer">
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="docs-block">
+    <aside class="docs-block__info">
+        <h3 class="docs-block__header">Simple with wrapped title</h3>
+    </aside>
+    <div class="docs-block__content">
+        <div class="mint-content-box">
+            <div class="mint-content-box__title">
+                <h2 class="mint-header-secondary">This is a title for context box<br>It has 2 lines to show title wrapping</h2>
+            </div>
+            <div class="mint-content-box__content">
+                <div class="mint-text-description">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel dui porttitor, tincidunt
+                    lorem quis, gravida ex. Phasellus semper orci nulla, sit amet egestas orci mattis sit amet.
+                    Aenean laoreet, dolor ac aliquet porta, velit libero euismod purus, quis dignissim ante sem
+                    vel eros.
+                </div>
+            </div>
+            <div class="mint-content-box__footer">
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="docs-block">
+    <aside class="docs-block__info">
+        <h3 class="docs-block__header">Simple with wrapped title and header</h3>
+    </aside>
+    <div class="docs-block__content">
+        <div class="mint-content-box">
+            <div class="mint-content-box__title">
+                <h2 class="mint-header-secondary">This is a title for context box<br>It has 2 lines to show title wrapping</h2>
+            </div>
+            <div class="mint-content-box__header">
+                <div class="mint-avatar">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <ul class="mint-breadcrumb-list mint-breadcrumb-list--alt">
+                    <li class="mint-breadcrumb-list__element">
+                        <span class="mint-link mint-link--gray">The Brain</span>
+                    </li>
+                    <li class="mint-breadcrumb-list__element">
+                        <span class="mint-link mint-link--gray">Answerer</span>
+                    </li>
+                </ul>
+            </div>
+            <div class="mint-content-box__content">
+                <div class="mint-text-description">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel dui porttitor, tincidunt
+                    lorem quis, gravida ex. Phasellus semper orci nulla, sit amet egestas orci mattis sit amet.
+                    Aenean laoreet, dolor ac aliquet porta, velit libero euismod purus, quis dignissim ante sem
+                    vel eros.
+                </div>
+            </div>
+            <div class="mint-content-box__footer">
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
                 <div class="mint-overlayed-box">
                     <div class="mint-avatar">
                         <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>

--- a/src/components/content-box/content-box.html
+++ b/src/components/content-box/content-box.html
@@ -127,6 +127,124 @@
 </section>
 <section class="docs-block">
     <aside class="docs-block__info">
+        <h3 class="docs-block__header">Simple with two titles</h3>
+    </aside>
+    <div class="docs-block__content">
+        <div class="mint-content-box">
+            <div class="mint-content-box__title">
+                <h2 class="mint-header-secondary">This is a title for context box<br>It has 2 lines to show title wrapping</h2>
+            </div>
+            <div class="mint-content-box__title">
+                <ul class="mint-breadcrumb-list mint-breadcrumb-list--alt">
+                    <li class="mint-breadcrumb-list__element">
+                        <a class="mint-link mint-link--gray mint-link--emphasised" href="#">Math</a>
+                    </li>
+                    <li class="mint-breadcrumb-list__element">
+                        <a class="mint-link mint-link--gray mint-link--emphasised" href="#">10 pts</a>
+                    </li>
+                    <li class="mint-breadcrumb-list__element">
+                        <a class="mint-link mint-link--gray" href="#">2 min ago</a>
+                    </li>
+                    <li class="mint-breadcrumb-list__element">
+                        <div class="mint-badge mint-badge--warning">hot</div>
+                    </li>
+                </ul>
+            </div>
+            <div class="mint-content-box__content">
+                <div class="mint-text-description">
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel dui porttitor, tincidunt
+                    lorem quis, gravida ex. Phasellus semper orci nulla, sit amet egestas orci mattis sit amet.
+                    Aenean laoreet, dolor ac aliquet porta, velit libero euismod purus, quis dignissim ante sem
+                    vel eros.
+                </div>
+            </div>
+            <div class="mint-content-box__footer">
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+                <div class="mint-overlayed-box">
+                    <div class="mint-avatar">
+                        <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                    </div>
+                    <div class="mint-overlayed-box__overlay">
+                        <div class="mint-sticker mint-sticker--answering"></div>
+                    </div>
+                </div>
+                <div class="mint-separator"></div>
+                <div class="mint-avatar mint-avatar--small">
+                    <img class="mint-avatar__image" src="http://lorempixel.com/64/64/"/>
+                </div>
+                <div class="mint-avatar mint-avatar--small"></div>
+                <button class="mint-button-secondary mint-button-secondary--small mint-button-secondary--alt">
+                    <div class="mint-button-secondary__hole">Answer</div>
+                </button>
+            </div>
+        </div>
+    </div>
+</section>
+<section class="docs-block">
+    <aside class="docs-block__info">
         <h3 class="docs-block__header">Simple with wrapped title and header</h3>
     </aside>
     <div class="docs-block__content">

--- a/src/components/dropdowns/_dropdowns.scss
+++ b/src/components/dropdowns/_dropdowns.scss
@@ -1,7 +1,6 @@
-// your components variables
-$dropdownFontSize: 12px;
-$dropdownHeight: 32px;
-$dropdownBorderSize: 2px;
+$dropdownFontSize: fontSize(obscure);
+$dropdownHeight: rhythm(1.5);
+$dropdownBorderSize: rhythm(1/12);
 $dropdownBackground: $white;
 $dropdownHoverColor: $graySecondary;
 $dropdownBorderColor: $grayAltLight;
@@ -21,7 +20,7 @@ $include-html: false !default;
     border-radius: $dropdownHeight / 2;
     min-height: $dropdownHeight;
     height: $dropdownHeight;
-    cursor: pointer;
+    cursor: pointer;    
     user-select: none;
     z-index: 1;
 
@@ -36,7 +35,7 @@ $include-html: false !default;
       font-size: $iconSize;
       font-weight: bold;
       position: absolute;
-      top: $dropdownHeight/4 - 2;
+      top: $dropdownHeight/4;
       right: $dropdownHeight / 2 - $iconSize / 2;
       color: $grayAlt;
       z-index: 2;

--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -16,15 +16,15 @@ $include-html: false !default;
         margin-left: auto;
         margin-right: auto;
 
-        padding: 40px $layoutDefaultPadding;
+        padding: rhythm(1) $layoutDefaultPadding;
       }
     }
 
     &__line {
-      margin-bottom: 10px;
+      margin-bottom: rhythm(1);
 
       @media (min-width: $breakpointMedium) {
-        margin-bottom: 15px;
+        margin-bottom: rhythm(1);
       }
 
       &:last-child {

--- a/src/components/footer/footer.html
+++ b/src/components/footer/footer.html
@@ -65,40 +65,50 @@
                 <div class="mint-footer__line">
                     <ul class="mint-breadcrumb-list mint-breadcrumb-list--for-fine-print">
                         <li class="mint-breadcrumb-list__element">
-                            United States:
-                            <a class="mint-link mint-link--for-fine-print-light" href="#"
-                               target="_blank">
-                                brainly.com
-                            </a>
+                            <span class="mint-text--emphasised">
+                                United States:
+                                <a class="mint-link mint-link--for-fine-print-light" href="#"
+                                   target="_blank">
+                                    brainly.com
+                                </a>
+                            </span>
                         </li>
                         <li class="mint-breadcrumb-list__element">
-                            Poland:
-                            <a class="mint-link mint-link--for-fine-print-light" href="#"
-                               target="_blank">
-                                zadane.pl
-                            </a>
+                            <span class="mint-text--emphasised">
+                                Poland:
+                                <a class="mint-link mint-link--for-fine-print-light" href="#"
+                                   target="_blank">
+                                    zadane.pl
+                                </a>
+                            </span>
                         </li>
                         <li class="mint-breadcrumb-list__element">
-                            Russia/Ukraine:
-                            <a class="mint-link mint-link--for-fine-print-light" href="#"
-                               target="_blank">
-                                znanija.com
-                            </a>
+                            <span class="mint-text--emphasised">
+                                Russia/Ukraine:
+                                <a class="mint-link mint-link--for-fine-print-light" href="#"
+                                   target="_blank">
+                                    znanija.com
+                                </a>
+                            </span>
                         </li>
                         <li class="mint-breadcrumb-list__element">
-                            Spain:
-                            <a class="mint-link mint-link--for-fine-print-light" href="#"
-                               target="_blank">
-                                misdeberes.es
-                            </a>
+                            <span class="mint-text--emphasised">
+                                Spain:
+                                <a class="mint-link mint-link--for-fine-print-light" href="#"
+                                   target="_blank">
+                                    misdeberes.es
+                                </a>
+                            </span>
                         </li>
                     </ul>
                 </div>
                 <div class="mint-footer__line">
-                    Strona korzysta z plików cookie w celu realizacji usług zgodnie z <a href="#"
-                                                                                         class="mint-link mint-link--for-fine-print-light">
-                    polityką cookie </a>. Możesz określić warunki przechowywania lub dostępu do cookie w Twojej
-                    przeglądarce.
+                    <span class="mint-text mint-text--obscure mint-text--for-fine-print mint-text--emphasised">
+                        Strona korzysta z plików cookie w celu realizacji usług zgodnie z
+                        <a href="#" class="mint-link mint-link--for-fine-print-light"> polityką cookie </a>.
+                        Możesz określić warunki przechowywania lub dostępu do cookie w Twojej
+                        przeglądarce.
+                    </span>
                 </div>
                 <div class="mint-footer__logo mint-hide-for-medium-up">
                     <div class="mint-logo mint-logo--small"></div>

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -47,7 +47,8 @@ $textareaPadding: 11px;
 $textareaSmallPadding: 6px;
 $textareaFocusBorderColor: $grayPrimary;
 $textareaPlaceholderTextColor: $grayPrimary;
-$textareaPlaceholderFontSize: fontSize(obscure);
+$textareaPlaceholderFontSize: 12px;
+$textareaPlaceholderFontFamily: $fontFamilySecondary;
 $textareaValidBorderColor: $mintSecondary;
 $textareaInvalidBorderColor: $peachSecondary;
 
@@ -360,4 +361,5 @@ $include-html: false !default;
       height: 178px;
     }
   }
+
 }

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -112,8 +112,10 @@ $include-html: false !default;
     &--full {
       width: 100%;
     }
+
     &--invalid {
       border: 2px solid $selectInvalidBorderColor;
+
       .mint-select__element {
         padding: 0 $selectHeight/2+12px 0 ($selectHeight/2 - 2px);
       }
@@ -137,36 +139,45 @@ $include-html: false !default;
       outline: none;
       border-color: $inputFocusBorderColor;
     }
+
     &::placeholder {
       color: $inputPlaceholderTextColor;
       text-transform: uppercase;
       font-size: $inputPlaceholderFontSize;
       font-weight: bold;
     }
+
     &--low {
       border-radius: $inputLowHeight/2;
       padding: 0 $inputLowHeight/2;
       height: $inputLowHeight;
       line-height: $inputLowHeight;
     }
+
     &--valid {
       border-color: $inputValidBorderColor;
+      
       &:focus {
         border-color: $inputFocusValidBorderColor;
       }
     }
+
     &--invalid {
       border-color: $inputInvalidBorderColor;
+
       &:focus {
-        border-color: $inputFocusInvalidBorderColor;
+        border-color: $inputInvalidBorderColor;
       }
     }
+
     &--spaced {
       margin-bottom: $inputHeight/4;
     }
+
     &--full {
       width: 100%;
     }
+    
     &--large {
       @media (min-width: $breakpointMedium) {
         height: $inputLargeHeight;
@@ -179,6 +190,7 @@ $include-html: false !default;
         }
       }
     }
+    
     &--subtle-border {
       border: none;
       box-shadow: 0 0 10px rgba(0,0,0,0.2);
@@ -188,6 +200,7 @@ $include-html: false !default;
         box-shadow: 0 0 10px rgba(0,0,0,0.4);
       }
     }
+
     &--transparent-border {
       border-color: $inputTransparentBorderColor;
       background-clip: padding-box;
@@ -211,6 +224,7 @@ $include-html: false !default;
     width: $crInputSize;
     height: $crInputSize;
     font-size: $crInputFontSize;
+
     &__element {
       opacity: 0;
       position: absolute;
@@ -219,13 +233,16 @@ $include-html: false !default;
       height: 100%;
       z-index: 1;
     }
+
     &__element:active + &__ghost {
       border-color: $crInputActiveBorderColor;
     }
+
     &__element:checked + &__ghost {
       border-color: $crInputCheckedColor;
       background: $crInputCheckedColor;
     }
+
     &__ghost {
       background: $crInputColor;
       width: 100%;
@@ -259,6 +276,7 @@ $include-html: false !default;
   .mint-checkbox__ghost {
     @extend .mint-icon-check;
     border-radius: 25%;
+
     &:before {
       font-size: 137.5%;
       position: absolute;
@@ -270,6 +288,7 @@ $include-html: false !default;
 
   .mint-radio__ghost {
     border-radius: 50%;
+
     &:before {
       content: '';
       position: absolute;
@@ -300,31 +319,37 @@ $include-html: false !default;
       border-color: $textareaFocusBorderColor;
       outline: 0;
     }
+
     &::placeholder {
       color: $textareaPlaceholderTextColor;
       text-transform: uppercase;
       font-size: $textareaPlaceholderFontSize;
       font-weight: bold;
     }
+
     &--full {
       width: 100%;
     }
+
     &--valid {
       border-color: $textareaValidBorderColor;
       &:focus {
         border-color: $textareaValidBorderColor;
       }
     }
+
     &--invalid {
       border-color: $textareaInvalidBorderColor;
       &:focus {
         border-color: $textareaInvalidBorderColor;
       }
     }
+
     &--small {
       height: 36px;
       padding: $textareaSmallPadding $textareaPadding;
     }
+
     &--big {
       height: 178px;
     }

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -2,7 +2,6 @@ $selectBackground: $grayAltLight;
 $selectTextColor: $grayAlt;
 $selectFontSize: 12px;
 $selectHeight: 44px;
-$selectFontFamily: $fontFamilySecondary;
 $selectHoverBackground: $graySecondary;
 $selectInvalidBorderColor: $peachSecondary;
 
@@ -13,13 +12,11 @@ $inputBackground: $white;
 $inputBorderColor: $graySecondary;
 $inputTextColor: $black;
 $inputFontSize: 15px;
-$inputLargeFontSize: 19px;
-$inputFontFamily: $fontFamilyPrimary;
+$inputLargeFontSize: fontSize(outstanding);
 $inputFocusBorderColor: $grayPrimary;
 $inputPlaceholderTextColor: $grayPrimary;
 $inputPlaceholderFontSize: 12px;
-$inputLargePlaceholderFontSize: 15px;
-$inputPlaceholderFontFamily: $fontFamilySecondary;
+$inputLargePlaceholderFontSize: fontSize(medium);
 $inputValidBorderColor: $mintSecondary;
 $inputFocusValidBorderColor: $mintPrimary;
 $inputInvalidBorderColor: $peachSecondary;
@@ -35,7 +32,6 @@ $crInputHoverBorderColor: $blueSecondaryLight;
 $crInputActiveBorderColor: $bluePrimary;
 $crInputCheckedColor: $bluePrimary;
 
-$crInputLabelFontFamily: $fontFamilySecondary;
 $crInputLabelFontSize: 12px;
 $crInputLabelLineHeight: 18px;
 $crInputLabelHeight: 16px;
@@ -45,7 +41,6 @@ $textareaBackground: $white;
 $textareaBorderColor: $graySecondary;
 $textareaBorderRadius: 11px;
 $textareaFontSize: 15px;
-$textareaFontFamily: $fontFamilyPrimary;
 $textareaLineHeight: 19px;
 $textareaTextColor: $black;
 $textareaPadding: 11px;
@@ -53,10 +48,8 @@ $textareaSmallPadding: 6px;
 $textareaFocusBorderColor: $grayPrimary;
 $textareaPlaceholderTextColor: $grayPrimary;
 $textareaPlaceholderFontSize: 12px;
-$textareaPlaceholderFontFamily: $fontFamilySecondary;
 $textareaValidBorderColor: $mintSecondary;
 $textareaInvalidBorderColor: $peachSecondary;
-
 
 $include-html: false !default;
 
@@ -73,7 +66,6 @@ $include-html: false !default;
       background: $selectBackground;
       border: 0;
       font-size: inherit;
-      font-family: $selectFontFamily;
       font-weight: bold;
       color: inherit;
       display: inline-block;
@@ -135,8 +127,6 @@ $include-html: false !default;
     border-radius: $inputHeight/2;
     color: $inputTextColor;
     font-size: $inputFontSize;
-    font-family: $inputFontFamily;
-    font-weight: normal;
     padding: 0 $inputHeight/2;
     height: $inputHeight;
     line-height: $inputHeight;
@@ -150,7 +140,6 @@ $include-html: false !default;
     &::placeholder {
       color: $inputPlaceholderTextColor;
       text-transform: uppercase;
-      font-family: $inputPlaceholderFontFamily;
       font-size: $inputPlaceholderFontSize;
       font-weight: bold;
     }
@@ -249,7 +238,7 @@ $include-html: false !default;
   .mint-checkbox-label,
   .mint-radio-label {
     @include component;
-    font-family: $crInputLabelFontFamily;
+    font-weight: bold;
     font-size: $crInputLabelFontSize;
     line-height: $crInputLabelLineHeight;
     height: $crInputLabelHeight;
@@ -300,8 +289,6 @@ $include-html: false !default;
     border-radius: $textareaBorderRadius;
     color: $textareaTextColor;
     font-size: $textareaFontSize;
-    font-family: $textareaFontFamily;
-    font-weight: normal;
     line-height: $textareaLineHeight;
     padding: $textareaPadding;
     resize: none;
@@ -316,7 +303,6 @@ $include-html: false !default;
     &::placeholder {
       color: $textareaPlaceholderTextColor;
       text-transform: uppercase;
-      font-family: $textareaPlaceholderFontFamily;
       font-size: $textareaPlaceholderFontSize;
       font-weight: bold;
     }
@@ -343,5 +329,4 @@ $include-html: false !default;
       height: 178px;
     }
   }
-
 }

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -1,21 +1,21 @@
 $selectBackground: $grayAltLight;
 $selectTextColor: $grayAlt;
-$selectFontSize: 12px;
-$selectHeight: 44px;
+$selectFontSize: fontSize(obscure);
+$selectHeight: rhythm(1.833);
 $selectHoverBackground: $graySecondary;
 $selectInvalidBorderColor: $peachSecondary;
 
-$inputHeight: 44px;
-$inputLowHeight: 36px;
-$inputLargeHeight: 64px;
+$inputHeight: rhythm(1.833);
+$inputLowHeight: rhythm(1.5);
+$inputLargeHeight: rhythm(2.666);
 $inputBackground: $white;
 $inputBorderColor: $graySecondary;
 $inputTextColor: $black;
-$inputFontSize: 15px;
-$inputLargeFontSize: fontSize(outstanding);
+$inputFontSize: fontSize(medium);
+$inputLargeFontSize: fontSize(standout);
 $inputFocusBorderColor: $grayPrimary;
 $inputPlaceholderTextColor: $grayPrimary;
-$inputPlaceholderFontSize: 12px;
+$inputPlaceholderFontSize: fontSize(obscure);
 $inputLargePlaceholderFontSize: fontSize(medium);
 $inputValidBorderColor: $mintSecondary;
 $inputFocusValidBorderColor: $mintPrimary;
@@ -24,30 +24,30 @@ $inputFocusInvalidBorderColor: $peachPrimary;
 $inputTransparentBorderColor: rgba($graySecondary, 0.7);
 $inputTransparentFocusBorderColor: rgba($grayPrimary, 0.7);
 
-$crInputSize: 16px;
-$crInputFontSize: 16px;
+$crInputSize: fontSize(default);
+$crInputFontSize: fontSize(default);
 $crInputColor: $white;
 $crInputBorderColor: $graySecondary;
 $crInputHoverBorderColor: $blueSecondaryLight;
 $crInputActiveBorderColor: $bluePrimary;
 $crInputCheckedColor: $bluePrimary;
 
-$crInputLabelFontSize: 12px;
-$crInputLabelLineHeight: 18px;
-$crInputLabelHeight: 16px;
+$crInputLabelFontSize: fontSize(obscure);
+$crInputLabelLineHeight: rhythm(0.9);
+$crInputLabelHeight: rhythm(0.666);
 $crInputLabelColor: $grayPrimary;
 
 $textareaBackground: $white;
 $textareaBorderColor: $graySecondary;
 $textareaBorderRadius: 11px;
-$textareaFontSize: 15px;
-$textareaLineHeight: 19px;
+$textareaFontSize: fontSize(default);
+$textareaLineHeight: rhythm(0.792);
 $textareaTextColor: $black;
 $textareaPadding: 11px;
 $textareaSmallPadding: 6px;
 $textareaFocusBorderColor: $grayPrimary;
 $textareaPlaceholderTextColor: $grayPrimary;
-$textareaPlaceholderFontSize: 12px;
+$textareaPlaceholderFontSize: fontSize(obscure);
 $textareaValidBorderColor: $mintSecondary;
 $textareaInvalidBorderColor: $peachSecondary;
 
@@ -62,6 +62,7 @@ $include-html: false !default;
     font-size: $selectFontSize;
     color: $selectTextColor;
     height: $selectHeight;
+
     &__element {
       background: $selectBackground;
       border: 0;
@@ -71,18 +72,21 @@ $include-html: false !default;
       display: inline-block;
       height: $selectHeight;
       position: relative;
-      padding: 0 $selectHeight/2+14px 0 $selectHeight/2;
+      padding: 0 $selectHeight/2 + rhythm(0.56) 0 $selectHeight/2;
       outline: 0;
       appearance: none;
       text-transform: uppercase;
       width: 100%;
+
       &::-ms-expand {
         display: none;
       }
+
       &:hover, &:focus, &:active {
         background: $selectHoverBackground;
       }
     }
+
     &:before {
       $iconSize: $selectFontSize + $iconBoostValue;
       font-size: $iconSize;
@@ -117,7 +121,7 @@ $include-html: false !default;
       border: 2px solid $selectInvalidBorderColor;
 
       .mint-select__element {
-        padding: 0 $selectHeight/2+12px 0 ($selectHeight/2 - 2px);
+        padding: 0 $selectHeight/2 rhythm(0.5) 0 ($selectHeight/2 - rhythm(1/12));
       }
     }
   }
@@ -131,7 +135,6 @@ $include-html: false !default;
     font-size: $inputFontSize;
     padding: 0 $inputHeight/2;
     height: $inputHeight;
-    line-height: $inputHeight;
     appearance: none;
     transition: border 300ms;
 
@@ -221,8 +224,10 @@ $include-html: false !default;
   .mint-checkbox,
   .mint-radio {
     @include component;
+    overflow: visible;
     width: $crInputSize;
     height: $crInputSize;
+    min-height: $crInputSize;
     font-size: $crInputFontSize;
 
     &__element {
@@ -255,6 +260,7 @@ $include-html: false !default;
   .mint-checkbox-label,
   .mint-radio-label {
     @include component;
+    overflow: visible;
     font-weight: bold;
     font-size: $crInputLabelFontSize;
     line-height: $crInputLabelLineHeight;
@@ -278,10 +284,10 @@ $include-html: false !default;
     border-radius: 25%;
 
     &:before {
-      font-size: 137.5%;
+      font-size: 1.375rem;
       position: absolute;
-      left: -18.75%;
-      top: -18.75%;
+      left: -18%;
+      top: -8%;
       color: $crInputColor;
     }
   }
@@ -296,7 +302,7 @@ $include-html: false !default;
       background-color: $crInputColor;
       width: 50%;
       height: 50%;
-      top: 25%;
+      top: 35%;
       left: 25%;
     }
   }

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -170,7 +170,7 @@ $include-html: false !default;
       border-color: $inputInvalidBorderColor;
 
       &:focus {
-        border-color: $inputInvalidBorderColor;
+        border-color: $inputFocusInvalidBorderColor;
       }
     }
 

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -13,6 +13,7 @@ $inputBorderColor: $graySecondary;
 $inputTextColor: $black;
 $inputFontSize: fontSize(medium);
 $inputLargeFontSize: fontSize(standout);
+$inputLargePlaceholderFontSize: fontSize(medium);
 $inputFocusBorderColor: $grayPrimary;
 $inputPlaceholderTextColor: $grayPrimary;
 $inputPlaceholderFontSize: fontSize(obscure);
@@ -48,7 +49,6 @@ $textareaSmallPadding: 6px;
 $textareaFocusBorderColor: $grayPrimary;
 $textareaPlaceholderTextColor: $grayPrimary;
 $textareaPlaceholderFontSize: fontSize(obscure);
-$textareaPlaceholderFontFamily: $fontFamilySecondary;
 $textareaValidBorderColor: $mintSecondary;
 $textareaInvalidBorderColor: $peachSecondary;
 

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -47,7 +47,7 @@ $textareaPadding: 11px;
 $textareaSmallPadding: 6px;
 $textareaFocusBorderColor: $grayPrimary;
 $textareaPlaceholderTextColor: $grayPrimary;
-$textareaPlaceholderFontSize: 12px;
+$textareaPlaceholderFontSize: fontSize(obscure);
 $textareaPlaceholderFontFamily: $fontFamilySecondary;
 $textareaValidBorderColor: $mintSecondary;
 $textareaInvalidBorderColor: $peachSecondary;

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -33,7 +33,7 @@ $crInputActiveBorderColor: $bluePrimary;
 $crInputCheckedColor: $bluePrimary;
 
 $crInputLabelFontSize: fontSize(obscure);
-$crInputLabelLineHeight: rhythm(0.9);
+$crInputLabelLineHeight: rhythm(0.933);
 $crInputLabelHeight: rhythm(0.666);
 $crInputLabelColor: $grayPrimary;
 

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -1,13 +1,13 @@
 $selectBackground: $grayAltLight;
 $selectTextColor: $grayAlt;
 $selectFontSize: fontSize(obscure);
-$selectHeight: rhythm(1.833);
+$selectHeight: rhythm(1 + 5/6);
 $selectHoverBackground: $graySecondary;
 $selectInvalidBorderColor: $peachSecondary;
 
-$inputHeight: rhythm(1.833);
+$inputHeight: rhythm(1 + 5/6);
 $inputLowHeight: rhythm(1.5);
-$inputLargeHeight: rhythm(2.666);
+$inputLargeHeight: rhythm(2 + 2/3);
 $inputBackground: $white;
 $inputBorderColor: $graySecondary;
 $inputTextColor: $black;
@@ -73,7 +73,7 @@ $include-html: false !default;
       display: inline-block;
       height: $selectHeight;
       position: relative;
-      padding: 0 $selectHeight/2 + rhythm(0.56) 0 $selectHeight/2;
+      padding: 0 $selectHeight/2 + rhythm(1/2) 0 $selectHeight/2;
       outline: 0;
       appearance: none;
       text-transform: uppercase;

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -122,7 +122,7 @@ $include-html: false !default;
       border: 2px solid $selectInvalidBorderColor;
 
       .mint-select__element {
-        padding: 0 $selectHeight/2 rhythm(0.5) 0 ($selectHeight/2 - rhythm(1/12));
+        padding: 0 $selectHeight/2 rhythm(1/2) 0 ($selectHeight/2 - rhythm(1/12));
       }
     }
   }

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -6,7 +6,6 @@ $labelFontSizePrimary: fontSize(obscure);
 $labelFontSizeSecondary: fontSize(tiny);
 $labelIconSizePrimary: 16px;
 $labelIconSizeSecondary: 14px;
-$labelHeight: $defaultComponentHeight;
 $labelScaleFactor: 2/3;
 
 $include-html: false !default;
@@ -25,7 +24,6 @@ $include-html: false !default;
     overflow: visible;
     display: flex;
     align-items: center;
-    min-height: $labelHeight;
 
     &__text, &__number {
       @include fixText($labelFontSizePrimary, 2/16);
@@ -43,7 +41,7 @@ $include-html: false !default;
 
     &__text {
       margin-right: $layoutDefaultPadding/2;
-      overflow: hidden; /
+      overflow: hidden;
     }
 
     &__icon {
@@ -118,8 +116,6 @@ $include-html: false !default;
     }
 
     &--small {
-      min-height: $labelScaleFactor * $labelHeight;
-
       .mint-label__text, .mint-label__number {
         @include fixText($labelFontSizeSecondary);
         margin-right: $labelScaleFactor * $layoutDefaultPadding/4;

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -1,7 +1,7 @@
 $labelPrimaryColor: $black;
 $labelSecondaryColor: $grayPrimary;
 $labelInactiveColor: $grayAlt;
-$labelFont: $fontFamilySecondary;
+$labelFontWeight: $fontWeightBlack;
 $labelFontSizePrimary: 12px;
 $labelFontSizeSecondary: 10px;
 $labelIconSizePrimary: 16px;
@@ -32,7 +32,7 @@ $include-html: false !default;
       display: block;
       vertical-align: middle;
       color: $labelPrimaryColor;
-      font-family: $labelFont;
+      font-weight: $labelFontWeight;
       text-transform: uppercase;
       margin-right: $layoutDefaultPadding/4;
 
@@ -43,7 +43,7 @@ $include-html: false !default;
 
     &__text {
       margin-right: $layoutDefaultPadding/2;
-      overflow: hidden;
+      overflow: hidden; /
     }
 
     &__icon {
@@ -139,6 +139,5 @@ $include-html: false !default;
       }
     }
   }
-
+  
 }
-

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -2,8 +2,8 @@ $labelPrimaryColor: $black;
 $labelSecondaryColor: $grayPrimary;
 $labelInactiveColor: $grayAlt;
 $labelFontWeight: $fontWeightBlack;
-$labelFontSizePrimary: 12px;
-$labelFontSizeSecondary: 10px;
+$labelFontSizePrimary: fontSize(obscure);
+$labelFontSizeSecondary: fontSize(tiny);
 $labelIconSizePrimary: 16px;
 $labelIconSizeSecondary: 14px;
 $labelHeight: $defaultComponentHeight;
@@ -28,7 +28,7 @@ $include-html: false !default;
     min-height: $labelHeight;
 
     &__text, &__number {
-      @include fixText($labelFontSizePrimary, 2px);
+      @include fixText($labelFontSizePrimary, 2/16);
       display: block;
       vertical-align: middle;
       color: $labelPrimaryColor;

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -11,7 +11,7 @@ $labelScaleFactor: 2/3;
 
 $include-html: false !default;
 
-@mixin label-from-icon($name){
+@mixin label-from-icon($name) {
   &--#{$name}:before {
     @extend .mint-icon-#{$name}:before;
     display: block;
@@ -139,5 +139,5 @@ $include-html: false !default;
       }
     }
   }
-  
+
 }

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -11,7 +11,7 @@ $labelScaleFactor: 2/3;
 
 $include-html: false !default;
 
-@mixin label-from-icon($name) {
+@mixin label-from-icon($name){
   &--#{$name}:before {
     @extend .mint-icon-#{$name}:before;
     display: block;

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -3,7 +3,7 @@ $labelSecondaryColor: $grayPrimary;
 $labelInactiveColor: $grayAlt;
 $labelFontWeight: $fontWeightBlack;
 $labelFontSizePrimary: fontSize(obscure);
-$labelFontSizeSecondary: fontSize(tiny);
+$labelFontSizeSecondary: fontSize(xsmall);
 $labelIconSizePrimary: 16px;
 $labelIconSizeSecondary: 14px;
 $labelScaleFactor: 2/3;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -111,7 +111,7 @@ $include-html: false !default;
       display: inline-block;
 
       &:after {
-        content: '•';
+        content: '·';
         display: inline-block;
         color: $breadcrumbListSeparatorColor;
         padding: 0 2px;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -23,7 +23,7 @@ $include-html: false !default;
 
   .mint-list {
     @include mint-list-basic-styles();
-    line-height: 2*$baseline;
+    line-height: rhythm(2);
 
     .mint-list__element {
       @extend .mint-icon-arrow_down;
@@ -48,7 +48,7 @@ $include-html: false !default;
     }
 
     &--small {
-      line-height: $baseline;
+      line-height: rhythm(1);
       .mint-list__element {
         &:before {
           font-size: 24px;
@@ -70,8 +70,8 @@ $include-html: false !default;
     @include mint-list-basic-styles();
     &__element {
       box-sizing: border-box;
-      height: 2 * $baseline;
-      line-height: 2 * $baseline;
+      height: rhythm(2);
+      line-height: rhythm(2);
       border-bottom: 1px dashed $menuListBorderColor;
 
       &:last-child {

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,6 +1,3 @@
-$listDefaultFont: $fontFamilyPrimary;
-
-$breadcrumbListFontFamily: $fontFamilySecondary;
 $breadcrumbListFontSize: 13px;
 $breadcrumbListSeparatorColor: $grayPrimary;
 $breadcrumbListBlueSeparatorColor: $blueSecondary;
@@ -9,7 +6,6 @@ $breadcrumbListLightBlueSeparatorColor: $blueSecondaryLight;
 $menuListColor: $bluePrimary;
 $menuListFontSize: 13px;
 $menuListBorderColor: $graySecondary;
-$listSmallFontFamily: $fontFamilySecondary;
 $listSmallIconColor: $graySecondary;
 
 $include-html: false !default;
@@ -26,7 +22,6 @@ $include-html: false !default;
 
   .mint-list {
     @include mint-list-basic-styles();
-    font-family: $listDefaultFont;
     font-size: 24px;
     line-height: 44px;
 
@@ -55,7 +50,6 @@ $include-html: false !default;
     &--small {
       font-size: 15px;
       line-height: 30px;
-      font-family: $listSmallFontFamily;
 
       .mint-list__element {
         &:before {
@@ -76,7 +70,6 @@ $include-html: false !default;
 
   .mint-menu-list {
     @include mint-list-basic-styles();
-    font-family: $listDefaultFont;
     &__element {
       height: 35px;
       line-height: 35px;
@@ -109,11 +102,10 @@ $include-html: false !default;
     @include mint-list-basic-styles();
     display: inline-block;
     vertical-align: inherit;
-    font-family: $breadcrumbListFontFamily;
     font-size: $breadcrumbListFontSize;
     line-height: $breadcrumbListFontSize * 1.5;
     color: $breadcrumbListSeparatorColor;
-
+  
     &__element {
       display: inline-block;
 
@@ -147,5 +139,5 @@ $include-html: false !default;
       }
     }
   }
-
+  
 }

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -105,7 +105,7 @@ $include-html: false !default;
     font-size: $breadcrumbListFontSize;
     line-height: $breadcrumbListFontSize * 1.5;
     color: $breadcrumbListSeparatorColor;
-  
+
     &__element {
       display: inline-block;
 
@@ -139,5 +139,5 @@ $include-html: false !default;
       }
     }
   }
-  
+
 }

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -123,7 +123,7 @@ $include-html: false !default;
     }
 
     &--for-fine-print {
-      font-size: 0.8125rem;
+      font-size: fontSize(small);
       color: $breadcrumbListBlueSeparatorColor;
       .mint-breadcrumb-list__element {
         &:after {
@@ -133,7 +133,7 @@ $include-html: false !default;
     }
 
     &--for-fine-print-light {
-      font-size: 0.8125rem;
+      font-size: fontSize(small);
       color: $breadcrumbListLightBlueSeparatorColor;
       .mint-breadcrumb-list__element {
         &:after {

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -12,6 +12,7 @@ $include-html: false !default;
 
 @mixin mint-list-basic-styles() {
   @include component;
+  overflow: visible; // move baseline from margin to the last line box
   display: block;
   margin: 0;
   padding: 0;
@@ -22,8 +23,7 @@ $include-html: false !default;
 
   .mint-list {
     @include mint-list-basic-styles();
-    font-size: 24px;
-    line-height: 44px;
+    line-height: 2*$baseline;
 
     .mint-list__element {
       @extend .mint-icon-arrow_down;
@@ -33,14 +33,14 @@ $include-html: false !default;
         color: white;
         transform: rotate(-90deg);
         font-size: 38px;
-        vertical-align: -6px;
+        vertical-align: -5px;
         margin-right: 10px;
       }
 
       &--with-plus {
         &:before {
           font-size: 24px;
-          vertical-align: 0;
+          vertical-align: -4px;
           color: $listSmallIconColor;
           @extend .mint-icon-plus;
         }
@@ -48,9 +48,7 @@ $include-html: false !default;
     }
 
     &--small {
-      font-size: 15px;
-      line-height: 30px;
-
+      line-height: $baseline;
       .mint-list__element {
         &:before {
           font-size: 24px;
@@ -61,7 +59,7 @@ $include-html: false !default;
         &--with-plus {
           &:before {
             font-size: 14px;
-            vertical-align: 0;
+            vertical-align: 1px;
           }
         }
       }
@@ -71,10 +69,11 @@ $include-html: false !default;
   .mint-menu-list {
     @include mint-list-basic-styles();
     &__element {
-      height: 35px;
-      line-height: 35px;
+      box-sizing: border-box;
+      height: 2 * $baseline;
+      line-height: 2 * $baseline;
       border-bottom: 1px dashed $menuListBorderColor;
-      font-family: inherit;
+
       &:last-child {
         border: 0;
       }
@@ -87,7 +86,6 @@ $include-html: false !default;
       text-decoration: none;
       display: block;
       font-size: $menuListFontSize;
-      font-family: inherit;
       white-space: nowrap;
       &:hover {
         text-decoration: underline;
@@ -102,15 +100,13 @@ $include-html: false !default;
     @include mint-list-basic-styles();
     display: inline-block;
     vertical-align: inherit;
-    font-size: $breadcrumbListFontSize;
-    line-height: $breadcrumbListFontSize * 1.5;
     color: $breadcrumbListSeparatorColor;
 
     &__element {
       display: inline-block;
 
       &:after {
-        content: '·';
+        content: '•';
         display: inline-block;
         color: $breadcrumbListSeparatorColor;
         padding: 0 2px;
@@ -122,6 +118,7 @@ $include-html: false !default;
     }
 
     &--for-fine-print {
+      font-size: 0.8125rem;
       color: $breadcrumbListBlueSeparatorColor;
       .mint-breadcrumb-list__element {
         &:after {
@@ -131,6 +128,7 @@ $include-html: false !default;
     }
 
     &--for-fine-print-light {
+      font-size: 0.8125rem;
       color: $breadcrumbListLightBlueSeparatorColor;
       .mint-breadcrumb-list__element {
         &:after {

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,3 +1,6 @@
+$listFontSize: fontSize(headline);
+$smallListFontSize: fontSize(default);
+
 $breadcrumbListSeparatorColor: $grayPrimary;
 $breadcrumbListBlueSeparatorColor: $blueSecondary;
 $breadcrumbListLightBlueSeparatorColor: $blueSecondaryLight;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -105,7 +105,6 @@ $include-html: false !default;
   .mint-breadcrumb-list {
     @include mint-list-basic-styles();
     display: inline-block;
-    vertical-align: inherit;
     color: $breadcrumbListSeparatorColor;
 
     &__element {

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,6 +1,3 @@
-$listFontSize: fontSize(headline);
-$smallListFontSize: fontSize(default);
-
 $breadcrumbListSeparatorColor: $grayPrimary;
 $breadcrumbListBlueSeparatorColor: $blueSecondary;
 $breadcrumbListLightBlueSeparatorColor: $blueSecondaryLight;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -1,10 +1,12 @@
-$breadcrumbListFontSize: 13px;
+$listFontSize: fontSize(headline);
+$smallListFontSize: fontSize(default);
+
 $breadcrumbListSeparatorColor: $grayPrimary;
 $breadcrumbListBlueSeparatorColor: $blueSecondary;
 $breadcrumbListLightBlueSeparatorColor: $blueSecondaryLight;
 
 $menuListColor: $bluePrimary;
-$menuListFontSize: 13px;
+$menuListFontSize: fontSize(small);
 $menuListBorderColor: $graySecondary;
 $listSmallIconColor: $graySecondary;
 
@@ -23,6 +25,7 @@ $include-html: false !default;
 
   .mint-list {
     @include mint-list-basic-styles();
+    font-size: $listFontSize;
     line-height: rhythm(2);
 
     .mint-list__element {
@@ -40,7 +43,7 @@ $include-html: false !default;
       &--with-plus {
         &:before {
           font-size: 24px;
-          vertical-align: -4px;
+          vertical-align: 0;
           color: $listSmallIconColor;
           @extend .mint-icon-plus;
         }
@@ -49,6 +52,9 @@ $include-html: false !default;
 
     &--small {
       line-height: rhythm(1);
+      font-weight: bold;
+      font-size: $smallListFontSize;
+
       .mint-list__element {
         &:before {
           font-size: 24px;

--- a/src/components/list/list.html
+++ b/src/components/list/list.html
@@ -17,35 +17,35 @@
             </ul>
             <ul class="mint-breadcrumb-list">
                 <li class="mint-breadcrumb-list__element">
-                    <a class="mint-link mint-link--gray mint-link--emphasised" href="#">English</a>
+                    <a class="mint-link mint-link--small mint-link--gray mint-link--emphasised" href="#">English</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    <a class="mint-link mint-link--gray" href="#">Katie</a>
+                    <a class="mint-link mint-link--small mint-link--gray" href="#">Katie</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    <span class="mint-link mint-link--gray mint-link--disabled">Answerer</span>
+                    <span class="mint-link mint-link--small mint-link--gray mint-link--disabled">Answerer</span>
                 </li>
             </ul>
             <ul class="mint-breadcrumb-list mint-breadcrumb-list--for-fine-print">
                 <li class="mint-breadcrumb-list__element">
-                    Poland: <a class="mint-link mint-link--for-fine-print-light" href="#">Zadane.pl</a>
+                    Poland: <a class="mint-link mint-link--small mint-link--for-fine-print-light" href="#">Zadane.pl</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    Russia: <a class="mint-link mint-link--for-fine-print-light" href="#">Znanija.com</a>
+                    Russia: <a class="mint-link mint-link--small mint-link--for-fine-print-light" href="#">Znanija.com</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    Spain: <a class="mint-link mint-link--for-fine-print-light">Misdeberes.es</a>
+                    Spain: <a class="mint-link mint-link--small mint-link--for-fine-print-light">Misdeberes.es</a>
                 </li>
             </ul>
             <ul class="mint-breadcrumb-list mint-breadcrumb-list--for-fine-print-light">
                 <li class="mint-breadcrumb-list__element">
-                    Poland: <a class="mint-link mint-link--for-fine-print" href="#">Zadane.pl</a>
+                    Poland: <a class="mint-link mint-link--small mint-link--for-fine-print" href="#">Zadane.pl</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    Russia: <a class="mint-link mint-link--for-fine-print" href="#">Znanija.com</a>
+                    Russia: <a class="mint-link mint-link--small mint-link--for-fine-print" href="#">Znanija.com</a>
                 </li>
                 <li class="mint-breadcrumb-list__element">
-                    Spain: <a class="mint-link mint-link--for-fine-print">Misdeberes.es</a>
+                    Spain: <a class="mint-link mint-link--small mint-link--for-fine-print">Misdeberes.es</a>
                 </li>
             </ul>
         </div>

--- a/src/components/overlayed-box/_overlayed_box.scss
+++ b/src/components/overlayed-box/_overlayed_box.scss
@@ -9,6 +9,7 @@ $include-html: false !default;
     vertical-align: inherit;
 
     &__overlay {
+      @include components-container;
       position: absolute;
       right: 0;
       bottom: 0;

--- a/src/components/promo-box/_promo-box.scss
+++ b/src/components/promo-box/_promo-box.scss
@@ -1,10 +1,9 @@
 $promoBoxBackgroundColor: $mintSecondary;
 $promoBoxHeaderColor: $white;
-$promoBoxHeaderPrimaryFontFamily: $fontFamilyEmphasized;
-$promoBoxHeaderPrimaryFontSize: 50px;
+$promoBoxHeaderFontWeight: $fontWeightBlack;
+$promoBoxHeaderFontSize: 50px;
 $promoBoxTextSize: 24px;
 $promoBoxLineHeight: 44px;
-$promoBoxFontFamily: $fontFamilyPrimary;
 
 $include-html: false !default;
 
@@ -17,8 +16,8 @@ $include-html: false !default;
 
     &__header {
       color: $promoBoxHeaderColor;
-      font-family: $promoBoxHeaderPrimaryFontFamily;
-      font-size: $promoBoxHeaderPrimaryFontSize;
+      font-weight: $promoBoxHeaderFontWeight;
+      font-size: $promoBoxHeaderFontSize;
       line-height: 1;
       margin: 0;
       text-transform: uppercase;
@@ -30,9 +29,8 @@ $include-html: false !default;
     &__content {
       font-size: $promoBoxTextSize;
       line-height: $promoBoxLineHeight;
-      font-family: $promoBoxFontFamily;
       padding: 5px 0 15px 0;
     }
   }
-  
+
 }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -5,8 +5,8 @@ $rateStarActiveColor: $graySecondaryLight;
 $rateStarActiveCheckedColor: $mustardSecondary;
 $rateCounterColor: $grayPrimary;
 $rateCounterFontWeight: $fontWeightBlack;
-$rateStarFontSize: 12px;
-$rateStarSmallFontSize: 10px;
+$rateStarFontSize: fontSize(obscure);
+$rateStarSmallFontSize: fontSize(tiny);
 $rateScaleFactor: 2/3;
 
 $include-html: false !default;
@@ -52,7 +52,7 @@ $include-html: false !default;
     }
 
     &__counter {
-      @include fixText($rateStarFontSize, 2px);
+      @include fixText($rateStarFontSize, 0.125rem);
       font-weight: $rateCounterFontWeight;
       color: $rateCounterColor;
       margin: 0 0 0 $layoutDefaultPadding/2;

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -72,5 +72,5 @@ $include-html: false !default;
       }
     }
   }
-  
+
 }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -6,7 +6,7 @@ $rateStarActiveCheckedColor: $mustardSecondary;
 $rateCounterColor: $grayPrimary;
 $rateCounterFontWeight: $fontWeightBlack;
 $rateStarFontSize: fontSize(obscure);
-$rateStarSmallFontSize: fontSize(tiny);
+$rateStarSmallFontSize: fontSize(xsmall);
 $rateScaleFactor: 2/3;
 
 $include-html: false !default;

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -4,7 +4,7 @@ $rateStarCheckedColor: $mustardPrimary;
 $rateStarActiveColor: $graySecondaryLight;
 $rateStarActiveCheckedColor: $mustardSecondary;
 $rateCounterColor: $grayPrimary;
-$rateCounterFont: $fontFamilyEmphasized;
+$rateCounterFontWeight: $fontWeightBlack;
 $rateStarFontSize: 12px;
 $rateStarSmallFontSize: 10px;
 $rateScaleFactor: 2/3;
@@ -53,7 +53,7 @@ $include-html: false !default;
 
     &__counter {
       @include fixText($rateStarFontSize, 2px);
-      font-family: $rateCounterFont;
+      font-weight: $rateCounterFontWeight;
       color: $rateCounterColor;
       margin: 0 0 0 $layoutDefaultPadding/2;
     }
@@ -72,5 +72,5 @@ $include-html: false !default;
       }
     }
   }
-
+  
 }

--- a/src/components/separators/_horizontal-separator.scss
+++ b/src/components/separators/_horizontal-separator.scss
@@ -1,4 +1,4 @@
-$horizontalSeparatorHeight: 1px;
+$horizontalSeparatorHeight: 0.0625rem;
 $horizontalSeparatorColor: $grayPrimary;
 
 $include-html: false !default;
@@ -7,13 +7,14 @@ $include-html: false !default;
 
   .mint-horizontal-separator {
     @include component();
+    min-height: auto;
     display: block;
     height: $horizontalSeparatorHeight;
     border-bottom: $horizontalSeparatorHeight dotted $horizontalSeparatorColor;
     width: 100%;
 
     &--spaced {
-      margin: $layoutDefaultPadding - $horizontalSeparatorHeight 0 $layoutDefaultPadding 0;
+      margin: rhythm(1) - $horizontalSeparatorHeight 0 rhythm(1) 0;
     }
   }
 

--- a/src/components/separators/_separators.scss
+++ b/src/components/separators/_separators.scss
@@ -1,7 +1,7 @@
 $separatorColor: $grayPrimary;
-$separatorHeight: 18px;
+$separatorHeight: rhythm(0.75);
 $separatorSpacing: 15px;
-$separatorHeightSmall: 10px;
+$separatorHeightSmall: rhythm(0.417);
 $separatorSpacingSmall: 10px;
 
 $include-html: false !default;
@@ -10,6 +10,7 @@ $include-html: false !default;
 
   .mint-separator {
     @include component;
+    min-height: auto;
 
     margin-right: $separatorSpacing;
     border-right: solid $separatorColor 1px;

--- a/src/components/stickers/_stickers.scss
+++ b/src/components/stickers/_stickers.scss
@@ -39,7 +39,9 @@ $include-html: false !default;
 
   .mint-sticker {
     @include component;
+    @include remove-descenders;
     overflow: visible;
+
 
     @include from-icon(answering);
     @include from-icon(answered);

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -8,8 +8,6 @@ $tabHoverTextColor: $white;
 $tabHeight: 44px;
 $tabSmallHeight: 32px;
 $tabFontSize: 12px;
-$tabsFontFamily: $fontFamilySecondary;
-
 
 $include-html: false !default;
 
@@ -29,7 +27,7 @@ $include-html: false !default;
       border-right: 1px solid $tabSeparatorColor;
       color: $tabTextColor;
       cursor: pointer;
-      font-family: $tabsFontFamily;
+      font-weight: bold;
       float: left;
       padding: 0 $tabHeight/2;
       text-transform: uppercase;

--- a/src/components/tabs/_tabs.scss
+++ b/src/components/tabs/_tabs.scss
@@ -5,9 +5,9 @@ $tabActiveBackground: $bluePrimary;
 $tabActiveTextColor: $white;
 $tabHoverBackground: $blueSecondary;
 $tabHoverTextColor: $white;
-$tabHeight: 44px;
-$tabSmallHeight: 32px;
-$tabFontSize: 12px;
+$tabHeight: rhythm(1.833);
+$tabSmallHeight: rhythm(1.5);
+$tabFontSize: fontSize(obscure);
 
 $include-html: false !default;
 

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -14,7 +14,7 @@ $include-html: false !default;
     }
 
     &--light {
-      color: $white;;
+      color: $white;
     }
   }
 
@@ -33,7 +33,7 @@ $include-html: false !default;
     }
 
     &--light {
-      color: $white;;
+      color: $white;
     }
   }
 

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -24,12 +24,12 @@ $include-html: false !default;
     display: block;
     color: $black;
     font-weight: bold;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.03rem;
     text-transform: uppercase;
 
     &--small {
       @include typeVariant(small, 0.667);
-      letter-spacing: 1px;
+      letter-spacing: 0.0625rem;
     }
 
     &--light {

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -4,13 +4,13 @@ $include-html: false !default;
 
   .mint-header-primary {
     @include component;
-    @include typeVariant(header, 2, 11/16, 37/16);
+    @include typeVariant(header, 2);
     display: block;
     color: $black;
     font-weight: $fontWeightBlack;
 
     &--small {
-      @include typeVariant(headline, 2, 1, 8/16);
+      @include typeVariant(headline);
     }
 
     &--light {
@@ -20,7 +20,7 @@ $include-html: false !default;
 
   .mint-header-secondary {
     @include component;
-    @include typeVariant(default, 0.667, 12/16, 20/16);
+    @include typeVariant(default, 0.667);
     display: block;
     color: $black;
     font-weight: bold;
@@ -28,7 +28,7 @@ $include-html: false !default;
     text-transform: uppercase;
 
     &--small {
-      @include typeVariant(small, 0.667, 13/16, 19/16);
+      @include typeVariant(small, 0.667);
       letter-spacing: 1px;
     }
 

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -10,14 +10,14 @@ $include-html: false !default;
     font-weight: $fontWeightBlack;
 
     &--small {
-      font-size: $headerPrimarySmallFontSize;
+      @include type-variant(1.75, 2, 1, 8/16);
     }
 
     &--light {
       color: $white;;
     }
-
   }
+
   .mint-header-secondary {
     @include component;
     @include type-variant(1, 0.667, 12/16, 20/16);
@@ -30,11 +30,11 @@ $include-html: false !default;
     &--small {
       @include type-variant(0.8125, 0.667, 13/16, 19/16);
       letter-spacing: 1px;
-      }
-  
+    }
+
     &--light {
       color: $white;;
     }
   }
-  
+
 }

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -1,7 +1,6 @@
 $headerColor: $black;
 $headerColorLight: $white;
-$headerPrimaryFontFamily: $fontFamilyEmphasized;
-$headerSecondaryFontFamily: $fontFamilySecondary;
+$headerPrimaryFontWeight: $fontWeightBlack;
 $headerPrimaryFontSize: 64px;
 $headerPrimarySmallFontSize: 48px;
 $headerSecondaryFontSize: 16px;
@@ -15,7 +14,7 @@ $include-html: false !default;
     @include component;
     display: block;
     color: $headerColor;
-    font-family: $headerPrimaryFontFamily;
+    font-weight: $headerPrimaryFontWeight;
     font-size: $headerPrimaryFontSize;
     line-height: 1;
     margin: 0;
@@ -33,7 +32,7 @@ $include-html: false !default;
     @include component;
     display: block;
     color: $headerColor;
-    font-family: $headerSecondaryFontFamily;
+    font-weight: bold;
     font-size: $headerSecondaryFontSize;
     line-height: 1;
     text-transform: uppercase;
@@ -47,5 +46,5 @@ $include-html: false !default;
       color: $headerColorLight;
     }
   }
-
+  
 }

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -1,49 +1,39 @@
-$headerColor: $black;
-$headerColorLight: $white;
-$headerPrimaryFontWeight: $fontWeightBlack;
-$headerPrimaryFontSize: 64px;
-$headerPrimarySmallFontSize: 48px;
-$headerSecondaryFontSize: 16px;
-$headerSecondarySmallFontSize: 12px;
-
 $include-html: false !default;
 
 @if ($include-html) {
 
   .mint-header-primary {
     @include component;
+    @include type-variant(3, 2, 11/16, 37/16);
     display: block;
-    color: $headerColor;
-    font-weight: $headerPrimaryFontWeight;
-    font-size: $headerPrimaryFontSize;
-    line-height: 1;
-    margin: 0;
+    color: $black;
+    font-weight: $fontWeightBlack;
 
     &--small {
       font-size: $headerPrimarySmallFontSize;
     }
 
     &--light {
-      color: $headerColorLight;
+      color: $white;;
     }
 
   }
   .mint-header-secondary {
     @include component;
+    @include type-variant(1, 0.667, 12/16, 20/16);
     display: block;
-    color: $headerColor;
+    color: $black;
     font-weight: bold;
-    font-size: $headerSecondaryFontSize;
-    line-height: 1;
+    letter-spacing: 0.03em;
     text-transform: uppercase;
-    margin: 0;
 
     &--small {
-      font-size: $headerSecondarySmallFontSize;
-    }
-
+      @include type-variant(0.8125, 0.667, 13/16, 19/16);
+      letter-spacing: 1px;
+      }
+  
     &--light {
-      color: $headerColorLight;
+      color: $white;;
     }
   }
   

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -4,13 +4,13 @@ $include-html: false !default;
 
   .mint-header-primary {
     @include component;
-    @include type-variant(3, 2, 11/16, 37/16);
+    @include typeVariant(header, 2, 11/16, 37/16);
     display: block;
     color: $black;
     font-weight: $fontWeightBlack;
 
     &--small {
-      @include type-variant(1.75, 2, 1, 8/16);
+      @include typeVariant(headline, 2, 1, 8/16);
     }
 
     &--light {
@@ -20,7 +20,7 @@ $include-html: false !default;
 
   .mint-header-secondary {
     @include component;
-    @include type-variant(1, 0.667, 12/16, 20/16);
+    @include typeVariant(default, 0.667, 12/16, 20/16);
     display: block;
     color: $black;
     font-weight: bold;
@@ -28,7 +28,7 @@ $include-html: false !default;
     text-transform: uppercase;
 
     &--small {
-      @include type-variant(0.8125, 0.667, 13/16, 19/16);
+      @include typeVariant(small, 0.667, 13/16, 19/16);
       letter-spacing: 1px;
     }
 

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -13,6 +13,10 @@
     color: $grayPrimary;
   }
 
+  &--small {
+    @include type-variant(0.8125, 0.75);
+  }
+
   &--for-fine-print {
     color: $blueSecondary;
   }
@@ -22,7 +26,6 @@
   }
 
   &--emphasised {
-    @include type-variant(0.8125, 0.75);
     text-transform: uppercase;
     letter-spacing: 0.01em;
   }

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -3,6 +3,7 @@
   color: $bluePrimary;
   text-decoration: none;
   font-weight: bold;
+  line-height: 0.75rem; // forbid descenders overflow line-height
 
   &:hover, &:active {
     text-decoration: underline;
@@ -21,7 +22,7 @@
   }
 
   &--emphasised {
-    @include type-variant(0.8125, 1);
+    @include type-variant(0.8125, 0.75);
     text-transform: uppercase;
     letter-spacing: 0.01em;
   }

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -14,7 +14,7 @@
   }
 
   &--small {
-    @include type-variant(0.8125, 0.75);
+    @include typeVariant(small, 0.75);
   }
 
   &--for-fine-print {

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -1,9 +1,9 @@
 .mint-link {
+  @include remove-descenders;
   cursor: pointer;
   color: $bluePrimary;
   text-decoration: none;
   font-weight: bold;
-  line-height: 0.75rem; // forbid descenders overflow line-height
 
   &:hover, &:active {
     text-decoration: underline;

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -1,0 +1,36 @@
+.mint-link {
+  cursor: pointer;
+  color: $bluePrimary;
+  text-decoration: none;
+  font-weight: bold;
+
+  &:hover, &:active {
+    text-decoration: underline;
+  }
+
+  &--gray {
+    color: $grayPrimary;
+  }
+
+  &--for-fine-print {
+    color: $blueSecondary;
+  }
+
+  &--for-fine-print-light {
+    color: $blueSecondaryLight;
+  }
+
+  &--emphasised {
+    @include type-variant(0.8125, 1);
+    text-transform: uppercase;
+    letter-spacing: 0.01em;
+  }
+
+  &--disabled {
+    cursor: default;
+
+    &:hover, &:active {
+      text-decoration: none;
+    }
+  }
+}

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -1,6 +1,5 @@
 $textBitFontWeight: $fontWeightBlack;
-$textBitFontSize: 44px;
-$textBitLineHeight: 2 * $baseline;
+$textBitFontSize: fontSize(header);
 $textBitColor: $mintSecondary;
 $textBitAltColor: $blueSecondary;
 $textBitWarningColor: $peachPrimary;
@@ -11,10 +10,10 @@ $textBitLargerTabletFontSize: 72px;
 $textBitLargerDesktopFontSize: 80px;
 
 .mint-text-bit {
+  @include typeVariant(large, 2);
+  
   color: $textBitColor;
   font-weight: $textBitFontWeight;
-  font-size: $textBitFontSize;
-  line-height: $textBitLineHeight;
   text-transform: uppercase;
   word-wrap: break-word;
   margin: 0;

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -1,0 +1,70 @@
+$textBitFontWeight: $fontWeightBlack;
+$textBitFontSize: 44px;
+$textBitLineHeight: 2 * $baseline;
+$textBitColor: $mintSecondary;
+$textBitAltColor: $blueSecondary;
+$textBitWarningColor: $peachPrimary;
+$textBitLightColor: $white;
+$textBitDarkColor: $black;
+$textBitLargeFontSize: 62px;
+$textBitLargerTabletFontSize: 72px;
+$textBitLargerDesktopFontSize: 80px;
+
+.mint-text-bit {
+  color: $textBitColor;
+  font-weight: $textBitFontWeight;
+  font-size: $textBitFontSize;
+  line-height: $textBitLineHeight;
+  text-transform: uppercase;
+  word-wrap: break-word;
+  margin: 0;
+  position: relative;
+  letter-spacing: -1px;
+
+  &__hole {
+    display: block;
+    position: absolute;
+    top: -22px;
+    left: -13px;
+    line-height: 0;
+    &--small {
+      top: -25px;
+      left: -10px;
+    }
+  }
+
+  &--alt {
+    color: $textBitAltColor;
+  }
+
+  &--light {
+    color: $textBitLightColor;
+  }
+
+  &--dark {
+    color: $textBitDarkColor;
+  }
+
+  &--warning {
+    color: $textBitWarningColor;
+  }
+
+  &--large {
+    font-size: $textBitLargeFontSize;
+  }
+
+  @media (min-width: $breakpointTablet) {
+    &:not(.mint-text-bit--not-responsive) {
+      font-size: $textBitLargeFontSize;
+    }
+  }
+
+  &--to-larger:not(.mint-text-bit--not-responsive) {
+    @media (min-width: $breakpointTablet) {
+      font-size: $textBitLargerTabletFontSize;
+    }
+    @media (min-width: $breakpointDesktop) {
+      font-size: $textBitLargerDesktopFontSize;
+    }
+  }
+}

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -1,16 +1,16 @@
 $textBitFontWeight: $fontWeightBlack;
-$textBitFontSize: fontSize(header);
+$textBitFontSize: header;
 $textBitColor: $mintSecondary;
 $textBitAltColor: $blueSecondary;
 $textBitWarningColor: $peachPrimary;
 $textBitLightColor: $white;
 $textBitDarkColor: $black;
-$textBitLargeFontSize: 62px;
-$textBitLargerTabletFontSize: 72px;
-$textBitLargerDesktopFontSize: 80px;
+$textBitLargeFontSize: fontSize(large);
+$textBitLargerTabletFontSize: fontSize(xlarge);
+$textBitLargerDesktopFontSize: fontSize(xxlarge);
 
 .mint-text-bit {
-  @include typeVariant(large, 2);
+  @include typeVariant($textBitFontSize, 2);
 
   color: $textBitColor;
   font-weight: $textBitFontWeight;

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -52,17 +52,17 @@ $textBitLargerDesktopFontSize: fontSize(xxlarge);
     font-size: $textBitLargeFontSize;
   }
 
-  @media (min-width: $breakpointTablet) {
+  @media (min-width: $breakpointMedium) {
     &:not(.mint-text-bit--not-responsive) {
       font-size: $textBitLargeFontSize;
     }
   }
 
   &--to-larger:not(.mint-text-bit--not-responsive) {
-    @media (min-width: $breakpointTablet) {
+    @media (min-width: $breakpointMedium) {
       font-size: $textBitLargerTabletFontSize;
     }
-    @media (min-width: $breakpointDesktop) {
+    @media (min-width: $breakpointLarge) {
       font-size: $textBitLargerDesktopFontSize;
     }
   }

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -11,7 +11,7 @@ $textBitLargerDesktopFontSize: 80px;
 
 .mint-text-bit {
   @include typeVariant(large, 2);
-  
+
   color: $textBitColor;
   font-weight: $textBitFontWeight;
   text-transform: uppercase;

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -18,7 +18,7 @@ $textBitLargerDesktopFontSize: fontSize(xxlarge);
   word-wrap: break-word;
   margin: 0;
   position: relative;
-  letter-spacing: -1px;
+  letter-spacing: -0.0625rem;
 
   &__hole {
     display: block;

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -3,24 +3,23 @@ $include-html: false !default;
 @if ($include-html) {
 
   .mint-text {
-    @include type-variant(1, 1);
+    @include typeVariant(default, 1);
     font-family: $fontFamilyPrimary;
     color: $black;
 
     &--standout {
-      @include type-variant(1.125, 1);
-      font-size: 1.125rem;
+      @include typeVariant(standout, 1);
     }
 
     &--obscure {
-      @include type-variant(0.75, 1);
+      @include typeVariant(obscure, 1);
     }
 
     &--headline {
-      @include type-variant(1.75, 1.334);
+      @include typeVariant(headline, 1.334);
       font-weight: normal;
       margin: 0;
-      margin-bottom: $baseline;
+      margin-bottom: rhythm(1);
     }
 
     &--emphasised {

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -2,9 +2,8 @@ $linkColor: $bluePrimary;
 $linkGrayColor: $grayPrimary;
 $linkBlueColor: $blueSecondary;
 $linkLightBlueColor: $blueSecondaryLight;
-$linkFontFamily: $fontFamilySecondary;
 
-$textBitFontFamily: $fontFamilyEmphasized;
+$textBitFontWeight: $fontWeightBlack;
 $textBitFontSize: 44px;
 $textBitLineHeight: 0.9;
 $textBitColor: $mintSecondary;
@@ -16,7 +15,6 @@ $textBitLargeFontSize: 62px;
 $textBitLargerTabletFontSize: 72px;
 $textBitLargerDesktopFontSize: 80px;
 
-$textBlockFontFamily: $fontFamilySecondary;
 $textBlockFontSize: 13px;
 $textBlockLineHeight: 14px;
 $textBlockColor: $black;
@@ -25,7 +23,6 @@ $textBlockLightBlueColor: $blueSecondaryLight;
 $textBlockGrayColor: $grayPrimary;
 $textBlockLightColor: $white;
 
-$textDescriptionFontFamily: $fontFamilyPrimary;
 $textDescriptionColor: $black;
 $textDescriptionFontSize: 18px;
 $textDescriptionLineHeight: 21px;
@@ -34,15 +31,13 @@ $textDescriptionLargeLineHeight: 32px;
 $textDescriptionSmallFontSize: 15px;
 $textDescriptionSmallLineHeight: 19px;
 
-$textEmphasisedFontFamily: $fontFamilySecondary;
-
 $include-html: false !default;
 
 @if ($include-html) {
 
   .mint-text-bit {
     color: $textBitColor;
-    font-family: $textBitFontFamily;
+    font-weight: $textBitFontWeight;
     font-size: $textBitFontSize;
     line-height: $textBitLineHeight;
     text-transform: uppercase;
@@ -92,7 +87,7 @@ $include-html: false !default;
   }
 
   .mint-text-block {
-    font-family: $textBlockFontFamily;
+    font-weight: bold;
     font-size: $textBlockFontSize;
     line-height: $textBlockLineHeight;
     color: $textBlockColor;
@@ -117,13 +112,12 @@ $include-html: false !default;
   }
 
   .mint-text-description {
-    font-family: $textDescriptionFontFamily;
     font-size: $textDescriptionFontSize;
     line-height: $textDescriptionLineHeight;
     color: $textDescriptionColor;
     margin: 0;
     padding: 0;
-
+  
     &--large {
       font-size: $textDescriptionLargeFontSize;
       line-height: $textDescriptionLargeLineHeight;
@@ -135,14 +129,14 @@ $include-html: false !default;
   }
 
   .mint-text-emphasised {
-    font-family: $textEmphasisedFontFamily;
+    font-weight: bold;
   }
 
   .mint-link {
     cursor: pointer;
     color: $linkColor;
     text-decoration: none;
-    font-family: $linkFontFamily;
+    font-weight: bold;
 
     &:hover, &:active {
       text-decoration: underline;
@@ -172,5 +166,5 @@ $include-html: false !default;
       }
     }
   }
-
+  
 }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -43,5 +43,5 @@ $include-html: false !default;
       color: $blueSecondary;
     }
   }
-  
+
 }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -1,169 +1,46 @@
-$linkColor: $bluePrimary;
-$linkGrayColor: $grayPrimary;
-$linkBlueColor: $blueSecondary;
-$linkLightBlueColor: $blueSecondaryLight;
-
-$textBitFontWeight: $fontWeightBlack;
-$textBitFontSize: 44px;
-$textBitLineHeight: 0.9;
-$textBitColor: $mintSecondary;
-$textBitAltColor: $blueSecondary;
-$textBitWarningColor: $peachPrimary;
-$textBitLightColor: $white;
-$textBitDarkColor: $black;
-$textBitLargeFontSize: 62px;
-$textBitLargerTabletFontSize: 72px;
-$textBitLargerDesktopFontSize: 80px;
-
-$textBlockFontSize: 13px;
-$textBlockLineHeight: 14px;
-$textBlockColor: $black;
-$textBlockBlueColor: $blueSecondary;
-$textBlockLightBlueColor: $blueSecondaryLight;
-$textBlockGrayColor: $grayPrimary;
-$textBlockLightColor: $white;
-
-$textDescriptionColor: $black;
-$textDescriptionFontSize: 18px;
-$textDescriptionLineHeight: 21px;
-$textDescriptionLargeFontSize: 32px;
-$textDescriptionLargeLineHeight: 32px;
-$textDescriptionSmallFontSize: 15px;
-$textDescriptionSmallLineHeight: 19px;
-
 $include-html: false !default;
 
 @if ($include-html) {
 
-  .mint-text-bit {
-    color: $textBitColor;
-    font-weight: $textBitFontWeight;
-    font-size: $textBitFontSize;
-    line-height: $textBitLineHeight;
-    text-transform: uppercase;
-    word-wrap: break-word;
-    margin: 0;
-    position: relative;
-    letter-spacing: -1px;
-    &__hole {
-      display: block;
-      position: absolute;
-      top: -22px;
-      left: -13px;
-      line-height: 0;
-      &--small {
-        top: -25px;
-        left: -10px;
-      }
-    }
-    &--alt {
-      color: $textBitAltColor;
-    }
-    &--light {
-      color: $textBitLightColor;
-    }
-    &--dark {
-      color: $textBitDarkColor;
-    }
-    &--warning {
-      color: $textBitWarningColor;
-    }
-    &--large {
-      font-size: $textBitLargeFontSize;
-    }
-    @media (min-width: $breakpointMedium) {
-      &:not(.mint-text-bit--not-responsive) {
-        font-size: $textBitLargeFontSize;
-      }
-    }
-    &--to-larger:not(.mint-text-bit--not-responsive) {
-      @media (min-width: $breakpointMedium) {
-        font-size: $textBitLargerTabletFontSize;
-      }
-      @media (min-width: $breakpointLarge) {
-        font-size: $textBitLargerDesktopFontSize;
-      }
-    }
-  }
+  .mint-text {
+    @include type-variant(1, 1);
+    font-family: $fontFamilyPrimary;
+    color: $black;
 
-  .mint-text-block {
-    font-weight: bold;
-    font-size: $textBlockFontSize;
-    line-height: $textBlockLineHeight;
-    color: $textBlockColor;
-    margin: 0;
-    padding: 0;
-
-    &--gray {
-      color: $textBlockGrayColor;
-    }
-    &--light {
-      color: $textBlockLightColor;
-    }
-    &--for-fine-print-light {
-      color: $textBlockLightBlueColor;
-    }
-    &--for-fine-print {
-      color: $textBlockBlueColor;
-    }
-    &--emphasised {
-      text-transform: uppercase;
-    }
-  }
-
-  .mint-text-description {
-    font-size: $textDescriptionFontSize;
-    line-height: $textDescriptionLineHeight;
-    color: $textDescriptionColor;
-    margin: 0;
-    padding: 0;
-  
-    &--large {
-      font-size: $textDescriptionLargeFontSize;
-      line-height: $textDescriptionLargeLineHeight;
-    }
-    &--small {
-      font-size: $textDescriptionSmallFontSize;
-      line-height: $textDescriptionSmallLineHeight;
-    }
-  }
-
-  .mint-text-emphasised {
-    font-weight: bold;
-  }
-
-  .mint-link {
-    cursor: pointer;
-    color: $linkColor;
-    text-decoration: none;
-    font-weight: bold;
-
-    &:hover, &:active {
-      text-decoration: underline;
+    &--standout {
+      @include type-variant(1.125, 1);
+      font-size: 1.125rem;
     }
 
-    &--gray {
-      color: $linkGrayColor;
+    &--obscure {
+      @include type-variant(0.75, 1);
     }
 
-    &--for-fine-print {
-      color: $linkBlueColor;
-    }
-
-    &--for-fine-print-light {
-      color: $linkLightBlueColor;
+    &--headline {
+      @include type-variant(1.75, 1.334);
+      font-weight: normal;
+      margin: 0;
+      margin-bottom: $baseline;
     }
 
     &--emphasised {
-      text-transform: uppercase;
+      font-weight: bold;
     }
 
-    &--disabled {
-      cursor: default;
+    &--gray {
+      color: $grayPrimary;
+    }
 
-      &:hover, &:active {
-        text-decoration: none;
-      }
+    &--light {
+      color: $white;
+    }
+
+    &--for-fine-print-light {
+      color: $blueSecondaryLight;
+    }
+
+    &--for-fine-print {
+      color: $blueSecondary;
     }
   }
   

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -4,19 +4,23 @@
     </aside>
     <div class="docs-block__content">
         <h2 class="mint-header-primary">
-            Together we go far!
+            X Together we go far!
+            <br>
+            X2 Together we go far!
         </h2>
 
         <h2 class="mint-header-primary mint-header-primary--small">
-            We've got your back!
+            X We've got your back!
+            <br>
+            X2 We've got your back!
         </h2>
 
         <h2 class="mint-header-secondary">
-            We've got your back!
+            X We've got your back!
         </h2>
 
         <h2 class="mint-header-secondary mint-header-secondary--small">
-            We've got your back!
+            X We've got your back!
         </h2>
 
         <div class="docs-block__contrast-box">
@@ -41,54 +45,63 @@
 </section>
 <section class="docs-block">
     <aside class="docs-block__info">
-        <h3 class="docs-block__header">Text block</h3>
+        <h3 class="docs-block__header">Text</h3>
     </aside>
     <div class="docs-block__content">
-        <div class="mint-text-block">
-            Together we go far!
-        </div>
-        <div class="mint-text-block mint-text-block--emphasised">
-            Together we go far!
-        </div>
-        <div class="mint-text-block mint-text-block--gray">
-            Together we go far!
+        <div class="mint-text">
+            This is a default typeface for text everywhere.<br>
+            Here is <span class="mint-text mint-text--gray">gray text</span>
+            <br>
+            And <span class="mint-text mint-text--emphasised">emphasised text</span>
+            <br>
+            <span class="mint-text mint-text--gray">This text is gray</span>
+            <br>
+            and here
+            <br>
+            it is a multiline
+            <br>
+            to give vertical rhythm a shot
+            <br><br>
         </div>
         <div class="docs-block__contrast-box">
-            <div class="mint-text-block mint-text-block--light">
-                We've got your back
+            <div class="mint-text mint-text--light">
+                This text is light
             </div>
         </div>
-        <div class="mint-text-block mint-text-block--for-fine-print">
-            We've got your back!
+        <div class="mint-text mint-text--obscure">
+            <br>
+            This text is not really intended to be read
+            <br>
         </div>
-        <div class="mint-text-block mint-text-block--for-fine-print-light">
-            We've got your back!
+        <div class="mint-text mint-text--obscure mint-text--for-fine-print">
+            <br>
+            This is a fine print example
+            <br><br>
         </div>
-    </div>
-</section>
-<section class="docs-block">
-    <aside class="docs-block__info">
-        <h3 class="docs-block__header">Text description</h3>
-    </aside>
-    <div class="docs-block__content">
-        <div class="mint-text-description mint-text-description--large">
-            Together <a href="#" class="mint-link">we go</a> far!
-        </div>
-        <div class="mint-text-description">
-            Together <a href="#" class="mint-link">we go</a> far!
-        </div>
-        <div class="mint-text-description mint-text-description--small">
-            Together <a href="#" class="mint-link">we go</a> far!
+        <div class="docs-block__contrast-box">
+            <div class="mint-text mint-text--obscure mint-text--for-fine-print-light">
+                This is a very light fine print
+            </div>
         </div>
     </div>
 </section>
 <section class="docs-block">
     <aside class="docs-block__info">
-        <h3 class="docs-block__header">Emphasised text</h3>
+        <h3 class="docs-block__header">Text (headline + standout)</h3>
     </aside>
     <div class="docs-block__content">
-        <div class="mint-text-description">
-            Together we go <strong class="mint-text-emphasised">far</strong>!
+        <h2 class="mint-text mint-text--headline">
+            After President Nixon’s resignation,
+            <br>who became president
+            <br>of the United States?
+        </h2>
+
+        <div class="mint-text mint-text--standout">
+            President <strong class="mint-text mint-text--standout mint-text--emphasised">Richard Nixon</strong>
+            is the only president to resign from the office and was the 37th president of the
+            United States, serving from <span class="mint-text mint-text--standout mint-text--gray">1969 to 1974</span>.
+            Vice president Gerald R. Ford of Michigan took the office as the new president
+            to complete the remaining 2 1/2 years of Nixon's term.
         </div>
     </div>
 </section>
@@ -98,11 +111,21 @@
     </aside>
     <div class="docs-block__content">
         <div class="mint-text-description">
-            <a href="#" class="mint-link">Comments (9)</a><br/>
-            <span class="mint-link mint-link--gray mint-link--disabled">2 min ago</span><br/>
-            <a href="#" class="mint-link mint-link--gray mint-link--emphasised">Math</a><br/>
-            <a href="#" class="mint-link mint-link--for-fine-print mint-link--emphasised">Terms of use</a><br/>
-            <a href="#" class="mint-link mint-link--for-fine-print-light">zadane.pl</a><br/>
+            <div>
+                Some texts and a link <a href="#" class="mint-link">Comments (9)</a><br/>
+            </div>
+            <div>
+                Some texts and a disabled link <span class="mint-link mint-link--gray mint-link--disabled">2 min ago</span><br/>
+            </div>
+            <div>
+                An emphasized link <a href="#" class="mint-link mint-link--gray mint-link--emphasised">Math</a><br/>
+            </div>
+            <div>
+                Fine print link <a href="#" class="mint-link mint-link--for-fine-print-light">zadane.pl</a><br/>
+            </div>
+            <div>
+                Fine print emphasised link <a href="#" class="mint-link mint-link--for-fine-print mint-link--emphasised">Terms of use</a><br/>
+            </div>
         </div>
     </div>
 </section>

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -1,6 +1,6 @@
 <section class="docs-block">
     <aside class="docs-block__info">
-        <h3 class="docs-block__header">Heading</h3>
+        <h3 class="docs-block__header">Headers</h3>
     </aside>
     <div class="docs-block__content">
         <h2 class="mint-header-primary">

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -118,7 +118,7 @@
                 Some texts and a disabled link <span class="mint-link mint-link--gray mint-link--disabled">2 min ago</span><br/>
             </div>
             <div>
-                An emphasized link <a href="#" class="mint-link mint-link--gray mint-link--emphasised">Math</a><br/>
+                An emphasized link <a href="#" class="mint-link mint-link--gray mint-link--small mint-link--emphasised">Math</a><br/>
             </div>
             <div>
                 Fine print link <a href="#" class="mint-link mint-link--for-fine-print-light">zadane.pl</a><br/>

--- a/src/components/toplayer/_toplayer.scss
+++ b/src/components/toplayer/_toplayer.scss
@@ -3,7 +3,10 @@ $toplayerCrossColor: $white;
 $toplayerBackgroundColor: $white;
 $toplayerShadow: $defaultBottomShadow;
 $toplayerMarginTop: 65px;
-$toplayerMarginBottom: 30px;
+$toplayerMarginBottom: rhythm(1);
+$toplayerHeaderHeight: rhythm(1.25);
+
+$toplayerFirstVerticalPadding: (rhythm(1) - ($toplayerHeaderHeight - rhythm(1)));
 
 $include-html: false !default;
 
@@ -20,15 +23,16 @@ $include-html: false !default;
       .mint-toplayer__wrapper {
 
         @media (min-width: $breakpointMedium) {
-          margin: $layoutDefaultPadding;
-          padding: $layoutDefaultPadding;
+
+          padding: ($toplayerFirstVerticalPadding + rhythm(1)) 2 * $layoutDefaultPadding rhythm(2) 2 * $layoutDefaultPadding;
         }
 
       }
+      
       .mint-toplayer__heading {
 
         @media (min-width: $breakpointMedium) {
-          margin-bottom: 2 * $layoutDefaultPadding;
+          margin-bottom: rhythm(2);
         }
 
       }
@@ -86,7 +90,7 @@ $include-html: false !default;
       display: flex;
       justify-content: flex-end;
       align-items: center;
-      height: 30px;
+      height: $toplayerHeaderHeight;
       background-image: url($mintImagesPath + 'header_background_wide.jpg');
       background-repeat: repeat-x;
       background-color: $toplayerHeaderDominantColor;
@@ -106,7 +110,7 @@ $include-html: false !default;
     }
 
     &__wrapper {
-      margin: $layoutDefaultPadding;
+      padding: $toplayerFirstVerticalPadding $layoutDefaultPadding/2 rhythm(1) $layoutDefaultPadding/2;
     }
 
     &__heading {
@@ -118,10 +122,12 @@ $include-html: false !default;
     }
 
     &__list-title {
-      margin-bottom: 10px;
+      margin-bottom: rhythm(1);
     }
 
     &__actions {
+      @include components-container;
+      min-height: rhythm(2);
     }
   }
 

--- a/src/docs/_data/navigation.yml
+++ b/src/docs/_data/navigation.yml
@@ -5,6 +5,8 @@
       location: colors/colors
     - name: Text
       location: text/text
+    - name: Text Bit
+      location: text/text-bit
     - name: Icons
       location: icons/icons
     - name: Subject Icons
@@ -15,8 +17,6 @@
 - name: Components
   location: components
   elements:
-    - name: Text Bit
-      location: text/text-bit
     - name: Lists
       location: list/list
     - name: Badges

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -19,10 +19,6 @@
   &__content {
     flex: 1 1 auto;
 
-    &--logo-preview {
-      font-size: 150px;
-    }
-
     &--centered {
       display: flex;
       align-items: center

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -80,6 +80,7 @@
 .mint-overlayed-box__overlay,
 .mint-footer__line,
 .mint-content-box__header,
+.mint-content-box__title,
 .mint-content-box__footer,
 .mint-content-box__content,
 .mint-toplayer__heading,

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -70,7 +70,7 @@
   }
 }
 
-.mint-bubble,
+.mint-bubble__hole,
 .mint-box,
 .mint-promo-box__content,
 .mint-header__left,

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -46,7 +46,7 @@
         z-index: 1;
         content: '';
         background: linear-gradient(to bottom, #0ff 0, rgba(255, 255, 255, 0) 1px) repeat-y;
-        background-size: 100% $baseline;
+        background-size: 100% 1rem;
         height: 100%;
         width: 100%;
         position: absolute;
@@ -68,7 +68,6 @@
     padding: $baseline;
     display: inline-block;
   }
-
 }
 
 .mint-bubble,

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -1,6 +1,7 @@
 .docs-block {
   margin: 50px 0 0;
   display: flex;
+
   &__header {
     color: $grayPrimary;
     display: block;
@@ -8,34 +9,61 @@
     font-weight: normal;
     margin: 0;
   }
+
   &__info {
     flex: 0 1 auto;
     padding: 0 20px 0 0;
     width: 230px;
   }
+
   &__content {
     flex: 1 1 auto;
+
+    &--logo-preview {
+      font-size: 150px;
+    }
+
     &--centered {
       display: flex;
       align-items: center
     }
+
     &--align-top {
       & > * {
         vertical-align: top;
       }
     }
+
     &:hover {
+      position: relative;
+
       .docs-highlight-placeholder {
         outline: 2px dashed white;
         box-shadow: black 0 0 10px 0;
       }
+
+      &:before {
+        z-index: 1;
+        content: '';
+        background: linear-gradient(to bottom, #0ff 0, rgba(255, 255, 255, 0) 1px) repeat-y;
+        background-size: 100% 1rem;
+        height: 100%;
+        width: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        padding: 1px;
+      }
     }
+
   }
+
   &__contrast-box {
     background-color: $grayPrimary;
     padding: 10px;
     display: inline-block;
   }
+
   &__content-box {
     padding: 10px;
     display: inline-block;

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -46,7 +46,7 @@
         z-index: 1;
         content: '';
         background: linear-gradient(to bottom, #0ff 0, rgba(255, 255, 255, 0) 1px) repeat-y;
-        background-size: 100% 1rem;
+        background-size: 100% $baseline;
         height: 100%;
         width: 100%;
         position: absolute;

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -71,7 +71,7 @@
 }
 
 .mint-bubble__hole,
-.mint-box,
+.mint-box__hole,
 .mint-promo-box__content,
 .mint-header__left,
 .mint-header__middle,

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -46,7 +46,7 @@
         z-index: 1;
         content: '';
         background: linear-gradient(to bottom, #0ff 0, rgba(255, 255, 255, 0) 1px) repeat-y;
-        background-size: 100% 1rem;
+        background-size: 100% rhythm(1);
         height: 100%;
         width: 100%;
         position: absolute;

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -60,12 +60,12 @@
 
   &__contrast-box {
     background-color: $grayPrimary;
-    padding: 10px;
+    padding: $baseline;
     display: inline-block;
   }
 
   &__content-box {
-    padding: 10px;
+    padding: $baseline;
     display: inline-block;
   }
 

--- a/src/docs/_sass/main.scss
+++ b/src/docs/_sass/main.scss
@@ -1,7 +1,7 @@
 @charset "utf-8";
 
-@import "../../sass/config";
-//style guide variables
+@import "../../sass/config"; //style guide variables
+@import "../../sass/mixins";
 @import "../_sass/config";
 @import "../_sass/colors-list";
 @import "../_sass/color-box";

--- a/src/docs/_sass/main.scss
+++ b/src/docs/_sass/main.scss
@@ -11,9 +11,6 @@
 html, body {
   margin: 0;
   padding: 0;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-family: "HelveticaNeue", "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
 body {

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -14,6 +14,9 @@ $include-html: false !default;
   body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+
+    font-size: $base-font;
+    line-height: $baseline;
   }
 
 }

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -20,7 +20,7 @@ $include-html: false !default;
 
     font-size: fontSize(default);
     font-family: $fontFamilyPrimary;
-    line-height: $baseline;
+    line-height: rhythm(1);
   }
 
 }

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -16,6 +16,7 @@ $include-html: false !default;
     -moz-osx-font-smoothing: grayscale;
 
     font-size: $base-font;
+    font-family: $fontFamilyPrimary;
     line-height: $baseline;
   }
 

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -1,6 +1,9 @@
 $include-html: false !default;
 
 @if ($include-html) {
+  html {
+    font-size: $baseFont;
+  }
 
   * {
     box-sizing: border-box;
@@ -15,7 +18,7 @@ $include-html: false !default;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
-    font-size: $baseFont;
+    font-size: fontSize(default);
     font-family: $fontFamilyPrimary;
     line-height: $baseline;
   }

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -15,7 +15,7 @@ $include-html: false !default;
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
 
-    font-size: $base-font;
+    font-size: $baseFont;
     font-family: $fontFamilyPrimary;
     line-height: $baseline;
   }

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -45,9 +45,8 @@ $grayAltLight: #E9ECEE;
 $defaultBottomShadow: 0px 3px 5px -1px rgba(0, 0, 0, 0.25);
 
 // Fonts
-$fontFamilyPrimary: 'ProximaNovaRegular', 'Helvetica', 'Arial', sans-serif;
-$fontFamilySecondary: 'ProximaNovaExtrabold', 'Helvetica', 'Arial', sans-serif;
-$fontFamilyEmphasized: 'ProximaNovaBlack', 'Helvetica', 'Arial', sans-serif;
+$fontFamilyPrimary: 'ProximaNova', 'Helvetica', 'Arial', sans-serif;
+$fontWeightBlack: 500;
 
 // Icons
 $iconBoostValue: 4px;

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -52,6 +52,10 @@ $fontFamilyEmphasized: 'ProximaNovaBlack', 'Helvetica', 'Arial', sans-serif;
 // Icons
 $iconBoostValue: 4px;
 
+// Vertical rhythm
+$base-font: 16px;
+$baseline: 1.5rem;
+
 // Layout
 $layoutMaximumWidth: 960px;
 $layoutDefaultPadding: 24px;

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -52,10 +52,23 @@ $fontWeightBlack: 500;
 $iconBoostValue: 4px;
 
 // Vertical rhythm
-$base-font: 16px;
+$baseFont: 16px;
 $baseline: 1.5rem;
 
-// Layout
+// Typo
+$fontSizes: (
+  default: 1rem,      // 16px
+  tiny: 0.625rem,     // 10px
+  obscure: 0.75rem,   // 12px
+  small: 0.8125rem,   // 13px
+  large: 3.625rem,    // 58px
+  standout: 1.125rem, // 18px
+  headline: 1.75rem,  // 28px
+  header: 3rem        // 48px
+);
+
+
+  // Layout
 $layoutMaximumWidth: 960px;
 $layoutDefaultPadding: 24px;
 $defaultComponentHeight: 20px;

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -49,7 +49,7 @@ $fontFamilyPrimary: 'ProximaNova', 'Helvetica', 'Arial', sans-serif;
 $fontWeightBlack: 500;
 
 // Icons
-$iconBoostValue: 4px;
+$iconBoostValue: 0.25rem;
 
 // Vertical rhythm
 $baseFont: 16px;
@@ -59,9 +59,10 @@ $baseline: 1.5rem;
 $fontSizes: (
   default: 1rem,      // 16px
   tiny: 0.625rem,     // 10px
-  obscure: 0.75rem,   // 12px
   small: 0.8125rem,   // 13px
+  medium: 0.9375rem,  // 15px
   large: 3.625rem,    // 58px
+  obscure: 0.75rem,   // 12px
   standout: 1.125rem, // 18px
   headline: 1.75rem,  // 28px
   header: 3rem        // 48px

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -58,7 +58,7 @@ $baseline: 1.5rem;
 // Typo
 $fontSizes: (
   default: 1rem,      // 16px
-  tiny: 0.625rem,     // 10px
+  xsmall: 0.625rem,     // 10px
   small: 0.8125rem,   // 13px
   medium: 0.9375rem,  // 15px
   large: 3.625rem,    // 58px

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -62,6 +62,8 @@ $fontSizes: (
   small: 0.8125rem,   // 13px
   medium: 0.9375rem,  // 15px
   large: 3.625rem,    // 58px
+  xlarge: 4.5rem,     // 72px
+  xxlarge: 5rem,      // 80px
   obscure: 0.75rem,   // 12px
   standout: 1.125rem, // 18px
   headline: 1.75rem,  // 28px

--- a/src/sass/_fonts.scss
+++ b/src/sass/_fonts.scss
@@ -3,24 +3,24 @@ $include-html: false !default;
 @if ($include-html) {
 
   @font-face {
-    font-family: 'ProximaNovaRegular';
+    font-family: 'ProximaNova';
     src: url($mintFontsPath + 'ProximaNova-Regular.woff') format('woff');
     font-weight: normal;
     font-style: normal;
   }
 
   @font-face {
-    font-family: 'ProximaNovaExtrabold';
+    font-family: 'ProximaNova';
     src: url($mintFontsPath + 'ProximaNova-Extrabold.woff') format('woff');
     font-weight: bold;
     font-style: normal;
   }
 
   @font-face {
-    font-family: 'ProximaNovaBlack';
+    font-family: 'ProximaNova';
     src: url($mintFontsPath + 'ProximaNova-Black.woff') format('woff');
-    font-weight: bold;
+    font-weight: $fontWeightBlack;
     font-style: normal;
   }
-
+  
 }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -1,4 +1,4 @@
-@mixin image-2x($image, $width:"auto", $height:"auto") {
+@mixin image-2x($image, $width: "auto", $height: "auto") {
   @media (min-resolution: 144dpi) {
     /* on retina, use image that's scaled by 2 */
     background-image: url($image);
@@ -15,7 +15,7 @@
   margin: 0;
 }
 
-@mixin hole(){
+@mixin hole() {
   &__hole {
     display: flex;
     align-items: center;
@@ -24,38 +24,52 @@
   }
 }
 
-// $line-height-offset is a way to fix font issue with the baseline
+// $lineHeight-offset is a way to fix font issue with the baseline
 // the issue is visible when centering the text of at least 12px
-@mixin fixText($fontSize, $lineHeightOffset: 0){
+@mixin fixText($fontSize, $lineHeightOffset: 0) {
   font-size: $fontSize;
   height: $fontSize;
   line-height: $fontSize + $lineHeightOffset;
 }
 
-@mixin icon($name){
+@mixin icon($name) {
   @extend .mint-icon-#{$name};
   &:before {
     display: inline-block;
   }
 }
 
-// Used for messing with fonts and baseline
-// Sets the font size and line height
-// fontsize - rem
-// line-height - rem
-@mixin type-variant($fontsize, $line-height, $shift: 0, $push: 0){
-
-  $rem-fontsize: $fontsize * 1rem;
-  $rem-lineheight: $line-height * $baseline;
-
-  font-size: $rem-fontsize;
-  line-height: $rem-lineheight;
-  padding-top: $shift * 1rem;
-  margin-bottom: $push * 1rem;
+@function fontSize($fontsizeKey) {
+  @return map-get($fontSizes, $fontsizeKey);
 }
 
+// Used for messing with fonts and baseline
+// Sets the font size and line height
+// fontsizeName - string
+// lineHeight - int, number of baselines
+@mixin typeVariant($fontsizeName, $lineHeight: null, $shift: null, $push: null) {
+
+  $remFontsize: fontSize($fontsizeName);
+
+  @if $remFontsize != null {
+    font-size: $remFontsize;
+  }
+
+  @if $lineHeight != null {
+    $remLineHeight: rhythm($lineHeight);
+    line-height: $remLineHeight;
+  }
+
+  @if $shift != null {
+    padding-top: $shift * 1rem;
+  }
+
+  @if $push != null {
+    margin-bottom: $push * 1rem;
+  }
+}
 
 // set a value as a multiple of baselines
-@function rhythm($baselines){
+@function rhythm($baselines) {
   @return $baselines * $baseline;
 }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -11,6 +11,7 @@
   position: relative;
   overflow: hidden;
   text-overflow: ellipsis;
+  margin: 0;
 }
 
 @mixin hole(){
@@ -35,4 +36,25 @@
   &:before {
     display: inline-block;
   }
+}
+
+// Used for messing with fonts and baseline
+// Sets the font size and line height
+// fontsize - rem
+// line-height - rem
+@mixin type-variant($fontsize, $line-height, $shift: 0, $push: 0){
+
+  $rem-fontsize: $fontsize * 1rem;
+  $rem-lineheight: $line-height * $baseline;
+
+  font-size: $rem-fontsize;
+  line-height: $rem-lineheight;
+  padding-top: $shift * 1rem;
+  margin-bottom: $push * 1rem;
+}
+
+
+// set a value as a multiple of baselines
+@function rhythm($baselines){
+  @return $baselines * $baseline;
 }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -61,11 +61,11 @@
   }
 
   @if $shift != null {
-    padding-top: $shift * 1rem;
+    padding-top: rhythm($shift);
   }
 
   @if $push != null {
-    margin-bottom: $push * 1rem;
+    margin-bottom: rhythm($push);
   }
 }
 

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -11,6 +11,7 @@
   position: relative;
   overflow: hidden;
   text-overflow: ellipsis;
+  line-height: 0.8 * $baseline; // take descenders into account for small inline-block elements
   margin: 0;
 }
 

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -16,13 +16,25 @@
   margin: 0;
 }
 
+// this mixin allows inserting inline-based components without concerns about vertical dimension
+@mixin components-container() {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
 @mixin hole() {
   &__hole {
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    @include components-container();
     height: 100%;
   }
+}
+
+// this mixin remove additional space for ascenders/descenders
+// should be applied for inline-block elements with height < line-height
+@mixin remove-descenders() {
+  line-height: rhythm(0.66);
+  min-height: auto;
 }
 
 // $lineHeight-offset is a way to fix font issue with the baseline

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -19,14 +19,15 @@
 // this mixin allows inserting inline-based components without concerns about vertical dimension
 @mixin components-container() {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  justify-content: center;
 }
 
 @mixin hole() {
   &__hole {
     @include components-container();
     height: 100%;
+    justify-content: center;
   }
 }
 

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -11,7 +11,8 @@
   position: relative;
   overflow: hidden;
   text-overflow: ellipsis;
-  line-height: 0.8 * $baseline; // take descenders into account for small inline-block elements
+  line-height: rhythm(1);
+  min-height: rhythm(1);
   margin: 0;
 }
 

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -18,6 +18,8 @@ $mintFontsPath: 'fonts/' !default;
 @import "../components/dropdowns/dropdowns";
 @import "../components/text/text";
 @import "../components/text/headers";
+@import "../components/text/text-bits";
+@import "../components/text/links";
 @import "../components/bubble/bubble";
 @import "../components/search/search";
 @import "../components/avatar/avatar";


### PR DESCRIPTION
**Note**: this PR will be merged into `master` and will be a huge breaking change!

Close #13 
Close #101 
Close #230
Close #192
Close #112

Relates to #103, #104, #108.

Mockup used: http://typecast.com/QhQQkkddGr/share/87eeaf5d967424f871d1236edad36ee3d46a85b6KrPQgjrbw

Incorporate changes from: https://github.com/brainly/style-guide/pull/254 https://github.com/brainly/style-guide/pull/271 https://github.com/brainly/style-guide/pull/291
## Changes

This PR introduces changes to the whole code base and touches almost every non-trivial component.

#### Font Map and `fontSize` function

From now on there is a font map, which incorporates all possible font sizes which should be used across components.
There are 2 axes:

* 2D dimensions for "labels" ("labels" is a set of text-based components which are not supposed to wrap more than in 2 lines and cannot change it's size arbitrary. E.g. Text Bit is a "label".): `default, tiny, small, medium, large, xlarge, xxlarge`
* Importance dimension for copy text (headers, content text): `default, obscure, standout, headline, header`


```
$fontSizes: (
  default: 1rem,      // 16px
  tiny: 0.625rem,     // 10px
  small: 0.8125rem,   // 13px
  medium: 0.9375rem,  // 15px
  large: 3.625rem,    // 58px
  xlarge: 4.5rem,     // 72px
  xxlarge: 5rem,      // 80px
  obscure: 0.75rem,   // 12px
  standout: 1.125rem, // 18px
  headline: 1.75rem,  // 28px
  header: 3rem        // 48px
);
```

Ideally, this map should not change.

Additionally, there is a function for getting font size based on size name, `fontSize`:
```
font-size: fontSize(small);
```

#### `rhythm` function

There is a function for easier adding sizes, which are multiples of `$baseline`:

```
height: rhythm(10); // translates to 15rem == 240px by default
margin-bottom: rhythm(1/2);
```

The usage is the same as in ruby's `compass`.

#### `typeVariant` mixin

Used to set up copy text properties. 
Allows text to be pushed to baseline.

See details: https://github.com/brainly/style-guide/pull/254

#### `components-container` mixin

Used in containers to mark holes, where other arbitrary components can go.
Uses flexbox + wrap + vertical centering by default.

## Pending Refactors

1. `mint-checkbox` implementation need to be reconsidered #299
1. `mint-list` should be transformed to container using flexbox #104 
1. `mint-promo-box` should be revisited #300
1. Introduce `inline-component`/`small-component` #301
1. Make positioning using flexbox  #103  - will help to deal with `inline-block` elements problems (descenders, repositioned baseline, baseline vs overflow:hidden)
1. Letter spacing for uppercase text in labels/components #302
1. figure out a better way of triggering the rhythm guidelines #303
1. omit `$fontWeightBlack` variable usage - use `bolder` instead #304
1. Separators should be revisited #305

## Breaking Changes

Containers:

* `mint-bubble`, added `__hole`
* `mint-box`, added `__hole`
* `mint-content-box`, added `__title`
* `footer` lost all original styling for holes. Use `mint-link` and `mint-text` instead!

Components: 

* `.mint-breadcrumb-list` lost its specific text styles. Now it is more like a container - you can put arbitrary text blocks inside.

Text:


```
mint-text-block -> mint-text--obscure
mint-text-description -> mint-text--standout
mint-text-description--large -> mint-headline
mint-text-description--large + bold -> mint-header-primary--small
```

These things have changed it dimensions and MAY need refactoring:

```
mint-header-primary -> mint-text-bit
mint-header-primary--small -> mint-text-bit--small
mint-text-emphasised -> mint-text--emphasised
```