### PR TITLE
Add dark-semitransparent text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "28.0.1-1",
+  "version": "28.1.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -1,4 +1,5 @@
 $includeHtml: false !default;
+$mintTextDarkSemitransparentColor: rgba(0, 0, 0, 0.4);
 
 @if ($includeHtml) {
 
@@ -43,6 +44,10 @@ $includeHtml: false !default;
 
     &--light {
       color: $white;
+    }
+
+    &--dark-semitransparent {
+      color: $mintTextDarkSemitransparentColor;
     }
 
     &--for-fine-print-light {

--- a/src/components/text/text.html
+++ b/src/components/text/text.html
@@ -48,6 +48,7 @@
             This is a default typeface for text everywhere.<br>
             Here is a <span class="mint-text mint-text--gray">gray text</span>,
             this is a <span class="mint-text mint-text--mint">mint text</span>,
+            this is a <span class="mint-text mint-text--dark-semitransparent">dark semitransparent text</span>,
             <span class="mint-text mint-text--no-wrap">this text will not wrap</span>,
             <br>
             and an <span class="mint-text mint-text--emphasised">emphasised text</span>.


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/706

it looks differently on different backgrounds.
it's already in use in game-box and baby-progress-bar features.

example (baby progress bar):
<img width="234" alt="screen shot 2016-04-27 at 09 45 34" src="https://cloud.githubusercontent.com/assets/1231144/14845173/d3dd8af0-0c5c-11e6-918c-dd6f71375781.png">


<img width="749" alt="screen shot 2016-04-27 at 09 43 07" src="https://cloud.githubusercontent.com/assets/1231144/14845133/989fda2e-0c5c-11e6-97fb-787f303c2f74.png">
