### PR TITLE
Redirect from root folder to the latest styleguide version docs 

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -62,10 +62,12 @@ gulp.task('watch', ['watch:sass', 'watch:docs-templates', 'watch:docs-sass']);
 gulp.task('scss-lint', getTask('scss-lint'));
 gulp.task('scss-unused-variables', getTask('scss-unused-variables'));
 
+gulp.task('root-redirect-page', getTask('root-redirect-page'));
+
 gulp.task('ci', ['scss-lint', 'scss-unused-variables']);
 
 gulp.task('deploy', getTask('deploy'));
 
 gulp.task('build', function (done) {
-    runSequence('clean:dist', 'sass:build', 'sass:docs-build', 'svgs-generate', 'jekyll:docs', 'docs:copy-components', 'fingerprint', 'fingerprint-replace', 'index-fingerprint-replace', done);
+    runSequence('clean:dist', 'sass:build', 'sass:docs-build', 'svgs-generate', 'jekyll:docs', 'docs:copy-components', 'fingerprint', 'fingerprint-replace', 'index-fingerprint-replace', 'root-redirect-page', done);
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "25.0.0-0",
+  "version": "25.0.0-1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/scripts/tasks/root-redirect-page.js
+++ b/scripts/tasks/root-redirect-page.js
@@ -1,0 +1,13 @@
+module.exports = function (gulp, plugins, consts) {
+  return function () {
+    var fs = require('fs');
+
+    var outputPath = plugins.path.join(consts.DIST, 'index.html');
+    var redirectPageContent = fs.readFileSync(plugins.path.join(consts.SRC, 'root-redirect.html'), "utf8");
+
+    redirectPageContent = redirectPageContent.replace(/#LATEST_VERSION#/g, consts.VERSION);
+
+    fs.writeFileSync(outputPath, redirectPageContent);
+
+  };
+};

--- a/src/root-redirect.html
+++ b/src/root-redirect.html
@@ -1,0 +1,14 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="refresh" content="1;url=/#LATEST_VERSION#/docs/">
+  <script type="text/javascript">
+    window.location.href = "/#LATEST_VERSION#/docs/"
+  </script>
+  <title>Page Redirection</title>
+</head>
+<body>
+If you are not redirected automatically, follow the <a href='/#LATEST_VERSION#/docs/'>link</a>
+</body>
+</html>


### PR DESCRIPTION
using simple, yet effective, html meta redirect

http://styleguide.brainly.com/ will finally redirect to the latest version of the doc automagically ✨


✴it won't work locally as local root (/dist/version/docs) is different from the production root (/version/docs)