### PR TITLE
Add padding for flash message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "85.1.0",
+  "version": "85.1.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/flash-messages/_flash-messages.scss
+++ b/src/components/flash-messages/_flash-messages.scss
@@ -11,6 +11,7 @@
     background-color: $blueSecondary;
     min-height: rhythm(1);
     width: 100%;
+    padding: rhythm(1/4);
 
     &--error {
       background-color: $peachSecondary;


### PR DESCRIPTION
Before:
<img width="692" alt="screen shot 2017-07-04 at 09 57 43" src="https://user-images.githubusercontent.com/9083292/27820649-be951ba2-609f-11e7-8a7a-852f115d587e.png">

After:
<img width="696" alt="screen shot 2017-07-04 at 09 58 20" src="https://user-images.githubusercontent.com/9083292/27820613-9a374f82-609f-11e7-8031-5ca84b962d72.png">
Fixed issue #3391