### PR TITLE
Update mint-text add 'small' option

### DIFF
--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -15,6 +15,10 @@ $includeHtml: false !default;
       @include typeVariant(obscure, 1);
     }
 
+    &--small {
+      @include typeVariant(small, 0.75);
+    }
+
     &--headline {
       @include typeVariant(headline, 1.334);
       font-weight: $fontWeightNormal;

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -60,6 +60,11 @@
             This text is not really intended to be read
             <br>
         </div>
+        <div class="mint-text mint-text--small">
+          <br>
+          This text is small but you should be able to read it
+          <br>
+        </div>
         <div class="mint-text mint-text--obscure mint-text--for-fine-print">
             <br>
             This is a fine print example


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/442