### PR TITLE
Fix background color fallback (it was removed by the plugin as it was…

### DIFF
--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -127,10 +127,11 @@ $includeHtml: false !default;
 @mixin mintButtonPrimaryThreeColorVariant($buttonColor, $gradientColor, $buttonShadowColor: null) {
   background-color: $buttonColor;
   // scss-lint:disable NameFormat
-  background: $gradientColor linear-gradient(170deg, $gradientColor 0%, $gradientColor 50%, $buttonColor 51%, $buttonColor 100%) no-repeat;
+  background-image: linear-gradient(170deg, $gradientColor 0%, $gradientColor 50%, $buttonColor 51%, $buttonColor 100%);
   // scss-lint:disable NameFormat
   background-size: 100% 140%;
   background-position: 0 -10px;
+  background-repeat: no-repeat;
 
   @if ($buttonShadowColor) {
     box-shadow: 0 -1px 0 $buttonShadowColor inset;


### PR DESCRIPTION
… overridden by background declaration)
closes https://github.com/brainly/style-guide/issues/445
Default (no gradient)
![screen shot 2015-10-22 at 11 47 49](https://cloud.githubusercontent.com/assets/316313/10662218/4b56e07e-78b3-11e5-8a34-9da503261752.png)

Hover (no gradient)
![screen shot 2015-10-22 at 11 47 53](https://cloud.githubusercontent.com/assets/316313/10662219/4b6c5760-78b3-11e5-8b5a-8f4d1e1bb9b4.png)