### PR TITLE
Add modifiers for badge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "65.5.0",
+  "version": "65.6.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/badges/_badges.scss
+++ b/src/components/badges/_badges.scss
@@ -28,6 +28,14 @@ $includeHtml: false !default;
       background-color: $blueSecondaryLight;
     }
 
+    &--mint-secondary {
+      background-color: $mintSecondary;
+    }
+
+    &--gray-secondary {
+      background-color: $graySecondary;
+    }
+
     &--rounded {
       border-radius: gutter(1 / 2);
     }

--- a/src/components/badges/badges.html
+++ b/src/components/badges/badges.html
@@ -9,6 +9,12 @@
     <div class="sg-badge sg-badge--mustard">
       <div class="sg-text sg-text--emphasised sg-text--xsmall sg-text--light">HOT</div>
     </div>
+    <div class="sg-badge sg-badge--mint-secondary">
+      <div class="sg-text sg-text--emphasised sg-text--xsmall sg-text--light">1 / 2</div>
+    </div>
+    <div class="sg-badge sg-badge--gray-secondary">
+      <div class="sg-text sg-text--emphasised sg-text--xsmall sg-text--light">2 / 3</div>
+    </div>
     <div class="sg-badge sg-badge--mint-secondary-light">
       <div class="sg-text sg-text--emphasised sg-text--xsmall sg-text--mint"> 4 / 5</div>
     </div>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/801

<img width="122" alt="screen shot 2016-11-24 at 16 51 17" src="https://cloud.githubusercontent.com/assets/1231144/20604377/63219076-b266-11e6-8fe5-086c80b61dab.png">
