### PR TITLE
Update textarea placeholder styles

### DIFF
--- a/src/components/form-elements/_textarea.scss
+++ b/src/components/form-elements/_textarea.scss
@@ -8,7 +8,7 @@ $textareaPadding: 11px;
 $textareaSmallPadding: 4px;
 $textareaFocusBorderColor: $grayPrimary;
 $textareaPlaceholderTextColor: $grayPrimary;
-$textareaPlaceholderFontSize: fontSize(obscure);
+$textareaPlaceholderFontSize: fontSize(medium);
 $textareaValidBorderColor: $mintSecondary;
 $textareaInvalidBorderColor: $peachSecondary;
 
@@ -36,12 +36,9 @@ $includeHtml: false !default;
     }
 
     &::placeholder {
-      @include uppercaseText;
-      position: relative;
-      top: rhythm(0.125);
       color: $textareaPlaceholderTextColor;
       font-size: $textareaPlaceholderFontSize;
-      font-weight: $fontWeightBold;
+      position: relative;
     }
 
     &--full {


### PR DESCRIPTION
<img width="455" alt="screen shot 2016-01-11 at 14 05 35" src="https://cloud.githubusercontent.com/assets/316313/12234363/bf395a14-b86c-11e5-92c9-80038005a5a4.png">
Placeholder styles should match those of input text