### PR TITLE
Content box spaced - do not apply to children

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "76.1.1",
+  "version": "76.1.2",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/content-box/_content-box.scss
+++ b/src/components/content-box/_content-box.scss
@@ -49,8 +49,8 @@ $includeHtml: false !default;
     }
 
     &--spaced {
-      .sg-content-box__content,
-      .sg-content-box__actions {
+      > .sg-content-box__content,
+      > .sg-content-box__actions {
         @include sgBreakpoint(medium-up) {
           padding-left: gutter(2);
         }


### PR DESCRIPTION
![screen shot 2017-03-03 at 09 49 34](https://cloud.githubusercontent.com/assets/985504/23544546/ba244880-fff7-11e6-916d-ae295652271f.png)

Unwanted spacing in attachments because `--spaced` styles are cascading