### PR TITLE
Add missing icon size

### DIFF
--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -1,6 +1,6 @@
 $includeHtml: false !default;
 
-$iconSizes: 48, 44, 38, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10, 8;
+$iconSizes: 140, 48, 44, 38, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10, 8;
 
 // Icon sizes :(
 // 48 - avatar large

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -1,6 +1,6 @@
 $includeHtml: false !default;
 
-$iconSizes: 140, 48, 44, 38, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10, 8;
+$iconSizes: 120, 48, 44, 38, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10, 8;
 
 // Icon sizes :(
 // 48 - avatar large

--- a/src/components/icons/icons.html
+++ b/src/components/icons/icons.html
@@ -36,7 +36,7 @@
   <div class="docs-block__content">
     <ul class="icons-list">
       {% for size in site.data.icons.sizes %}
-        <li class="icons-list__element">
+        <li class="icons-list__element icons-list__element--wider">
           <svg class="mint-icon mint-icon--x{{ size }} mint-icon--gray-alt">
             <use xlink:href="#icon-x"></use>
           </svg>

--- a/src/docs/_data/icons.yml
+++ b/src/docs/_data/icons.yml
@@ -27,7 +27,7 @@ names:
   - symbols
   - x
 sizes:
-  - 140
+  - 120
   - 48
   - 44
   - 38

--- a/src/docs/_data/icons.yml
+++ b/src/docs/_data/icons.yml
@@ -27,6 +27,7 @@ names:
   - symbols
   - x
 sizes:
+  - 140
   - 48
   - 44
   - 38

--- a/src/docs/_sass/main.scss
+++ b/src/docs/_sass/main.scss
@@ -80,6 +80,10 @@ article {
     display: flex;
     align-items: center;
 
+    &--wider {
+      width: 33%;
+    }
+
     &--wide {
       width: 50%;
     }


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/484
<img width="590" alt="screen shot 2015-10-30 at 11 05 31" src="https://cloud.githubusercontent.com/assets/316313/10842980/2cd3731c-7ef6-11e5-8caf-e38077c92fea.png">

