### PR TITLE
Add peach modifier to icon-as-button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "75.0.2",
+  "version": "75.1.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/buttons/_icon-as-button.scss
+++ b/src/components/buttons/_icon-as-button.scss
@@ -12,6 +12,8 @@ $iconAsButtonDarkColor: $black;
 $iconAsButtonDarkActiveColor: rgba($iconAsButtonDarkColor, 0.7);
 $iconAsButtonMintColor: $mintPrimary;
 $iconAsButtonMintActiveColor: rgba($iconAsButtonMintColor, 0.7);
+$iconAsButtonPeachColor: $peachPrimary;
+$iconAsButtonPeachActiveColor: rgba($iconAsButtonPeachColor, 0.7);
 $iconAsButtonActionColor: $white;
 $iconAsButtonTransparentColor: rgba($iconAsButtonDarkColor, 0.2);
 
@@ -149,6 +151,19 @@ $includeHtml: false !default;
       }
     }
 
+    &--peach {
+      fill: $iconAsButtonPeachColor;
+
+      &:hover,
+      &:active {
+        fill: $iconAsButtonPeachActiveColor;
+      }
+
+      .sg-icon-as-button__hole {
+        border-color: $iconAsButtonPeachColor;
+      }
+    }
+
     &--action {
       transition: background 0.3s ease-out, fill 0.3s ease-out;
       border-radius: 50%;
@@ -175,6 +190,10 @@ $includeHtml: false !default;
 
         &.sg-icon-as-button--mint {
           background: $iconAsButtonMintColor;
+        }
+
+        &.sg-icon-as-button--peach {
+          background: $iconAsButtonPeachColor;
         }
       }
     }
@@ -229,6 +248,10 @@ $includeHtml: false !default;
 
       &.sg-icon-as-button--mint {
         background: $iconAsButtonMintColor;
+      }
+
+      &.sg-icon-as-button--peach {
+        background: $iconAsButtonPeachColor;
       }
     }
   }

--- a/src/components/buttons/icon-as-button.html
+++ b/src/components/buttons/icon-as-button.html
@@ -1,4 +1,4 @@
-{% assign buttonVariants = "gray,gray-secondary,dark,mint,light" | split: "," %}
+{% assign buttonVariants = "gray,gray-secondary,dark,mint,peach,light" | split: "," %}
 <section class="docs-block">
   <aside class="docs-block__info">
     <h3 class="docs-block__header">Default</h3>
@@ -115,6 +115,13 @@
       </div>
     </button>
     <button class="sg-icon-as-button sg-icon-as-button--transparent sg-icon-as-button--mint">
+      <div class="sg-icon-as-button__hole">
+        <svg class="sg-icon sg-icon--adaptive sg-icon--x26">
+          <use xlink:href="#icon-heart"></use>
+        </svg>
+      </div>
+    </button>
+    <button class="sg-icon-as-button sg-icon-as-button--transparent sg-icon-as-button--peach">
       <div class="sg-icon-as-button__hole">
         <svg class="sg-icon sg-icon--adaptive sg-icon--x26">
           <use xlink:href="#icon-heart"></use>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/833
currently used in challenges (status === falied)
after:
<img width="832" alt="screen shot 2017-01-25 at 14 39 10" src="https://cloud.githubusercontent.com/assets/1231144/22292570/38b7f330-e30c-11e6-8652-b1efbd01e962.png">
before:
<img width="850" alt="screen shot 2017-01-25 at 14 39 15" src="https://cloud.githubusercontent.com/assets/1231144/22292571/38b966a2-e30c-11e6-9cfe-a66684098107.png">
