### PR TITLE
Update box--small-padding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "37.5.0",
+  "version": "37.6.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -48,7 +48,7 @@ $includeHtml: false !default;
     }
 
     &--small-padding {
-      padding: (gutter(1 / 2) - $boxBorderSize);
+      padding: gutter(2 / 3);
     }
 
     &--large-padding {


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/759
before:
<img width="343" alt="screen shot 2016-06-28 at 10 02 52" src="https://cloud.githubusercontent.com/assets/1231144/16408133/824565dc-3d17-11e6-81a1-99eeeb7df851.png">

after:
<img width="354" alt="screen shot 2016-06-28 at 10 01 42" src="https://cloud.githubusercontent.com/assets/1231144/16408112/67d84fac-3d17-11e6-8dca-d488353d5f06.png">
