### PR TITLE
Fix mint-label__icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "26.3.0",
+  "version": "26.4.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -39,6 +39,8 @@ $includeHtml: false !default;
       width: $labelIconSizePrimary;
       height: $labelIconSizePrimary;
       display: flex;
+      flex-shrink: 0;
+      align-items: center;
       margin-right: gutter(0.25);
 
       &:last-child {


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/629

<img width="226" alt="screen shot 2016-04-14 at 13 36 03" src="https://cloud.githubusercontent.com/assets/1231144/14526790/190400c6-0246-11e6-8455-503f3cc67b0a.png">
