### PR TITLE
Added --large modifier for label

### DIFF
--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -4,8 +4,10 @@ $labelInactiveColor: $grayAlt;
 $labelFontWeight: $fontWeightBlack;
 $labelFontSizePrimary: fontSize(obscure);
 $labelFontSizeSecondary: fontSize(xsmall);
+$labelFontSizeLarge: fontSize(standout);
 $labelIconSizePrimary: 16px;
 $labelIconSizeSecondary: 14px;
+$labelIconSizeLarge: 24px;
 $labelScaleFactor: 2 / 3;
 
 $includeHtml: false !default;
@@ -135,6 +137,25 @@ $includeHtml: false !default;
         margin-right: $labelScaleFactor * gutter(0.25);
         font-size: $labelIconSizeSecondary;
       }
+    }
+
+    &--large {
+      .mint-label__text,
+      .mint-label__number {
+        @include fixText($labelFontSizeLarge);
+        text-transform: none;
+
+
+        &:last-child {
+          margin-right: 0;
+        }
+      }
+
+      .mint-label__icon {
+        font-size: $labelIconSizeLarge;
+        margin-right: gutter(0.5);
+      }
+
     }
   }
 

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -145,7 +145,6 @@ $includeHtml: false !default;
         @include fixText($labelFontSizeLarge);
         text-transform: none;
 
-
         &:last-child {
           margin-right: 0;
         }

--- a/src/components/labels/labels.html
+++ b/src/components/labels/labels.html
@@ -48,3 +48,28 @@
         </div>
     </div>
 </section>
+<section class="docs-block">
+    <aside class="docs-block__info">
+        <h3 class="docs-block__header">Large</h3>
+    </aside>
+
+    <div class="docs-block__content">
+        <div class="mint-label mint-label--large">
+            <div class="mint-label__icon mint-label__icon--excellent"></div>
+            <div class="mint-label__text">Mark as best</div>
+        </div>
+        <div class="mint-label mint-label--secondary mint-label--large">
+            <div class="mint-label__icon mint-label__icon--comment"></div>
+            <div class="mint-label__text">Comment</div>
+            <div class="mint-label__number">21</div>
+        </div>
+        <div class="mint-label mint-label--secondary mint-label--large">
+            <div class="mint-label__icon mint-label__icon--heart"></div>
+            <div class="mint-label__text">Thank you</div>
+            <div class="mint-label__number">21</div>
+        </div>
+        <div class="mint-label mint-label--inactive mint-label--large">
+            <div class="mint-label__text">Inactive label</div>
+        </div>
+    </div>
+</section>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/180

<img width="592" alt="screen shot 2015-09-22 at 10 41 58" src="https://cloud.githubusercontent.com/assets/1231144/10014018/aca53290-6116-11e5-87fa-b403c95e0dff.png">