### PR TITLE
Revert "Limit height of toplayer--splash-screen"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "116.2.3",
+  "version": "116.2.4",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/toplayer/_toplayer.scss
+++ b/src/components/toplayer/_toplayer.scss
@@ -93,12 +93,7 @@ $includeHtml: false !default;
       // sass-lint:enable no-duplicate-properties
 
       @include sgBreakpoint(medium-up) {
-        min-height: 0;
-        height: 100%;
-        // sass-lint:disable no-duplicate-properties
-        height: calc(100% - #{gutter(2)});
-        // sass-lint:enable no-duplicate-properties
-        max-height: gutter(33);
+        min-height: calc(100% - #{gutter(2)});
         margin: gutter(1);
       }
     }


### PR DESCRIPTION
Reverts brainly/style-guide#1315
issue: not visible content
<img width="1064" alt="screen shot 2017-10-25 at 09 56 42" src="https://user-images.githubusercontent.com/1231144/31987046-d477dac6-b96a-11e7-8119-8358ff00668c.png">
