### PR TITLE
Added opera mini fix for label font

### DIFF
--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -23,6 +23,8 @@ $includeHtml: false !default;
     &__text,
     &__number {
       @include fixText($labelFontSizePrimary, 2 / 16);
+      @include fixOperaMiniLabelText;
+
       display: block;
       color: $labelPrimaryColor;
       font-weight: $fontWeightBlack;
@@ -93,6 +95,8 @@ $includeHtml: false !default;
       .mint-label__text,
       .mint-label__number {
         @include fixText($labelFontSizeSecondary);
+        @include fixOperaMiniLabelText;
+
         margin-right: $labelScaleFactor * gutter(0.25);
         overflow: visible;
 
@@ -112,6 +116,7 @@ $includeHtml: false !default;
       .mint-label__text,
       .mint-label__number {
         @include fixText($labelFontSizeLarge);
+        @include fixOperaMiniLabelText;
 
         &:last-child {
           margin-right: 0;

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -55,6 +55,8 @@ $includeHtml: false !default;
     &__counter {
       @include fixText($rateFontSize, 0.125rem);
       @include uppercaseText;
+      @include fixOperaMiniLabelText;
+
       font-weight: $fontWeightBlack;
       color: $rateCounterColor;
       margin: 0 0 0 gutter(0.25);
@@ -71,6 +73,7 @@ $includeHtml: false !default;
 
       .mint-rate-box__counter {
         @include fixText($rateSmallFontSize, 0.125rem);
+        @include fixOperaMiniLabelText;
       }
     }
   }

--- a/src/sass/_fixes.scss
+++ b/src/sass/_fixes.scss
@@ -1,0 +1,17 @@
+@mixin fixText($fontSize, $lineHeightOffset: 0) {
+  // $lineHeightOffset is a way to fix font issue with the baseline
+  // the issue is visible when vertically centering the text of at least 12px
+  font-size: $fontSize;
+  height: $fontSize;
+  line-height: $fontSize + $lineHeightOffset;
+}
+
+@mixin fixOperaMiniLabelText {
+  // these styles fixes the vertical centering and visibility of label text on opera mini
+  // https://github.com/brainly/style-guide/issues/482
+  // https://github.com/brainly/style-guide/issues/489
+  // scss-lint:disable ImportantRule
+  line-height: 1 !important;
+  // scss-lint:enable ImportantRule
+  overflow: visible;
+}

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -38,14 +38,6 @@
   min-height: 0;
 }
 
-// $lineHeightOffset is a way to fix font issue with the baseline
-// the issue is visible when centering the text of at least 12px
-@mixin fixText($fontSize, $lineHeightOffset: 0) {
-  font-size: $fontSize;
-  height: $fontSize;
-  line-height: $fontSize + $lineHeightOffset;
-}
-
 @function fontSize($fontsizeKey) {
   // scss-lint:disable NameFormat
   @return map-get($fontSizes, $fontsizeKey);

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -4,6 +4,7 @@ $mintFontsPath: 'fonts/' !default;
 
 @import 'config';
 @import 'mixins';
+@import 'fixes';
 @import 'helpers';
 @import 'fonts';
 @import 'basics';


### PR DESCRIPTION
Fixed #482 
Fixed #489 

Labels::
![image](https://cloud.githubusercontent.com/assets/1062491/10885032/8e0da260-817b-11e5-9169-bc56d048c31d.png)


Buttons with labels:
![image](https://cloud.githubusercontent.com/assets/1062491/10885022/81ad052e-817b-11e5-900a-fa4dc1b367c6.png)