### PR TITLE
Set transparent background for sg-button-secondary--inverse

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "58.1.0",
+  "version": "58.2.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/buttons/_buttons_secondary.scss
+++ b/src/components/buttons/_buttons_secondary.scss
@@ -110,7 +110,7 @@ $includeHtml: false !default;
 
     &--inverse {
       @include sgButtonBasicColors($buttonSecondaryColor, $buttonSecondaryTextColorHover, $buttonSecondaryColor);
-      @include sgButtonSecondaryActive($buttonSecondaryColor, $buttonSecondaryColor, $buttonSecondaryTextColorHover);
+      @include sgButtonSecondaryActive($buttonSecondaryColor, $buttonSecondaryColor, transparent);
     }
 
     &--full {


### PR DESCRIPTION
when hovered (same as the rest of buttons)

<img width="110" alt="screen shot 2016-09-07 at 14 29 56" src="https://cloud.githubusercontent.com/assets/1231144/18312057/ffee39a0-7507-11e6-91f3-1536739629f1.png">
