### PR TITLE
Add auto-height modifier to textarea

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "70.0.0",
+  "version": "70.1.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/form-elements/_textarea.scss
+++ b/src/components/form-elements/_textarea.scss
@@ -79,5 +79,10 @@ $includeHtml: false !default;
     &--xtall {
       height: rhythm(7);
     }
+
+    &--auto-height {
+      line-height: rhythm(1);
+      height: auto;
+    }
   }
 }

--- a/src/components/form-elements/textarea.html
+++ b/src/components/form-elements/textarea.html
@@ -66,3 +66,14 @@
     </div>
   </div>
 </section>
+
+<section class="docs-block">
+  <aside class="docs-block__info">
+    <h3 class="docs-block__header">Auto height</h3>
+  </aside>
+  <div class="docs-block__content">
+    <div class="docs-block__contrast-box">
+      <textarea class="sg-textarea sg-textarea--auto-height" placeholder="Placeholder"></textarea>
+    </div>
+  </div>
+</section>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/893
renamed from `--wrapper` to `--auto-height`

<img width="579" alt="screen shot 2016-12-19 at 10 03 22" src="https://cloud.githubusercontent.com/assets/1231144/21306685/9368507e-c5d2-11e6-95d6-8b79b17f28da.png">


usage:

<img width="587" alt="screen shot 2016-12-19 at 10 04 31" src="https://cloud.githubusercontent.com/assets/1231144/21306687/937ccd4c-c5d2-11e6-9d11-c3f6b0542e90.png">
