### PR TITLE
Remove flex-basis: 1px; from layout content (IE11 issue)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "78.0.0",
+  "version": "78.0.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/layout/_layout.scss
+++ b/src/components/layout/_layout.scss
@@ -85,7 +85,6 @@ $layoutGapWidth: gutter(5 / 6);
 
     @include sgBreakpoint(large-only) {
       max-width: calc(100% - #{$layoutAsideWidth + $layoutGapWidth});
-      flex-basis: 1px;
       flex-grow: 1;
     }
 


### PR DESCRIPTION
using `flex-basis: 1px;` here was related to jumping two-column layout.
checked on chrome and firefox: layout is not jumping anymore without `flex-basic: 1px;`

IE11 before:
<img width="1383" alt="screen shot 2017-05-18 at 10 37 06" src="https://cloud.githubusercontent.com/assets/1231144/26193739/76b63d2e-3bb6-11e7-8b4a-db18ba396295.png">

IE11 after:
<img width="1175" alt="screen shot 2017-05-18 at 10 38 59" src="https://cloud.githubusercontent.com/assets/1231144/26193740/76b9c7b4-3bb6-11e7-9934-68aaec2f9f57.png">