### PR TITLE
Add mint text blue option

### DIFF
--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -37,6 +37,10 @@ $includeHtml: false !default;
       color: $white;
     }
 
+    &--blue {
+      color: $bluePrimary;
+    }
+
     &--for-fine-print-light {
       color: $blueSecondaryLight;
     }

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -48,7 +48,8 @@
             This is a default typeface for text everywhere.<br>
             Here is a <span class="mint-text mint-text--gray">gray text</span>,
             <br>
-            and an <span class="mint-text mint-text--emphasised">emphasised text</span>.
+            and an <span class="mint-text mint-text--emphasised">emphasised text</span>.<br>
+            and an <span class="mint-text mint-text--blue">blue text!</span>.
         </div>
         <div class="docs-block__contrast-box">
             <div class="mint-text mint-text--light">


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/609
<img width="580" alt="screen shot 2016-01-08 at 09 55 25" src="https://cloud.githubusercontent.com/assets/316313/12194159/19f5a308-b5ee-11e5-9243-f244bc7166a7.png">
