### PR TITLE
Update font family for labels, rating and primary headers

### DIFF
--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -63,7 +63,7 @@ $includeHtml: false !default;
     }
 
     &--emphasised {
-      @include uppercaseText;
+      @include uppercaseText(0);
     }
 
     &--secondary {

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -27,7 +27,7 @@ $includeHtml: false !default;
 
       display: block;
       color: $labelPrimaryColor;
-      font-weight: $fontWeightBlack;
+      font-weight: $fontWeightBold;
       margin-right: gutter(0.25);
 
       &:last-child {

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -57,7 +57,7 @@ $includeHtml: false !default;
       @include uppercaseText;
       @include fixOperaMiniLabelText;
 
-      font-weight: $fontWeightBlack;
+      font-weight: $fontWeightBold;
       color: $rateCounterColor;
       margin: 0 0 0 gutter(0.25);
     }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -54,7 +54,7 @@ $includeHtml: false !default;
 
     &__counter {
       @include fixText($rateFontSize, 0.125rem);
-      @include uppercaseText;
+      @include uppercaseText(0);
       @include fixOperaMiniLabelText;
 
       font-weight: $fontWeightBold;

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -8,7 +8,13 @@ $includeHtml: false !default;
     display: block;
     color: $black;
     font-weight: $fontWeightBold;
+    letter-spacing: -1px;
     margin-bottom: rhythm(1);
+
+    @include mintBreakpoint('medium-up') {
+      font-weight: $fontWeightBlack;
+      letter-spacing: 0;
+    }
 
     &--small {
       @include typeVariant(headline);

--- a/src/components/text/_headers.scss
+++ b/src/components/text/_headers.scss
@@ -7,7 +7,7 @@ $includeHtml: false !default;
     @include typeVariant(header, 2);
     display: block;
     color: $black;
-    font-weight: $fontWeightBlack;
+    font-weight: $fontWeightBold;
     margin-bottom: rhythm(1);
 
     &--small {


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/572
closes https://github.com/brainly/style-guide/issues/574
before:
<img width="462" alt="screen shot 2015-11-12 at 16 00 00" src="https://cloud.githubusercontent.com/assets/316313/11121585/0351a4f8-8957-11e5-98fa-23a163b4047b.png">
after:
<img width="507" alt="screen shot 2015-11-12 at 15 59 49" src="https://cloud.githubusercontent.com/assets/316313/11121592/0bd28e12-8957-11e5-8197-29bcc543fec3.png">

before:
<img width="398" alt="screen shot 2015-11-12 at 16 00 04" src="https://cloud.githubusercontent.com/assets/316313/11121603/17454be0-8957-11e5-94e4-0ae6a12d6eec.png">
after:
<img width="411" alt="screen shot 2015-11-12 at 16 00 11" src="https://cloud.githubusercontent.com/assets/316313/11121612/26198a0a-8957-11e5-9b02-c41357e1a1fa.png">

before:
<img width="747" alt="screen shot 2015-11-12 at 16 01 30" src="https://cloud.githubusercontent.com/assets/316313/11121618/313cb9b6-8957-11e5-8626-8d0db4194933.png">
after:
<img width="773" alt="screen shot 2015-11-12 at 16 01 21" src="https://cloud.githubusercontent.com/assets/316313/11121624/3c68133a-8957-11e5-8616-131c51bbff26.png">


Before:
<img width="937" alt="screen shot 2015-11-12 at 16 01 50" src="https://cloud.githubusercontent.com/assets/316313/11121633/4e5ca10a-8957-11e5-9ee7-5d67c7adf139.png">
After:
<img width="935" alt="screen shot 2015-11-12 at 16 01 58" src="https://cloud.githubusercontent.com/assets/316313/11121642/541551c8-8957-11e5-9103-e693aade03db.png">
Select to compare with: 
<img width="218" alt="screen shot 2015-11-12 at 16 02 07" src="https://cloud.githubusercontent.com/assets/316313/11121650/5c61ceba-8957-11e5-834d-0185183c68c9.png">
