### PR TITLE
Make box-sizing:border-box global. Fixes #260

### DIFF
--- a/src/components/footer/_footer.scss
+++ b/src/components/footer/_footer.scss
@@ -9,7 +9,6 @@ $include-html: false !default;
 
     &__container {
       position: relative;
-      box-sizing: border-box;
       padding: $layoutDefaultPadding $layoutDefaultPadding;
 
       @media (min-width: $breakpointTablet) {

--- a/src/components/form-elements/_form-elements.scss
+++ b/src/components/form-elements/_form-elements.scss
@@ -238,7 +238,6 @@ $include-html: false !default;
       background: $crInputCheckedColor;
     }
     &__ghost {
-      box-sizing: border-box;
       background: $crInputColor;
       width: 100%;
       height: 100%;

--- a/src/components/header/_header.scss
+++ b/src/components/header/_header.scss
@@ -14,7 +14,6 @@ $include-html: false !default;
     @include image-2x($mintImagesPath + 'header_background_wide@2x.jpg', auto, $headerHeight);
 
     &__container {
-      box-sizing: border-box;
       display: flex;
       width: 100%;
       height: 100%;

--- a/src/components/list/_list.scss
+++ b/src/components/list/_list.scss
@@ -78,7 +78,6 @@ $include-html: false !default;
     @include mint-list-basic-styles();
     font-family: $listDefaultFont;
     &__element {
-      box-sizing: border-box;
       height: 35px;
       line-height: 35px;
       border-bottom: 1px dashed $menuListBorderColor;

--- a/src/docs/_sass/_color-box.scss
+++ b/src/docs/_sass/_color-box.scss
@@ -1,5 +1,4 @@
 .color-box {
-  box-sizing: border-box;
   color: $black;
   display: inline-block;
   height: $colorBoxDimension;

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -10,7 +10,6 @@
   }
   &__info {
     flex: 0 1 auto;
-    box-sizing: border-box;
     padding: 0 20px 0 0;
     width: 230px;
   }

--- a/src/docs/_sass/main.scss
+++ b/src/docs/_sass/main.scss
@@ -1,6 +1,7 @@
 @charset "utf-8";
 
-@import "../../sass/config"; //style guide variables
+@import "../../sass/config";
+//style guide variables
 @import "../_sass/config";
 @import "../_sass/colors-list";
 @import "../_sass/color-box";
@@ -17,6 +18,11 @@ html, body {
 
 body {
   margin: 50px 10px;
+}
+
+iframe {
+  border: none;
+  box-shadow: black 0 0 0 4px;
 }
 
 .data-container {

--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -2,6 +2,15 @@ $include-html: false !default;
 
 @if ($include-html) {
 
+  * {
+    box-sizing: border-box;
+  }
+
+  *:before,
+  *:after {
+    box-sizing: border-box;
+  }
+
   body {
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -7,7 +7,6 @@
 }
 
 @mixin component {
-  box-sizing: border-box;
   display: inline-block;
   position: relative;
   overflow: hidden;


### PR DESCRIPTION
Added border-box globally, removed it from components.

Only thing that broke are iframes in the styleguide, but I replaced default iframe border with a shadow:

<img width="320" alt="screen shot 2015-09-16 at 09 46 51" src="https://cloud.githubusercontent.com/assets/985504/9902058/ebc2af02-5c6b-11e5-9921-eb1bdac398fc.png">

<img width="406" alt="screen shot 2015-09-16 at 12 10 50" src="https://cloud.githubusercontent.com/assets/985504/9902073/fea345a0-5c6b-11e5-9199-b2fc8dcfde59.png">
