### PR TITLE
Adjust Brainly Plus home-button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "118.2.0",
+  "version": "118.3.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/home-button/_home-button.scss
+++ b/src/components/home-button/_home-button.scss
@@ -35,7 +35,7 @@ $includeHtml: false !default;
     }
 
     &--brainly-plus &__logo-big {
-      width: 70px;
+      height: 41px;
     }
 
     &--eodev &__logo-big {


### PR DESCRIPTION
Brainly Plus home-button has the same width as Brainly default home-button.

<img width="646" alt="screen shot 2017-10-27 at 15 39 17" src="https://user-images.githubusercontent.com/1231144/32106853-2eddf93c-bb2d-11e7-82a4-b006319f268c.png">
