### PR TITLE
firefox transparent placeholder fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "112.2.0",
+  "version": "112.2.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/form-elements/_text-input.scss
+++ b/src/components/form-elements/_text-input.scss
@@ -55,6 +55,7 @@ $includeHtml: false !default;
       font-size: $inputPlaceholderFontSize;
       font-weight: $fontWeightBold;
       position: relative;
+      opacity: 1;
     }
 
     &--light {


### PR DESCRIPTION
before:
<img width="712" alt="screen shot 2017-09-11 at 12 56 56" src="https://user-images.githubusercontent.com/9083292/30271528-efc60e16-96f0-11e7-9980-7e369f32ea0e.png">

after:
<img width="711" alt="screen shot 2017-09-11 at 12 56 34" src="https://user-images.githubusercontent.com/9083292/30271532-f37e3b64-96f0-11e7-9c19-fd44b96ce4a2.png">

closes #934
