### PR TITLE
Expose mint-hide-for-* helper classes in the docs

### DIFF
--- a/src/components/helpers/rwd.html
+++ b/src/components/helpers/rwd.html
@@ -1,0 +1,21 @@
+<section class="docs-block">
+  <aside class="docs-block__info">
+    <h3 class="docs-block__header">RWD</h3>
+  </aside>
+  <div class="docs-block__content">
+    <ul>
+      <li><span class="mint-hide-for-small-only">
+        <svg class="mint-icon mint-icon--peach mint-icon--x14"><use xlink:href="#icon-heart"></use></svg>
+      </span> - hidden for small screens</li>
+      <li><span class="mint-hide-for-medium-only">
+        <svg class="mint-icon mint-icon--peach mint-icon--x14"><use xlink:href="#icon-heart"></use></svg>
+      </span> - hidden for medium screens</li>
+      <li><span class="mint-hide-for-medium-up">
+        <svg class="mint-icon mint-icon--peach mint-icon--x14"><use xlink:href="#icon-heart"></use></svg>
+      </span> - hidden for medium screens and higher</li>
+      <li><span class="mint-hide-for-large-only">
+        <svg class="mint-icon mint-icon--peach mint-icon--x14"><use xlink:href="#icon-heart"></use></svg>
+      </span> - hidden for large screens</li>
+    </ul>
+  </div>
+</section>

--- a/src/docs/_data/navigation.yml
+++ b/src/docs/_data/navigation.yml
@@ -15,6 +15,8 @@
       location: subject-icons/subject-icons
     - name: Logo
       location: logo/logo
+    - name: Helpers
+      location: helpers/rwd
 
 - name: Components
   location: components


### PR DESCRIPTION
<img width="625" alt="screen shot 2015-12-14 at 23 41 56" src="https://cloud.githubusercontent.com/assets/985504/11796401/6c4fc0a6-a2bc-11e5-9578-a49bf75513f6.png">

:two_hearts: show up and hide when you resize the page