### PR TITLE
Fix characters cut on labels

### DIFF
--- a/src/components/buttons/buttons.html
+++ b/src/components/buttons/buttons.html
@@ -314,7 +314,7 @@
                             <use xlink:href="#icon-excellent"></use>
                         </svg>
                     </div>
-                    <div class="mint-label__text">Mark as best</div>
+                    <div class="mint-label__text">Mark as brainliest</div>
                 </div>
             </div>
         </button>
@@ -391,7 +391,7 @@
                             <use xlink:href="#icon-excellent"></use>
                         </svg>
                     </div>
-                    <div class="mint-label__text">Mark as best</div>
+                    <div class="mint-label__text">Mark as brainliest</div>
                 </div>
             </div>
         </button>

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -35,10 +35,6 @@ $includeHtml: false !default;
       }
     }
 
-    &__text {
-      overflow: hidden;
-    }
-
     &__icon {
       width: $labelIconSizePrimary;
       height: $labelIconSizePrimary;
@@ -98,7 +94,6 @@ $includeHtml: false !default;
         @include fixOperaMiniLabelText;
 
         margin-right: $labelScaleFactor * gutter(0.25);
-        overflow: visible;
 
         &:last-child {
           margin-right: 0;

--- a/src/components/labels/labels.html
+++ b/src/components/labels/labels.html
@@ -10,7 +10,7 @@
                     <use xlink:href="#icon-excellent"></use>
                 </svg>
             </div>
-            <div class="mint-label__text">Mark as best</div>
+            <div class="mint-label__text">Mark as brainliest</div>
         </div>
         <div class="mint-label mint-label--emphasised mint-label--secondary">
             <div class="mint-label__icon">
@@ -47,7 +47,7 @@
                     <use xlink:href="#icon-excellent"></use>
                 </svg>
             </div>
-            <div class="mint-label__text">Mark as best</div>
+            <div class="mint-label__text">Mark as brainliest</div>
         </div>
         <div class="mint-label mint-label--emphasised mint-label--secondary mint-label--small">
             <div class="mint-label__icon">
@@ -84,7 +84,7 @@
                     <use xlink:href="#icon-excellent"></use>
                 </svg>
             </div>
-            <div class="mint-label__text">Mark as best</div>
+            <div class="mint-label__text">Mark as brainliest</div>
         </div>
         <div class="mint-label mint-label--secondary mint-label--large">
             <div class="mint-label__icon">


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/589
closes https://github.com/brainly/style-guide/issues/588

Before:
<img width="387" alt="screen shot 2015-11-23 at 08 25 39" src="https://cloud.githubusercontent.com/assets/316313/11331561/d2a8604e-91bc-11e5-91d4-f302a1513bac.png">
After:
<img width="382" alt="screen shot 2015-11-23 at 08 25 24" src="https://cloud.githubusercontent.com/assets/316313/11331565/db502b6e-91bc-11e5-918e-bc4117cd36ba.png">
