### PR TITLE
Added href to IconAsButton

### DIFF
--- a/src/components/icon-as-button/IconAsButton.jsx
+++ b/src/components/icon-as-button/IconAsButton.jsx
@@ -32,14 +32,20 @@ const IconAsButton = ({
     content = children;
   }
 
+  let renderType = 'button';
+
+  if (props.href) {
+    renderType = 'a';
+  }
+
   return (
-    <button {...props} className={buttonClass}>
+    <renderType {...props} className={buttonClass}>
       <div className="sg-icon-as-button__hole">
         <IconAsButtonContent overlay={overlay}>
           {content}
         </IconAsButtonContent>
       </div>
-    </button>
+    </renderType>
   );
 };
 

--- a/src/components/icon-as-button/IconAsButton.jsx
+++ b/src/components/icon-as-button/IconAsButton.jsx
@@ -32,20 +32,20 @@ const IconAsButton = ({
     content = children;
   }
 
-  let renderType = 'button';
+  let RenderType = 'button';
 
   if (props.href) {
-    renderType = 'a';
+    RenderType = 'a';
   }
 
   return (
-    <renderType {...props} className={buttonClass}>
+    <RenderType {...props} role="button" className={buttonClass}>
       <div className="sg-icon-as-button__hole">
         <IconAsButtonContent overlay={overlay}>
           {content}
         </IconAsButtonContent>
       </div>
-    </renderType>
+    </RenderType>
   );
 };
 
@@ -59,6 +59,7 @@ IconAsButton.propTypes = {
   transparent: PropTypes.bool,
   active: PropTypes.bool,
   overlay: PropTypes.node,
+  href: PropTypes.string,
   className: PropTypes.string
 };
 

--- a/src/components/icon-as-button/IconAsButton.spec.jsx
+++ b/src/components/icon-as-button/IconAsButton.spec.jsx
@@ -136,3 +136,14 @@ test('error when more than 1 child', () => {
 
   spy.mockRestore();
 });
+
+test('link as button', () => {
+  const type = TYPE.ANSWER;
+  const href = 'http://brainly.test';
+
+  const iconAsButton = shallow(
+    <IconAsButton type={type} href={href} />
+  );
+
+  expect(iconAsButton.find('a')).toHaveLength(1);
+});

--- a/src/components/icon-as-button/pages/icon-as-button-interactive.jsx
+++ b/src/components/icon-as-button/pages/icon-as-button-interactive.jsx
@@ -33,6 +33,10 @@ const IconsAsButtons = () => {
     {
       name: 'active',
       values: Boolean
+    },
+    {
+      name: 'href',
+      values: String
     }
   ];
 


### PR DESCRIPTION
IconAsButton will render as a `<a>` when href is passed in as props. Also added `role="button"` for accessibility. 