### PR TITLE
Add mint color of icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "27.1.0",
+  "version": "27.2.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -72,5 +72,9 @@ $iconSizes: 120, 64, 60, 48, 44, 38, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10, 8;
     &--dark {
       fill: $black;
     }
+
+    &--mint {
+      fill: $mintPrimary;
+    }
   }
 }

--- a/src/docs/_data/icons.yml
+++ b/src/docs/_data/icons.yml
@@ -53,3 +53,4 @@ colors:
   - lavender
   - peach
   - dark
+  - mint


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/720
<img width="159" alt="screen shot 2016-04-22 at 09 35 30" src="https://cloud.githubusercontent.com/assets/1231144/14734859/94e50302-086d-11e6-83c1-748e2d8f92b4.png">