### PR TITLE
Change browser support to the last two versions + opera mini.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -38,7 +38,7 @@ gulp.task('sass:build', function () {
         .pipe(sass({outputStyle: 'compressed'})
         .on('error', sass.logError))
         .pipe(autoprefixer({
-            browsers: ['last 2 versions', 'ie 8', 'ie 9'],
+            browsers: ['last 2 versions', 'op_mini'],
             cascade: false
         }))
         .pipe(rename('style-guide.css'))
@@ -53,7 +53,7 @@ gulp.task('sass:docs-build', function () {
         .pipe(sass({outputStyle: 'compressed'})
         .on('error', sass.logError))
         .pipe(autoprefixer({
-            browsers: ['last 2 versions', 'ie 8', 'ie 9'],
+            browsers: ['last 2 versions', 'op_mini'],
             cascade: false
         }))
         .pipe(rename('main.css'))


### PR DESCRIPTION
It was bothering me for a while - why we had ie8/9 support there? I'm not 100% about these new settings, just wanted to open a quick discussion.