### PR TITLE
Fix for search-light placeholder on mobile

### DIFF
--- a/src/components/header/header.html
+++ b/src/components/header/header.html
@@ -28,7 +28,7 @@
                 <div class="sg-header__middle">
                     <div class="sg-search">
                         <input type="search" placeholder="Find all the answers..."
-                               class="sg-search__input sg-input sg-input--light sg-input--full-width"/>
+                               class="sg-search__input sg-input sg-input--with-icon sg-input--light sg-input--full-width"/>
                         <div class="sg-search__button">
                             <button class="sg-icon-as-button sg-icon-as-button--small sg-icon-as-button--adaptive" type="submit">
                                 <div class="sg-icon-as-button__hole">

--- a/src/components/header/small-device.html
+++ b/src/components/header/small-device.html
@@ -19,7 +19,7 @@
       <div class="sg-header__middle">
         <div class="sg-search">
           <input type="search" placeholder="Find all the answers..."
-                 class="sg-search__input sg-input sg-input--light sg-input--full-width"/>
+                 class="sg-search__input sg-input sg-input--with-icon sg-input--light sg-input--full-width"/>
           <div class="sg-search__button">
             <button class="sg-icon-as-button sg-icon-as-button--small sg-icon-as-button--adaptive" type="submit">
               <div class="sg-icon-as-button__hole">

--- a/src/components/search/search.html
+++ b/src/components/search/search.html
@@ -69,7 +69,7 @@
         <div class="docs-block__contrast-box docs-block__contrast-box--full-width">
             <div class="sg-search">
                 <input type="search" placeholder="Find all the answers..."
-                       class="sg-search__input sg-input sg-input--light sg-input--full-width"/>
+                       class="sg-search__input sg-input--with-icon sg-input sg-input--light sg-input--full-width"/>
                 <div class="sg-search__button">
                     <button class="sg-icon-as-button sg-icon-as-button--small sg-icon-as-button--adaptive" type="submit">
                         <div class="sg-icon-as-button__hole">


### PR DESCRIPTION
Before:

<img width="210" alt="screen shot 2017-01-04 at 13 22 49" src="https://cloud.githubusercontent.com/assets/4272331/21642200/0180c748-d281-11e6-953c-8c09ad2bebab.png">

After:
<img width="229" alt="screen shot 2017-01-04 at 13 23 21" src="https://cloud.githubusercontent.com/assets/4272331/21642203/0896f37c-d281-11e6-8d3f-e78b371ca96d.png">
