### PR TITLE
dark docs active block bg for some interactive components

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "106.3.0",
+  "version": "106.3.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/badges/pages/badges-interactive.jsx
+++ b/src/components/badges/pages/badges-interactive.jsx
@@ -23,10 +23,10 @@ const Badges = () => {
   ];
 
   return <div>
-    <DocsActiveBlock settings={settings}>
+    <DocsActiveBlock settings={settings} backgroundColor="dark">
       <Badge>3 / 5</Badge>
     </DocsActiveBlock>
-    <DocsActiveBlock settings={settings}>
+    <DocsActiveBlock settings={settings} backgroundColor="dark">
       <Badge color={COLOR.PEACH} rounded={true} withAnimation={true}>123</Badge>
     </DocsActiveBlock>
   </div>;

--- a/src/components/bubble/pages/bubble-interactive.jsx
+++ b/src/components/bubble/pages/bubble-interactive.jsx
@@ -31,14 +31,14 @@ const Bubbles = () => {
   ];
 
   return <div>
-    <DocsActiveBlock settings={settings}>
+    <DocsActiveBlock settings={settings} backgroundColor="dark">
       <Bubble direction={DIRECTION.TOP}>
         Hi there!!<br/>
         Just wondering if you have any problems with your school work.
       </Bubble>
     </DocsActiveBlock>
 
-    <DocsActiveBlock settings={settings}>
+    <DocsActiveBlock settings={settings} backgroundColor="dark">
       <Bubble direction={DIRECTION.TOP}>
         <ContentBox>
           <ContentBoxHeader>

--- a/src/components/buttons/pages/buttons-interactive.jsx
+++ b/src/components/buttons/pages/buttons-interactive.jsx
@@ -86,13 +86,13 @@ const Buttons = () => {
         <Icon type={ICON_TYPES.SEARCH} color={ICON_COLORS.ADAPTIVE} size={14}/>
       </ButtonSecondary>
     </DocsActiveBlock>
-    <DocsActiveBlock settings={secondarySettings}>
+    <DocsActiveBlock settings={secondarySettings} backgroundColor="dark">
       <ButtonSecondary type={SECONDARY_TYPE.INVERSE} small={true}>
         <Label text="Comment" number={21} iconType={ICON_TYPE.COMMENT}
           iconColor={ICON_COLOR.LAVENDER} secondary={true}/>
       </ButtonSecondary>
     </DocsActiveBlock>
-    <DocsActiveBlock settings={secondarySettings}>
+    <DocsActiveBlock settings={secondarySettings} backgroundColor="dark">
       <ButtonSecondary type={SECONDARY_TYPE.ACTIVE_INVERSE} small={true}>
         <Label text="Thank you" number={331} iconType={ICON_TYPE.HEART}
           iconColor={ICON_COLOR.ADAPTIVE} secondary={true} unstyled={true}/>

--- a/src/components/separators/pages/separators-interactive.jsx
+++ b/src/components/separators/pages/separators-interactive.jsx
@@ -20,6 +20,7 @@ const Separators = () => {
 
   return <div>
     <DocsActiveBlock settings={verticalSettings}
+      backgroundColor="dark"
       contentBefore={<Avatar imgSrc="https://source.unsplash.com/64x64/?cat"/>}
       contentAfter={<Avatar size={AVATAR_SIZE.SMALL}/>}>
 
@@ -27,7 +28,9 @@ const Separators = () => {
 
     </DocsActiveBlock>
 
-    <DocsActiveBlock settings={horizontalSettings} componentType={SeparatorHorizontal}
+    <DocsActiveBlock
+      backgroundColor="dark"
+      settings={horizontalSettings} componentType={SeparatorHorizontal}
       contentBefore={<Avatar size={AVATAR_SIZE.SMALL}/>}
       contentAfter={<Avatar size={AVATAR_SIZE.SMALL}/>}
       wrapper={<div/>}>

--- a/src/components/stickers/pages/stickers-interactive.jsx
+++ b/src/components/stickers/pages/stickers-interactive.jsx
@@ -12,7 +12,7 @@ const Stickers = () => {
   ];
 
   return <div>
-    <DocsActiveBlock settings={settings}>
+    <DocsActiveBlock settings={settings} backgroundColor="dark">
       <Sticker type={TYPE.QUESTION}/>
     </DocsActiveBlock>
   </div>;

--- a/src/components/subject-icons/pages/subject-icons-interactive.jsx
+++ b/src/components/subject-icons/pages/subject-icons-interactive.jsx
@@ -23,7 +23,7 @@ const SubjectIcons = () => {
     <DocsActiveBlock settings={settings}>
       <SubjectIcon type={TYPE.MATHEMATICS}/>
     </DocsActiveBlock>
-    <DocsActiveBlock settings={settings}>
+    <DocsActiveBlock settings={settings} backgroundColor="dark">
       <SubjectIcon type={TYPE.BIOLOGY} mono={true}/>
     </DocsActiveBlock>
   </div>;


### PR DESCRIPTION
<img width="1040" alt="screen shot 2017-07-27 at 13 48 05" src="https://user-images.githubusercontent.com/9083292/28674633-3f04a00c-72e6-11e7-90c0-70601bb56638.png">
<img width="706" alt="screen shot 2017-07-27 at 16 09 51" src="https://user-images.githubusercontent.com/9083292/28674635-3f0867b4-72e6-11e7-8d80-bcf3cb98b149.png">
<img width="698" alt="screen shot 2017-07-27 at 16 10 00" src="https://user-images.githubusercontent.com/9083292/28674637-3f11f040-72e6-11e7-88b1-e6b325eff93f.png">
<img width="694" alt="screen shot 2017-07-27 at 16 10 07" src="https://user-images.githubusercontent.com/9083292/28674632-3f043716-72e6-11e7-9e91-98142240384a.png">
<img width="689" alt="screen shot 2017-07-27 at 16 10 15" src="https://user-images.githubusercontent.com/9083292/28674634-3f076666-72e6-11e7-8b9c-523cc8823610.png">
<img width="681" alt="screen shot 2017-07-27 at 16 10 21" src="https://user-images.githubusercontent.com/9083292/28674636-3f08ff8a-72e6-11e7-8f13-6d6ce1a61c9f.png">
<img width="693" alt="screen shot 2017-07-27 at 16 10 30" src="https://user-images.githubusercontent.com/9083292/28674638-3f1d4256-72e6-11e7-89db-b9895008d8c1.png">
