### PR TITLE
Fix secondary buttons small line height in safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "28.3.0",
+  "version": "28.3.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -2,6 +2,7 @@ $boxBorderColor: $graySecondary;
 $boxBackgroundDark: $graySecondaryLight;
 $boxBorderRadius: 22px;
 $boxBorderSize: rhythm(0.125);
+$boxBorderSize: rhythm(0.125);
 $boxSmallBorderSize: rhythm(2 / 24);
 
 $includeHtml: false !default;
@@ -17,7 +18,7 @@ $includeHtml: false !default;
     min-height: rhythm(3);
     border-radius: $boxBorderRadius;
     border: $boxBorderSize solid $boxBorderColor;
-    padding: (rhythm(1) - $borderSize) gutter(1);
+    padding: (rhythm(1) - $boxBorderSize) gutter(1);
     overflow: visible;
 
     &__image {
@@ -59,7 +60,7 @@ $includeHtml: false !default;
     &--image-wrapper {
       height: rhythm(4);
       width: rhythm(4);
-      padding: (rhythm(0.5) - $borderSize);
+      padding: (rhythm(0.5) - $boxBorderSize);
       align-items: center;
       justify-content: center;
     }

--- a/src/components/buttons/_buttons_secondary.scss
+++ b/src/components/buttons/_buttons_secondary.scss
@@ -1,4 +1,5 @@
-$buttonSecondaryHeight: rhythm(1.333);
+$buttonSecondaryBorderSize: rhythm(1 / 12);
+$buttonSecondaryHeight: rhythm(4 / 3);
 $buttonSecondarySmallHeight: rhythm(1);
 $buttonSecondaryFontSize: fontSize(obscure);
 
@@ -86,14 +87,13 @@ $includeHtml: false !default;
 
   // Secondary buttons
   .mint-button-secondary {
-    $borderSize: 2px;
     @include mintButtonBasicStyles();
     @include mintButtonBasicDimensions($buttonSecondaryHeight);
     @include mintButtonBasicColors($buttonSecondaryColor, $buttonSecondaryColor, $buttonSecondaryTextColorHover);
     @include mintButtonSecondaryActive($buttonSecondaryColor, $buttonSecondaryTextColorHover, $buttonSecondaryColor);
     @include hole;
 
-    border-width: $borderSize;
+    border-width: $buttonSecondaryBorderSize;
     border-style: solid;
     background-color: transparent;
     font-size: $buttonSecondaryFontSize;
@@ -155,5 +155,6 @@ $includeHtml: false !default;
 
   .mint-button-secondary--small {
     @include mintButtonBasicDimensions($buttonSecondarySmallHeight);
+    line-height: $buttonSecondarySmallHeight - $buttonSecondaryBorderSize;
   }
 }


### PR DESCRIPTION
Fix box borderSize variable

Before:
<img width="959" alt="screen shot 2016-05-04 at 14 20 27" src="https://cloud.githubusercontent.com/assets/316313/15014102/3dd036ea-1204-11e6-8101-054ba351c36f.png">

After:
<img width="1003" alt="screen shot 2016-05-04 at 14 21 14" src="https://cloud.githubusercontent.com/assets/316313/15014103/3de9e770-1204-11e6-9942-e080ecc1dce1.png">
