### PR TITLE
Add simple modifier for textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "65.4.0",
+  "version": "65.5.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/form-elements/_textarea.scss
+++ b/src/components/form-elements/_textarea.scss
@@ -61,6 +61,11 @@ $includeHtml: false !default;
       }
     }
 
+    &--simple {
+      border: none;
+      border-radius: 0;
+    }
+
     &--short {
       height: rhythm(1.5);
       padding: $textareaSmallPadding $textareaPadding;

--- a/src/components/form-elements/textarea.html
+++ b/src/components/form-elements/textarea.html
@@ -26,7 +26,6 @@
   </div>
 </section>
 
-
 <section class="docs-block">
   <aside class="docs-block__info">
     <h3 class="docs-block__header">Tall, XTall</h3>
@@ -38,7 +37,6 @@
     <textarea class="sg-textarea sg-textarea--xtall" placeholder="Placeholder"></textarea>
   </div>
 </section>
-
 
 <section class="docs-block">
   <aside class="docs-block__info">
@@ -58,3 +56,13 @@
   </div>
 </section>
 
+<section class="docs-block">
+  <aside class="docs-block__info">
+    <h3 class="docs-block__header">Simple</h3>
+  </aside>
+  <div class="docs-block__content">
+    <div class="docs-block__contrast-box">
+      <textarea class="sg-textarea sg-textarea--simple" placeholder="Placeholder"></textarea>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/861

<img width="580" alt="screen shot 2016-11-24 at 15 57 30" src="https://cloud.githubusercontent.com/assets/1231144/20602839/470b8a74-b25f-11e6-8f24-be1f24712c92.png">
