### PR TITLE
Add warning and error text options

### DIFF
--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -40,6 +40,14 @@ $includeHtml: false !default;
     &--for-fine-print {
       color: $blueSecondary;
     }
+
+    &--warning {
+      color: $mustardPrimary;
+    }
+
+    &--error {
+      color: $peachPrimary;
+    }
   }
 
 }

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -63,6 +63,14 @@
         <div class="mint-text mint-text--obscure mint-text--for-fine-print">
             <br>
             This is a fine print example
+        </div>
+        <div class="mint-text mint-text--emphasised mint-text--warning">
+            <br>
+            This is a warning example
+        </div>
+        <div class="mint-text mint-text--emphasised mint-text--error">
+            <br>
+            This is a error example
             <br><br>
         </div>
         <div class="docs-block__contrast-box">


### PR DESCRIPTION
closes #379
<img width="288" alt="screen shot 2015-09-30 at 14 38 52" src="https://cloud.githubusercontent.com/assets/316313/10193106/53e191fa-6781-11e5-9472-23e0c7a31eaa.png">
