### PR TITLE
Fix for mint-input--large placeholder

### DIFF
--- a/src/components/form-elements/_text-input.scss
+++ b/src/components/form-elements/_text-input.scss
@@ -80,6 +80,10 @@ $includeHtml: false !default;
         font-size: $inputLargeFontSize;
         border-radius: $inputLargeHeight / 2;
         padding: 0 $inputLargeHeight / 2;
+
+        &::placeholder {
+          font-size: fontSize(standout);
+        }
       }
     }
 


### PR DESCRIPTION
<img width="784" alt="screen shot 2015-12-16 at 10 24 52" src="https://cloud.githubusercontent.com/assets/316313/11837232/d88867ae-a3df-11e5-8991-f8c75224fd5f.png">
<img width="770" alt="screen shot 2015-12-16 at 10 24 21" src="https://cloud.githubusercontent.com/assets/316313/11837235/dcdafa4c-a3df-11e5-8a1d-12a8c4e511ef.png">
