### PR TITLE
Add gray-light modfier for icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "65.3.3",
+  "version": "65.4.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -53,6 +53,10 @@ $iconSizes: 120, 118, 96, 94, 64, 62, 48, 46, 38, 32, 30, 26, 24, 22, 20, 18, 16
       fill: $graySecondary;
     }
 
+    &--gray-light {
+      fill: $grayLight;
+    }
+
     &--blue {
       fill: $bluePrimary;
     }

--- a/src/docs/_data/icons.yml
+++ b/src/docs/_data/icons.yml
@@ -60,6 +60,7 @@ sizes:
 colors:
   - gray
   - gray-secondary
+  - gray-light
   - blue
   - mustard
   - lavender


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/825
<img width="163" alt="screen shot 2016-11-24 at 15 26 54" src="https://cloud.githubusercontent.com/assets/1231144/20601787/9ec63d36-b25a-11e6-8974-8336d8076a31.png">
