### PR TITLE
Add xxsmall and light modifier to icon-as-button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "76.4.0",
+  "version": "76.5.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/buttons/_icon-as-button.scss
+++ b/src/components/buttons/_icon-as-button.scss
@@ -66,6 +66,13 @@ $includeHtml: false !default;
       }
     }
 
+    &--xxsmall {
+      .sg-icon-as-button__hole {
+        width: 16px;
+        height: 16px;
+      }
+    }
+
     &--with-border {
       .sg-icon-as-button__hole {
         border: solid $iconAsButtonColor 1px;

--- a/src/components/buttons/_icon-as-button.scss
+++ b/src/components/buttons/_icon-as-button.scss
@@ -260,6 +260,10 @@ $includeHtml: false !default;
       &.sg-icon-as-button--peach {
         background: $iconAsButtonPeachColor;
       }
+
+      &.sg-icon-as-button--light {
+        background: $iconAsButtonActionColor;
+      }
     }
   }
 }

--- a/src/components/buttons/icon-as-button.html
+++ b/src/components/buttons/icon-as-button.html
@@ -232,3 +232,39 @@
     </button>
   </div>
 </section>
+
+<section class="docs-block">
+  <aside class="docs-block__info">
+    <h3 class="docs-block__header">xxsmall</h3>
+  </aside>
+  <div class="docs-block__content">
+    <button class="sg-icon-as-button sg-icon-as-button--xxsmall">
+      <div class="sg-icon-as-button__hole">
+        <svg class="sg-icon sg-icon--adaptive sg-icon--x10">
+          <use xlink:href="#icon-notifications"></use>
+        </svg>
+      </div>
+    </button>
+    <button class="sg-icon-as-button sg-icon-as-button--with-border sg-icon-as-button--xxsmall">
+      <div class="sg-icon-as-button__hole">
+        <svg class="sg-icon sg-icon--adaptive sg-icon--x10">
+          <use xlink:href="#icon-notifications"></use>
+        </svg>
+      </div>
+    </button>
+    <button class="sg-icon-as-button sg-icon-as-button--action sg-icon-as-button--xxsmall">
+      <div class="sg-icon-as-button__hole">
+        <svg class="sg-icon sg-icon--adaptive sg-icon--x10">
+          <use xlink:href="#icon-notifications"></use>
+        </svg>
+      </div>
+    </button>
+    <button class="sg-icon-as-button sg-icon-as-button--action sg-icon-as-button--rounded-square sg-icon-as-button--xxsmall">
+      <div class="sg-icon-as-button__hole">
+        <svg class="sg-icon sg-icon--adaptive sg-icon--x10">
+          <use xlink:href="#icon-notifications"></use>
+        </svg>
+      </div>
+    </button>
+  </div>
+</section>

--- a/src/components/buttons/icon-as-button.html
+++ b/src/components/buttons/icon-as-button.html
@@ -90,14 +90,18 @@
       </div>
     </button>
     {% for variant in buttonVariants %}
-      {% if variant != 'light' %}
-    <button class="sg-icon-as-button sg-icon-as-button--action-active sg-icon-as-button--{{ variant }}">
-      <div class="sg-icon-as-button__hole">
-        <svg class="sg-icon sg-icon--adaptive sg-icon--x26">
-          <use xlink:href="#icon-heart"></use>
-        </svg>
-      </div>
-    </button>
+      {% if variant == 'light' %}
+        <div class="docs-block__content docs-block__contrast-box">
+      {% endif %}
+      <button class="sg-icon-as-button sg-icon-as-button--action-active sg-icon-as-button--{{ variant }}">
+        <div class="sg-icon-as-button__hole">
+          <svg class="sg-icon sg-icon--adaptive {% if variant == 'light' %} sg-icon--mint{% endif %} sg-icon--x26">
+            <use xlink:href="#icon-heart"></use>
+          </svg>
+        </div>
+      </button>
+      {% if variant == 'light' %}
+        </div>
       {% endif %}
     {% endfor %}
   </div>


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/935
closes https://github.com/brainly/style-guide/issues/936

<img width="521" alt="screen shot 2017-03-24 at 16 10 26" src="https://cloud.githubusercontent.com/assets/1231144/24300369/8ed61d00-10ac-11e7-9df3-57160f0bd43d.png">

<img width="292" alt="screen shot 2017-03-24 at 16 22 23" src="https://cloud.githubusercontent.com/assets/1231144/24300880/37aca4ca-10ae-11e7-8de0-63b06e414a10.png">

