### PR TITLE
Clean toplayer component up

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "35.0.0",
+  "version": "36.0.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/toplayer/_toplayer.scss
+++ b/src/components/toplayer/_toplayer.scss
@@ -28,12 +28,6 @@ $includeHtml: false !default;
           padding: ($toplayerFirstVerticalPadding + rhythm(1)) gutter(2) rhythm(2);
         }
       }
-
-      .sg-toplayer__heading {
-        @include sgBreakpoint(medium-up) {
-          margin-bottom: rhythm(2);
-        }
-      }
     }
 
     &--fill {
@@ -112,18 +106,6 @@ $includeHtml: false !default;
 
     &__wrapper {
       padding: $toplayerFirstVerticalPadding gutter(1) rhythm(1);
-    }
-
-    &__heading {
-      margin-bottom: gutter(1);
-    }
-
-    &__content {
-      margin-bottom: gutter(1);
-    }
-
-    &__list-title {
-      margin-bottom: 0;
     }
 
     &__actions {

--- a/src/components/toplayer/default_toplayer.html
+++ b/src/components/toplayer/default_toplayer.html
@@ -15,16 +15,22 @@
 
         <div class="sg-toplayer__wrapper">
 
-            <div class="sg-toplayer__heading">
+            <div class="sg-content-box">
+              <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                 heading
+              </div>
             </div>
 
-            <div class="sg-toplayer__content">
+            <div class="sg-content-box">
+              <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                 content:<br>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse enim diam, dictum et maximus sit amet, pulvinar vel ante. Maecenas id tempus lacus. Cras vitae lectus vehicula, pretium odio sed, pretium nulla. Nunc ultrices nibh orci, sit amet gravida metus dapibus nec. Sed orci nisi, volutpat varius auctor sit amet, eleifend eu elit. Fusce eget nunc tristique nibh viverra lobortis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
+              </div>
             </div>
 
-            <div class="sg-toplayer__actions">
+            <div class="sg-content-box">
+              <div class="sg-content-box__actions">
                 actions
+              </div>
             </div>
 
         </div>

--- a/src/components/toplayer/default_toplayer.html
+++ b/src/components/toplayer/default_toplayer.html
@@ -19,15 +19,11 @@
               <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                 heading
               </div>
-            </div>
 
-            <div class="sg-content-box">
               <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                 content:<br>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse enim diam, dictum et maximus sit amet, pulvinar vel ante. Maecenas id tempus lacus. Cras vitae lectus vehicula, pretium odio sed, pretium nulla. Nunc ultrices nibh orci, sit amet gravida metus dapibus nec. Sed orci nisi, volutpat varius auctor sit amet, eleifend eu elit. Fusce eget nunc tristique nibh viverra lobortis. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.
               </div>
-            </div>
 
-            <div class="sg-content-box">
               <div class="sg-content-box__actions">
                 actions
               </div>

--- a/src/components/toplayer/notlogged_toplayer.html
+++ b/src/components/toplayer/notlogged_toplayer.html
@@ -15,18 +15,20 @@
 
         <div class="sg-toplayer__wrapper">
 
-            <div class="sg-toplayer__heading">
-                <h1 class="sg-text-bit sg-text-bit--alt">
-                    The world's largest learning community
-                </h1>
+            <div class="sg-content-box">
+                <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                    <h1 class="sg-text-bit sg-text-bit--alt">
+                      The world's largest learning community
+                    </h1>
+                </div>
             </div>
 
-            <div class="sg-toplayer__content">
-
-                <h2 class="sg-header-secondary sg-toplayer__list-title">
+            <div class="sg-content-box">
+                <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                  <h2 class="sg-header-secondary sg-toplayer__list-title">
                     Why join Brainly?
-                </h2>
-                <ul class="sg-list sg-list--small">
+                  </h2>
+                  <ul class="sg-list sg-list--small">
                     <li class="sg-list__element">
                       <div class="sg-list__icon">
                         <svg class="sg-icon sg-icon--x14 sg-icon--gray-secondary">
@@ -38,21 +40,23 @@
                         <svg class="sg-icon sg-icon--x14 sg-icon--gray-secondary">
                           <use xlink:href="#icon-plus"></use>
                         </svg>
-                    </div> get answer with explanation</li>
+                      </div> get answer with explanation</li>
                     <li class="sg-list__element">
                       <div class="sg-list__icon">
                         <svg class="sg-icon sg-icon--x14 sg-icon--gray-secondary">
                           <use xlink:href="#icon-plus"></use>
                         </svg>
-                    </div> find similar questions</li>
-                </ul>
-
+                      </div> find similar questions</li>
+                  </ul>
+                </div>
             </div>
-            <div class="sg-toplayer__actions">
-                <a class="sg-button-primary sg-button-primary--alt"
-                   href="#">
-                    <div class="sg-button-primary__hole">Join us</div>
-                </a>
+            <div class="sg-content-box">
+              <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                  <a class="sg-button-primary sg-button-primary--alt"
+                     href="#">
+                      <div class="sg-button-primary__hole">Join us</div>
+                  </a>
+                </div>
             </div>
 
         </div>

--- a/src/components/toplayer/notlogged_toplayer.html
+++ b/src/components/toplayer/notlogged_toplayer.html
@@ -21,9 +21,7 @@
                       The world's largest learning community
                     </h1>
                 </div>
-            </div>
 
-            <div class="sg-content-box">
                 <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                   <h2 class="sg-header-secondary sg-toplayer__list-title">
                     Why join Brainly?
@@ -49,16 +47,15 @@
                       </div> find similar questions</li>
                   </ul>
                 </div>
-            </div>
-            <div class="sg-content-box">
-              <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
-                  <a class="sg-button-primary sg-button-primary--alt"
-                     href="#">
-                      <div class="sg-button-primary__hole">Join us</div>
-                  </a>
+
+
+                <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                    <a class="sg-button-primary sg-button-primary--alt"
+                       href="#">
+                        <div class="sg-button-primary__hole">Join us</div>
+                    </a>
                 </div>
             </div>
-
         </div>
 
     </div>

--- a/src/components/toplayer/notlogged_toplayer.html
+++ b/src/components/toplayer/notlogged_toplayer.html
@@ -23,7 +23,7 @@
                 </div>
 
                 <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
-                  <h2 class="sg-header-secondary sg-toplayer__list-title">
+                  <h2 class="sg-header-secondary">
                     Why join Brainly?
                   </h2>
                   <ul class="sg-list sg-list--small">

--- a/src/components/toplayer/toplayer.html
+++ b/src/components/toplayer/toplayer.html
@@ -11,16 +11,22 @@
 
             <div class="sg-toplayer__wrapper">
 
-                <div class="sg-toplayer__heading">
+                <div class="sg-content-box">
+                  <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                     heading
+                  </div>
                 </div>
 
-                <div class="sg-toplayer__content">
+                <div class="sg-content-box">
+                  <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                     content
+                  </div>
                 </div>
 
-                <div class="sg-toplayer__actions">
+                <div class="sg-content-box">
+                  <div class="sg-content-box__actions">
                     actions
+                  </div>
                 </div>
 
             </div>
@@ -43,16 +49,22 @@
 
             <div class="sg-toplayer__wrapper">
 
-                <div class="sg-toplayer__heading">
-                    heading
+                <div class="sg-content-box">
+                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                        heading
+                    </div>
                 </div>
 
-                <div class="sg-toplayer__content">
-                    content
+                <div class="sg-content-box">
+                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                        content
+                    </div>
                 </div>
 
-                <div class="sg-toplayer__actions">
-                    actions
+                <div class="sg-content-box">
+                    <div class="sg-content-box__actions">
+                        actions
+                    </div>
                 </div>
 
             </div>
@@ -75,16 +87,22 @@
 
             <div class="sg-toplayer__wrapper">
 
-                <div class="sg-toplayer__heading">
-                    heading
+                <div class="sg-content-box">
+                   <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                        heading
+                   </div>
                 </div>
 
-                <div class="sg-toplayer__content">
-                    content
+                <div class="sg-content-box">
+                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                        content
+                    </div>
                 </div>
 
-                <div class="sg-toplayer__actions">
-                    actions
+                <div class="sg-content-box">
+                    <div class="sg-content-box__actions">
+                        actions
+                    </div>
                 </div>
 
             </div>
@@ -107,17 +125,23 @@
 
             <div class="sg-toplayer__wrapper">
 
-                <div class="sg-toplayer__heading">
-                    heading
-                </div>
+              <div class="sg-content-box">
+                  <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                      heading
+                  </div>
+              </div>
 
-                <div class="sg-toplayer__content">
-                    content
-                </div>
+              <div class="sg-content-box">
+                  <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                      content
+                  </div>
+              </div>
 
-                <div class="sg-toplayer__actions">
-                    actions
-                </div>
+              <div class="sg-content-box">
+                  <div class="sg-content-box__actions">
+                      actions
+                  </div>
+              </div>
 
             </div>
 
@@ -139,17 +163,23 @@
 
             <div class="sg-toplayer__wrapper">
 
-                <div class="sg-toplayer__heading">
-                    heading
-                </div>
+              <div class="sg-content-box">
+                  <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                      heading
+                  </div>
+              </div>
 
-                <div class="sg-toplayer__content">
-                    content
-                </div>
+              <div class="sg-content-box">
+                  <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                      content
+                  </div>
+              </div>
 
-                <div class="sg-toplayer__actions">
-                    actions
-                </div>
+              <div class="sg-content-box">
+                  <div class="sg-content-box__actions">
+                      actions
+                  </div>
+              </div>
 
             </div>
 
@@ -172,16 +202,22 @@
 
             <div class="sg-toplayer__wrapper">
 
-                <div class="sg-toplayer__heading">
-                    heading
+                <div class="sg-content-box">
+                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                        heading
+                    </div>
                 </div>
 
-                <div class="sg-toplayer__content">
-                    content
+                <div class="sg-content-box">
+                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                        content
+                    </div>
                 </div>
 
-                <div class="sg-toplayer__actions">
-                    actions
+                <div class="sg-content-box">
+                    <div class="sg-content-box__actions">
+                        actions
+                    </div>
                 </div>
 
             </div>
@@ -205,47 +241,53 @@
 
             <div class="sg-toplayer__wrapper">
 
-                <div class="sg-toplayer__heading">
-                    <h1 class="sg-text-bit sg-text-bit--alt">
-                        The world's largest learning community
-                    </h1>
+                <div class="sg-content-box">
+                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                        <h1 class="sg-text-bit sg-text-bit--alt">
+                            The world's largest learning community
+                        </h1>
+                    </div>
                 </div>
 
-                <div class="sg-toplayer__content">
+                <div class="sg-content-box">
+                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
 
-                    <h2 class="sg-header-secondary sg-toplayer__list-title">
-                        Why join Brainly?
-                    </h2>
-                    <ul class="sg-list sg-list--small">
-                        <li class="sg-list__element">
-                          <div class="sg-list__icon">
-                            <svg class="sg-icon sg-icon--x14 sg-icon--gray-secondary">
-                              <use xlink:href="#icon-plus"></use>
-                            </svg>
-                          </div> ask questions about your assignment
-                        </li>
-                        <li class="sg-list__element">
-                          <div class="sg-list__icon">
-                            <svg class="sg-icon sg-icon--x14 sg-icon--gray-secondary">
-                              <use xlink:href="#icon-plus"></use>
-                            </svg>
-                          </div> get answer with explanation
-                        </li>
-                        <li class="sg-list__element">
+                      <h2 class="sg-header-secondary sg-toplayer__list-title">
+                          Why join Brainly?
+                      </h2>
+                      <ul class="sg-list sg-list--small">
+                          <li class="sg-list__element">
                             <div class="sg-list__icon">
                               <svg class="sg-icon sg-icon--x14 sg-icon--gray-secondary">
                                 <use xlink:href="#icon-plus"></use>
                               </svg>
-                            </div> find similar questions
-                        </li>
-                    </ul>
-
+                            </div> ask questions about your assignment
+                          </li>
+                          <li class="sg-list__element">
+                            <div class="sg-list__icon">
+                              <svg class="sg-icon sg-icon--x14 sg-icon--gray-secondary">
+                                <use xlink:href="#icon-plus"></use>
+                              </svg>
+                            </div> get answer with explanation
+                          </li>
+                          <li class="sg-list__element">
+                              <div class="sg-list__icon">
+                                <svg class="sg-icon sg-icon--x14 sg-icon--gray-secondary">
+                                  <use xlink:href="#icon-plus"></use>
+                                </svg>
+                              </div> find similar questions
+                          </li>
+                      </ul>
+                    </div>
                 </div>
-                <div class="sg-toplayer__actions">
-                    <a class="sg-button-primary sg-button-primary--alt"
-                       href="#">
-                        <div class="sg-button-primary__hole">Join us</div>
-                    </a>
+
+                <div class="sg-content-box">
+                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
+                        <a class="sg-button-primary sg-button-primary--alt"
+                           href="#">
+                            <div class="sg-button-primary__hole">Join us</div>
+                        </a>
+                      </div>
                 </div>
 
             </div>

--- a/src/components/toplayer/toplayer.html
+++ b/src/components/toplayer/toplayer.html
@@ -226,7 +226,7 @@
 
                     <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
 
-                      <h2 class="sg-header-secondary sg-toplayer__list-title">
+                      <h2 class="sg-header-secondary">
                           Why join Brainly?
                       </h2>
                       <ul class="sg-list sg-list--small">

--- a/src/components/toplayer/toplayer.html
+++ b/src/components/toplayer/toplayer.html
@@ -15,15 +15,11 @@
                   <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                     heading
                   </div>
-                </div>
 
-                <div class="sg-content-box">
                   <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                     content
                   </div>
-                </div>
 
-                <div class="sg-content-box">
                   <div class="sg-content-box__actions">
                     actions
                   </div>
@@ -53,15 +49,11 @@
                     <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                         heading
                     </div>
-                </div>
 
-                <div class="sg-content-box">
                     <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                         content
                     </div>
-                </div>
 
-                <div class="sg-content-box">
                     <div class="sg-content-box__actions">
                         actions
                     </div>
@@ -91,15 +83,11 @@
                    <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                         heading
                    </div>
-                </div>
 
-                <div class="sg-content-box">
                     <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                         content
                     </div>
-                </div>
 
-                <div class="sg-content-box">
                     <div class="sg-content-box__actions">
                         actions
                     </div>
@@ -129,15 +117,11 @@
                   <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                       heading
                   </div>
-              </div>
 
-              <div class="sg-content-box">
                   <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                       content
                   </div>
-              </div>
 
-              <div class="sg-content-box">
                   <div class="sg-content-box__actions">
                       actions
                   </div>
@@ -167,15 +151,11 @@
                   <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                       heading
                   </div>
-              </div>
 
-              <div class="sg-content-box">
                   <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                       content
                   </div>
-              </div>
 
-              <div class="sg-content-box">
                   <div class="sg-content-box__actions">
                       actions
                   </div>
@@ -206,15 +186,11 @@
                     <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                         heading
                     </div>
-                </div>
 
-                <div class="sg-content-box">
                     <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                         content
                     </div>
-                </div>
 
-                <div class="sg-content-box">
                     <div class="sg-content-box__actions">
                         actions
                     </div>
@@ -247,9 +223,7 @@
                             The world's largest learning community
                         </h1>
                     </div>
-                </div>
 
-                <div class="sg-content-box">
                     <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
 
                       <h2 class="sg-header-secondary sg-toplayer__list-title">
@@ -279,9 +253,7 @@
                           </li>
                       </ul>
                     </div>
-                </div>
 
-                <div class="sg-content-box">
                     <div class="sg-content-box__content sg-content-box__content--spaced-bottom-large">
                         <a class="sg-button-primary sg-button-primary--alt"
                            href="#">

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -93,7 +93,6 @@ body.show-holes {
   .sg-content-box__title,
   .sg-content-box__footer,
   .sg-content-box__content,
-  .sg-toplayer__heading,
   .sg-toplayer__content,
   .sg-toplayer__actions,
   .sg-dropdown__hole,


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/377
we already do not use this containers.
there is only one case of usage in `symfony` that will be refactored when version of style-guide is bumped

<img width="1065" alt="screen shot 2016-06-15 at 15 13 17" src="https://cloud.githubusercontent.com/assets/1231144/16081077/278998f8-330c-11e6-8908-07d732edbd6f.png">
<img width="999" alt="screen shot 2016-06-15 at 15 13 23" src="https://cloud.githubusercontent.com/assets/1231144/16081076/27896f4a-330c-11e6-9ad4-38c1a11ba199.png">
<img width="938" alt="screen shot 2016-06-15 at 15 13 30" src="https://cloud.githubusercontent.com/assets/1231144/16081075/278948b2-330c-11e6-8e02-cccdd496bf50.png">
<img width="1070" alt="screen shot 2016-06-15 at 15 13 34" src="https://cloud.githubusercontent.com/assets/1231144/16081078/278a1896-330c-11e6-81ce-77b8d8dc9ae3.png">
<img width="1091" alt="screen shot 2016-06-15 at 15 13 41" src="https://cloud.githubusercontent.com/assets/1231144/16081079/278acdae-330c-11e6-9574-bcb7ee5a3853.png">


it's major change, right?