### PR TITLE
Added --short modifier for breadcrumbs

### DIFF
--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -25,6 +25,11 @@ $includeHtml: false !default;
       }
     }
 
+    &--short {
+      line-height: 1rem;
+      min-height: 1rem;
+    }
+
     &--for-fine-print {
       font-size: fontSize(small);
       color: $breadcrumbListBlueSeparatorColor;

--- a/src/components/breadcrumbs/breadcrumbs.html
+++ b/src/components/breadcrumbs/breadcrumbs.html
@@ -48,3 +48,21 @@
     </div>
   </div>
 </section>
+<section class="docs-block">
+  <aside class="docs-block__info">
+    <h3 class="docs-block__header">Short</h3>
+  </aside>
+  <div class="docs-block__content">
+    <ul class="mint-breadcrumb-list mint-breadcrumb-list--short">
+      <li class="mint-breadcrumb-list__element">
+        <a class="mint-link" href="#">Comments (9)</a>
+      </li>
+      <li class="mint-breadcrumb-list__element">
+        <a class="mint-link" href="#">Report</a>
+      </li>
+      <li class="mint-breadcrumb-list__element">
+        <a class="mint-link" href="#">Follow</a>
+      </li>
+    </ul>
+  </div>
+</section>


### PR DESCRIPTION
Fixes #417 

The size of these breadcrumbs vertically is smaller, then the default one - it can be incorporated in text... (though, not visible on a screenshot)

![image](https://cloud.githubusercontent.com/assets/1062491/11004181/0fe9ee0e-84b7-11e5-9eaf-a14435273a3c.png)
