### PR TITLE
Update sg-avatar to be display block

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "56.0.0",
+  "version": "57.0.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -14,8 +14,9 @@ $includeHtml: false !default;
 @if ($includeHtml) {
 
   .sg-avatar {
-
-    @include component;
+    display: block;
+    position: relative;
+    overflow: hidden;
 
     width: $avatarMediumSize;
     height: $avatarMediumSize;

--- a/src/components/avatar/avatar.html
+++ b/src/components/avatar/avatar.html
@@ -2,7 +2,7 @@
   <aside class="docs-block__info">
     <h3 class="docs-block__header">Default avatars</h3>
   </aside>
-  <div class="docs-block__content">
+  <div class="docs-block__content docs-block__content--to-bottom">
     <div class="sg-avatar sg-avatar--small">
       <div class="sg-avatar__image sg-avatar__image--icon">
         <svg class="sg-icon sg-icon--x24 sg-icon--gray-secondary">
@@ -51,8 +51,8 @@
   <aside class="docs-block__info">
     <h3 class="docs-block__header">Default avatars with border!</h3>
   </aside>
-  <div class="docs-block__content">
-    <div class="docs-block__contrast-box">
+  <div class="docs-block__content docs-block__content--to-bottom">
+    <div class="docs-block__contrast-box docs-block__contrast-box--to-bottom">
       <div class="sg-avatar sg-avatar--small sg-avatar--with-border">
         <div class="sg-avatar__image sg-avatar__image--icon">
           <svg class="sg-icon sg-icon--x22 sg-icon--gray-secondary">
@@ -102,7 +102,7 @@
   <aside class="docs-block__info">
     <h3 class="docs-block__header">Avatars with image</h3>
   </aside>
-  <div class="docs-block__content">
+  <div class="docs-block__content docs-block__content--to-bottom">
     <div class="sg-avatar sg-avatar--small">
       <img class="sg-avatar__image" src="https://placebear.com/48/48"/>
     </div>
@@ -127,8 +127,8 @@
   <aside class="docs-block__info">
     <h3 class="docs-block__header">Avatars with image and border</h3>
   </aside>
-  <div class="docs-block__content">
-    <div class="docs-block__contrast-box">
+  <div class="docs-block__content docs-block__content--to-bottom">
+    <div class="docs-block__contrast-box docs-block__contrast-box--to-bottom">
       <div class="sg-avatar sg-avatar--small sg-avatar--with-border">
         <img class="sg-avatar__image" src="https://placebear.com/44/44"/>
       </div>

--- a/src/docs/_sass/_docs-block.scss
+++ b/src/docs/_sass/_docs-block.scss
@@ -24,6 +24,11 @@
       align-items: center;
     }
 
+    &--to-bottom {
+      display: flex;
+      align-items: flex-end;
+    }
+
     &--align-top {
 
       & > * {
@@ -53,6 +58,11 @@
     background-color: $grayPrimary;
     padding: $baseline;
     display: inline-block;
+
+    &--to-bottom {
+      display: flex;
+      align-items: flex-end;
+    }
 
     &--full-width {
       width: 100%;


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/815
fixes issue with weird spacing around avatars