### PR TITLE
Fix selects sizes

### DIFF
--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -3,6 +3,8 @@ $selectTextColor: $grayAlt;
 $selectFontSize: fontSize(obscure);
 $selectIconSize: rhythm(0.333);
 $selectHeight: rhythm(2);
+$selectSmallHeight: rhythm(1.5);
+$selectBorderWidth: rhythm(2 / 24);
 $selectHoverBackground: $graySecondary;
 $selectInvalidBorderColor: $peachSecondary;
 
@@ -10,13 +12,15 @@ $includeHtml: false !default;
 
 @if ($includeHtml) {
   .mint-select {
+    $selectElementHeight: $selectHeight - 2 * $selectBorderWidth;
+
     @include component;
 
     border-radius: $selectHeight / 2;
     font-size: $selectFontSize;
     color: $selectTextColor;
     height: $selectHeight;
-    border: 2px solid $selectBackground;
+    border: $selectBorderWidth solid $selectBackground;
 
     &__element {
       @include uppercaseText;
@@ -26,9 +30,9 @@ $includeHtml: false !default;
       font-weight: $fontWeightBold;
       color: inherit;
       display: inline-block;
-      height: $selectHeight;
+      height: $selectElementHeight;
       position: relative;
-      padding: 0 ($selectHeight / 2 + rhythm(0.667)) 0 ($selectHeight / 2);
+      padding: 0 ($selectElementHeight / 2 + rhythm(0.667)) 0 ($selectElementHeight / 2);
       outline: 0;
       appearance: none;
       width: 100%;
@@ -46,8 +50,8 @@ $includeHtml: false !default;
 
     &__icon {
       position: absolute;
-      right: ($selectHeight / 4 + rhythm(0.333)) - $selectIconSize / 2;
-      top: $selectHeight / 2 - $selectIconSize / 2;
+      right: ($selectElementHeight / 4 + rhythm(0.333)) - $selectIconSize / 2;
+      top: $selectElementHeight / 2 - $selectIconSize / 2;
       height: $selectIconSize;
       width: $selectIconSize;
       pointer-events: none;
@@ -56,15 +60,16 @@ $includeHtml: false !default;
     }
 
     &--small {
-      height: rhythm(1.5);
+      $selectElementHeight: $selectSmallHeight - 2 * $selectBorderWidth;
+      height: $selectSmallHeight;
 
       .mint-select__icon {
-        top: rhythm(0.667) - $selectIconSize / 2;
-        right: rhythm(0.667) - $selectIconSize / 2;
+        top: $selectElementHeight / 2 - $selectIconSize / 2;
+        right: $selectElementHeight / 2 - $selectIconSize / 2;
       }
 
       .mint-select__element {
-        height: rhythm(1.5);
+        height: $selectElementHeight;
         padding: 0 rhythm(1.333) 0 rhythm(0.667);
       }
     }
@@ -74,7 +79,7 @@ $includeHtml: false !default;
     }
 
     &--invalid {
-      border: 2px solid $selectInvalidBorderColor;
+      border: $selectBorderWidth solid $selectInvalidBorderColor;
     }
   }
 }


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/579
Before:
<img width="817" alt="screen shot 2015-11-16 at 14 42 25" src="https://cloud.githubusercontent.com/assets/316313/11183463/197e3b06-8c72-11e5-853e-be8520bb4777.png">
After:
<img width="742" alt="screen shot 2015-11-16 at 14 41 39" src="https://cloud.githubusercontent.com/assets/316313/11183473/2260d18e-8c72-11e5-88b3-093b20111c47.png">
