### PR TITLE
Add --with-centered-text modifier to mint-content-box__content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "28.2.0",
+  "version": "28.3.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/content-box/_content-box.scss
+++ b/src/components/content-box/_content-box.scss
@@ -33,6 +33,10 @@ $includeHtml: false !default;
         width: 100%;
         height: 100%;
       }
+
+      &--with-centered-text {
+        text-align: center;
+      }
     }
 
     &__actions {

--- a/src/components/content-box/content-box.html
+++ b/src/components/content-box/content-box.html
@@ -605,6 +605,12 @@
       <div class="mint-content-box__title mint-content-box__title--with-centered-elements">
         <h2 class="mint-header-secondary">This is a title for context box</h2>
       </div>
+      <div class="mint-content-box__content mint-content-box__content--with-centered-text">
+        <div class="mint-text">
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel dui porttitor, tincidunt
+          lorem quis, gravida ex.
+        </div>
+      </div>
       <div class="mint-content-box__actions mint-content-box__actions--with-centered-elements">
         <ul class="mint-breadcrumb-list">
           <li class="mint-breadcrumb-list__element">


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/600

<img width="1030" alt="screen shot 2016-04-27 at 09 09 23" src="https://cloud.githubusercontent.com/assets/1231144/14844477/ed5d178e-0c57-11e6-9cf1-673d6b0d203a.png">
