### PR TITLE
Add hack for Safari inline-flex on buttons issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "77.2.0",
+  "version": "77.2.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -31,6 +31,13 @@ $buttonActiveScale: scale(0.985);
   transition-property: box-shadow, transform, opacity;
   transition-duration: 0.3s;
 
+  // hack for proper text centering on Safari related to inline-flex issue with <button> tag
+  &::before,
+  &::after {
+    content: '';
+    flex: 1 0 auto;
+  }
+
   &:hover,
   &:focus {
     box-shadow: $buttonHoverBoxShadow;


### PR DESCRIPTION
solution found here: http://stackoverflow.com/questions/35464067/flexbox-not-working-on-button-element-in-some-browsers/40483475#40483475

before:
<img width="565" alt="screen shot 2017-05-04 at 12 28 57" src="https://cloud.githubusercontent.com/assets/1231144/25700267/381bb890-30c7-11e7-904c-51f963323ecd.png">

after:
<img width="692" alt="screen shot 2017-05-04 at 12 40 25" src="https://cloud.githubusercontent.com/assets/1231144/25700268/381d420a-30c7-11e7-875b-82e3ceecafe5.png">
