### PR TITLE
Add sg-box light modifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "38.0.0",
+  "version": "38.1.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -18,6 +18,7 @@ $includeHtml: false !default;
     border: $boxBorderSize solid $boxBorderColor;
     padding: (gutter(1) - $boxBorderSize);
     overflow: visible;
+    background-color: $white;
 
     &__image {
       max-width: 100%;


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/766

white background is default now.