### PR TITLE
Add icon as button dark option

### DIFF
--- a/src/components/buttons/_icon-as-button.scss
+++ b/src/components/buttons/_icon-as-button.scss
@@ -4,6 +4,8 @@ $iconAsButtonLightColor: $white;
 $iconAsButtonLightActiveColor: rgba($iconAsButtonLightColor, 0.7);
 $iconAsButtonGrayColor: $grayPrimary;
 $iconAsButtonGrayActiveColor: rgba($iconAsButtonGrayColor, 0.7);
+$iconAsButtonDarkColor: $black;
+$iconAsButtonDarkActiveColor: rgba($iconAsButtonDarkColor, 0.7);
 $iconAsButtonActionColor: $white;
 
 $includeHtml: false !default;
@@ -79,6 +81,19 @@ $includeHtml: false !default;
       }
     }
 
+    &--dark {
+      fill: $iconAsButtonDarkColor;
+
+      &:hover,
+      &:active {
+        fill: $iconAsButtonDarkActiveColor;
+      }
+
+      .mint-icon-as-button__hole {
+        border-color: $iconAsButtonDarkColor;
+      }
+    }
+
     &--action {
       transition: background 0.3s ease-out, fill 0.3s ease-out;
       border-radius: 50%;
@@ -89,6 +104,10 @@ $includeHtml: false !default;
 
         &.mint-icon-as-button--gray {
           background: $iconAsButtonGrayColor;
+        }
+
+        &.mint-icon-as-button--dark {
+          background: $iconAsButtonDarkColor;
         }
       }
     }
@@ -104,6 +123,10 @@ $includeHtml: false !default;
 
       &.mint-icon-as-button--gray {
         background: $iconAsButtonGrayColor;
+      }
+
+      &.mint-icon-as-button--dark {
+        background: $iconAsButtonDarkColor;
       }
     }
 

--- a/src/components/buttons/icon-as-button.html
+++ b/src/components/buttons/icon-as-button.html
@@ -17,6 +17,13 @@
             </svg>
           </div>
         </button>
+      <button class="mint-icon-as-button mint-icon-as-button--dark">
+        <div class="mint-icon-as-button__hole">
+          <svg class="mint-icon mint-icon--adaptive mint-icon--x26">
+            <use xlink:href="#icon-heart"></use>
+          </svg>
+        </div>
+      </button>
         <div class="docs-block__content docs-block__contrast-box">
             <button class="mint-icon-as-button mint-icon-as-button--light">
               <div class="mint-icon-as-button__hole">
@@ -44,6 +51,13 @@
           <div class="mint-icon-as-button__hole">
             <svg class="mint-icon mint-icon--adaptive mint-icon--x26">
                 <use xlink:href="#icon-profile"></use>
+            </svg>
+          </div>
+        </button>
+      <button class="mint-icon-as-button mint-icon-as-button--dark mint-icon-as-button--with-border">
+          <div class="mint-icon-as-button__hole">
+            <svg class="mint-icon mint-icon--adaptive mint-icon--x26">
+                <use xlink:href="#icon-heart"></use>
             </svg>
           </div>
         </button>
@@ -77,6 +91,13 @@
             </svg>
           </div>
         </button>
+      <button class="mint-icon-as-button mint-icon-as-button--dark mint-icon-as-button--small">
+          <div class="mint-icon-as-button__hole">
+            <svg class="mint-icon mint-icon--adaptive mint-icon--x18">
+                <use xlink:href="#icon-heart"></use>
+            </svg>
+          </div>
+        </button>
         <div class="docs-block__content docs-block__contrast-box">
             <button class="mint-icon-as-button mint-icon-as-button--small mint-icon-as-button--light mint-icon-as-button--with-border">
               <div class="mint-icon-as-button__hole">
@@ -101,6 +122,13 @@
           </div>
         </button>
         <button class="mint-icon-as-button mint-icon-as-button--gray mint-icon-as-button--xsmall">
+          <div class="mint-icon-as-button__hole">
+            <svg class="mint-icon mint-icon--adaptive mint-icon--x18">
+                <use xlink:href="#icon-profile"></use>
+            </svg>
+          </div>
+        </button>
+      <button class="mint-icon-as-button mint-icon-as-button--dark mint-icon-as-button--xsmall">
           <div class="mint-icon-as-button__hole">
             <svg class="mint-icon mint-icon--adaptive mint-icon--x18">
                 <use xlink:href="#icon-profile"></use>
@@ -137,6 +165,13 @@
             </svg>
           </div>
         </button>
+        <button class="mint-icon-as-button mint-icon-as-button--dark mint-icon-as-button--action">
+          <div class="mint-icon-as-button__hole">
+            <svg class="mint-icon mint-icon--adaptive mint-icon--x26">
+                <use xlink:href="#icon-comment"></use>
+            </svg>
+          </div>
+        </button>
         <button class="mint-icon-as-button mint-icon-as-button--gray mint-icon-as-button--action-active">
           <div class="mint-icon-as-button__hole">
             <svg class="mint-icon mint-icon--adaptive mint-icon--x26">
@@ -160,6 +195,13 @@
       </div>
     </button>
     <button class="mint-icon-as-button mint-icon-as-button--gray mint-icon-as-button--action mint-icon-as-button--rounded-square">
+      <div class="mint-icon-as-button__hole">
+        <svg class="mint-icon mint-icon--adaptive mint-icon--x26">
+          <use xlink:href="#icon-comment"></use>
+        </svg>
+      </div>
+    </button>
+    <button class="mint-icon-as-button mint-icon-as-button--dark mint-icon-as-button--action mint-icon-as-button--rounded-square">
       <div class="mint-icon-as-button__hole">
         <svg class="mint-icon mint-icon--adaptive mint-icon--x26">
           <use xlink:href="#icon-comment"></use>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/470
<img width="547" alt="screen shot 2016-01-05 at 16 13 37" src="https://cloud.githubusercontent.com/assets/316313/12164385/72a6a4f4-b515-11e5-9ea9-74c3ee464ad4.png">
