### PR TITLE
Added js + svg + font to s3_website gzip definition

### DIFF
--- a/s3_website.yml
+++ b/s3_website.yml
@@ -20,6 +20,15 @@ gzip:
    - .html
    - .css
    - .md
+   - .js
+   - .svg
+   - .json
+   - .ico
+   - .eot
+   - .otf
+   - .ttf
+   # see https://www.fastly.com/blog/new-gzip-settings-and-deciding-what-to-compress
+
 # gzip_zopfli: true
 
 # See http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region for valid endpoints


### PR DESCRIPTION
I've added new definitions for gzip.

After PR is merged I will deploy the `prerelease` version **manually** to forcibly oveeride the files on s3.

**It will affect the old js-icons/svgs**. Those files should be served gzipped for v20.