### PR TITLE
Add white-space: nowrap to hole of button-secondary

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "28.1.0",
+  "version": "28.2.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/buttons/_buttons_secondary.scss
+++ b/src/components/buttons/_buttons_secondary.scss
@@ -114,6 +114,10 @@ $includeHtml: false !default;
       width: 100%;
       text-align: center;
     }
+
+    &__hole {
+      white-space: nowrap;
+    }
   }
 
   .mint-button-secondary--alt {


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/664

before:
<img width="125" alt="screen shot 2016-04-27 at 09 32 03" src="https://cloud.githubusercontent.com/assets/1231144/14844914/27defe38-0c5b-11e6-8e13-abab5e20397f.png">

after:
<img width="124" alt="screen shot 2016-04-27 at 09 32 09" src="https://cloud.githubusercontent.com/assets/1231144/14844905/1c8300c0-0c5b-11e6-94e0-3a1331867ab7.png">
