### PR TITLE
Add no-padding modifier to Toplayer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "130.6.1",
+  "version": "130.7.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/toplayer/TopLayer.jsx
+++ b/src/components/toplayer/TopLayer.jsx
@@ -22,6 +22,7 @@ const TopLayer = props => {
     splashScreen,
     limitedWidth,
     row,
+    noPadding,
     className,
     ...additionalProps
   } = props;
@@ -38,6 +39,10 @@ const TopLayer = props => {
     [`sg-toplayer--${size}`]: size
   }, className);
 
+  const toplayerWrapperClassName = classnames('sg-toplayer__wrapper', {
+    'sg-toplayer__wrapper--no-padding': noPadding
+  });
+
   return (
     <div {...additionalProps} className={topLayerClassName}>
       {onClose ?
@@ -45,7 +50,7 @@ const TopLayer = props => {
           <Icon type={iconTypes.X} color={ICON_COLOR.GRAY_SECONDARY} size={14} />
         </div> : null
       }
-      <div className="sg-toplayer__wrapper">
+      <div className={toplayerWrapperClassName}>
         {children}
       </div>
     </div>
@@ -64,6 +69,7 @@ TopLayer.propTypes = {
   limitedWidth: PropTypes.bool,
   row: PropTypes.bool,
   size: PropTypes.oneOf(Object.values(SIZE)),
+  noPadding: PropTypes.bool,
   className: PropTypes.string
 };
 

--- a/src/components/toplayer/TopLayer.spec.jsx
+++ b/src/components/toplayer/TopLayer.spec.jsx
@@ -95,3 +95,19 @@ test('testing modifications - all off', () => {
   expect(topLayer.hasClass('sg-toplayer--limited-width')).toEqual(false);
   expect(topLayer.hasClass('sg-toplayer--row')).toEqual(false);
 });
+
+test('testing wrapper', () => {
+  const topLayer = shallow(
+    <TopLayer>some text</TopLayer>
+  );
+
+  expect(topLayer.find('.sg-toplayer__wrapper')).toHaveLength(1);
+});
+
+test('testing wrapper without padding', () => {
+  const topLayer = shallow(
+    <TopLayer noPadding>some text</TopLayer>
+  );
+
+  expect(topLayer.find('.sg-toplayer__wrapper').hasClass('sg-toplayer__wrapper--no-padding')).toEqual(true);
+});

--- a/src/components/toplayer/_toplayer.scss
+++ b/src/components/toplayer/_toplayer.scss
@@ -117,6 +117,11 @@ $includeHtml: false !default;
 
     &__wrapper {
       padding: rhythm(1) gutter(1);
+      width: 100%;
+
+      &--no-padding {
+        padding: 0;
+      }
     }
 
     &__actions {

--- a/src/components/toplayer/pages/toplayer-interactive.jsx
+++ b/src/components/toplayer/pages/toplayer-interactive.jsx
@@ -51,6 +51,10 @@ const Toplayers = () => {
     {
       name: 'row',
       values: Boolean
+    },
+    {
+      name: 'noPadding',
+      values: Boolean
     }
   ];
 


### PR DESCRIPTION
noPadding=false

<img width="834" alt="screen shot 2018-02-08 at 10 21 29" src="https://user-images.githubusercontent.com/1231144/35965129-30df86ea-0cba-11e8-8b4d-8884e3e1b472.png">
<img width="868" alt="screen shot 2018-02-08 at 10 21 34" src="https://user-images.githubusercontent.com/1231144/35965130-31057a62-0cba-11e8-8104-2b132ab7b547.png">

noPadding=true