### PR TITLE
Add dark modifier for links

### DIFF
--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -22,6 +22,10 @@ $includeHtml: false !default;
       color: $white;
     }
 
+    &--dark {
+      color: $black;
+    }
+
     &--warning {
       color: $mustardPrimary;
     }

--- a/src/components/text/links.html
+++ b/src/components/text/links.html
@@ -28,6 +28,9 @@
       <div>
         Text with <a href="#" class="mint-link mint-link--unstyled">unstyled link</a><br/>
       </div>
+      <div>
+        Text with <a href="#" class="mint-link mint-link--dark">dark link</a><br/>
+      </div>
       <div class="docs-block__contrast-box">
         <div class="mint-text mint-text--light">
           This text is light and <a class="mint-link mint-link--light">this link is light!</a>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/653

<img width="202" alt="screen shot 2016-04-27 at 08 55 34" src="https://cloud.githubusercontent.com/assets/1231144/14844209/0cc27c92-0c56-11e6-9585-127123c98159.png">
