### PR TITLE
Fix issue in safari rating/badges/labels

### DIFF
--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -15,7 +15,7 @@ $includeHtml: false !default;
     @include fixText($badgeFontSize);
     @include uppercaseText;
     overflow: visible; // allow badges align as text
-    min-height: auto;
+    min-height: 0;
     height: auto;
 
     border-radius: $badgeFontSize;

--- a/src/components/form-elements/select.html
+++ b/src/components/form-elements/select.html
@@ -6,7 +6,7 @@
         <div class="mint-select">
             <div class="mint-select__icon">
                 <svg class="mint-icon mint-icon--fluid mint-icon--gray-alt">
-                    <use xlink:href="#icons-arrow_down"></use>
+                    <use xlink:href="#icon-arrow_down"></use>
                 </svg>
             </div>
             <select class="mint-select__element">
@@ -19,7 +19,7 @@
         <div class="mint-select mint-select--invalid">
             <div class="mint-select__icon">
                 <svg class="mint-icon mint-icon--fluid mint-icon--gray-alt">
-                    <use xlink:href="#icons-arrow_down"></use>
+                    <use xlink:href="#icon-arrow_down"></use>
                 </svg>
             </div>
             <select class="mint-select__element">
@@ -30,7 +30,7 @@
         <div class="mint-select mint-select--full">
             <div class="mint-select__icon">
                 <svg class="mint-icon mint-icon--fluid mint-icon--gray-alt">
-                    <use xlink:href="#icons-arrow_down"></use>
+                    <use xlink:href="#icon-arrow_down"></use>
                 </svg>
             </div>
             <select class="mint-select__element">
@@ -41,7 +41,7 @@
         <div class="mint-select mint-select--small">
             <div class="mint-select__icon">
                 <svg class="mint-icon mint-icon--fluid mint-icon--gray-alt">
-                    <use xlink:href="#icons-arrow_down"></use>
+                    <use xlink:href="#icon-arrow_down"></use>
                 </svg>
             </div>
             <select class="mint-select__element">

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -88,6 +88,8 @@ $includeHtml: false !default;
     }
 
     &--small {
+      min-height: 0;
+
       .mint-label__text,
       .mint-label__number {
         @include fixText($labelFontSizeSecondary);

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -62,7 +62,7 @@ $includeHtml: false !default;
 
     &--small {
       height: rhythm(0.667);
-      min-height: rhythm(0.667);
+      min-height: 0;
 
       .mint-rate-box__star {
         height: $rateSmallIconSize;
@@ -71,7 +71,6 @@ $includeHtml: false !default;
 
       .mint-rate-box__counter {
         @include fixText($rateSmallFontSize, 0.125rem);
-        margin-left: gutter(0.25);
       }
     }
   }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -8,7 +8,6 @@ $rateFontSize: fontSize(obscure);
 $rateIconSize: rhythm(0.75);
 $rateSmallFontSize: fontSize(xsmall);
 $rateSmallIconSize: rhythm(0.667);
-$rateScaleFactor: 2 / 3;
 
 $includeHtml: false !default;
 
@@ -62,8 +61,8 @@ $includeHtml: false !default;
     }
 
     &--small {
-      @include fixText($rateSmallFontSize);
-      height: $rateScaleFactor * $rateHeight;
+      height: rhythm(0.667);
+      min-height: rhythm(0.667);
 
       .mint-rate-box__star {
         height: $rateSmallIconSize;
@@ -71,7 +70,7 @@ $includeHtml: false !default;
       }
 
       .mint-rate-box__counter {
-        @include fixText($rateSmallFontSize);
+        @include fixText($rateSmallFontSize, 0.125rem);
         margin-left: gutter(0.25);
       }
     }

--- a/src/components/separators/_horizontal-separator.scss
+++ b/src/components/separators/_horizontal-separator.scss
@@ -7,7 +7,7 @@ $includeHtml: false !default;
 
   .mint-horizontal-separator {
     @include component();
-    min-height: auto;
+    min-height: 0;
     display: block;
     height: $horizontalSeparatorHeight;
     border-bottom: $horizontalSeparatorHeight dotted $horizontalSeparatorColor;

--- a/src/components/separators/_separators.scss
+++ b/src/components/separators/_separators.scss
@@ -10,7 +10,7 @@ $includeHtml: false !default;
 
   .mint-separator {
     @include component;
-    min-height: auto;
+    min-height: 0;
 
     margin-right: $separatorSpacing;
     border-right: solid $separatorColor 1px;

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -35,7 +35,7 @@
 // should be applied for inline-block elements with height < line-height
 @mixin removeDescenders() {
   line-height: rhythm(0.66);
-  min-height: auto;
+  min-height: 0;
 }
 
 // $lineHeightOffset is a way to fix font issue with the baseline
@@ -44,16 +44,6 @@
   font-size: $fontSize;
   height: $fontSize;
   line-height: $fontSize + $lineHeightOffset;
-}
-
-@mixin icon($name) {
-  // scss-lint:disable PlaceholderInExtend
-  @extend .mint-icon-#{$name};
-  // scss-lint:enable PlaceholderInExtends
-
-  &:before {
-    display: inline-block;
-  }
 }
 
 @function fontSize($fontsizeKey) {


### PR DESCRIPTION
closes #383
closes #354
<img width="489" alt="screen shot 2015-09-30 at 15 58 22" src="https://cloud.githubusercontent.com/assets/316313/10195160/8afcf6f6-678c-11e5-9f10-517856a6236a.png">
<img width="485" alt="screen shot 2015-09-30 at 15 58 29" src="https://cloud.githubusercontent.com/assets/316313/10195163/8b00661a-678c-11e5-87bd-75ca26e69257.png">
<img width="583" alt="screen shot 2015-09-30 at 15 58 42" src="https://cloud.githubusercontent.com/assets/316313/10195161/8afe4bf0-678c-11e5-889c-abbeacb8ddb4.png">
<img width="587" alt="screen shot 2015-09-30 at 15 58 51" src="https://cloud.githubusercontent.com/assets/316313/10195162/8b003410-678c-11e5-830b-683314ba91d7.png">

Small labels, small rating box and badge can't have min-height of vertical rhythm as they not fit buttons.

For now min-height is disabled for those small elements.

We can keep it that way and add some modifier to use those elements as standalone components (with margin compensation for it). We can make this min-height: 0 as some modifier and apply it when used in buttons etc. Maybe other ideas?

@mr-mig @kdzwinel @vergilius @matzimowski 