### PR TITLE
Fix textarea value PropType

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "131.0.0",
+  "version": "132.0.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/form-elements/Textarea.jsx
+++ b/src/components/form-elements/Textarea.jsx
@@ -51,7 +51,7 @@ const Textarea = props => {
 Textarea.propTypes = {
   Type: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   textareaRef: PropTypes.func,
-  value: PropTypes.string,
+  value: PropTypes.any,
   size: PropTypes.oneOf(Object.values(SIZE)),
   valid: PropTypes.bool,
   invalid: PropTypes.bool,


### PR DESCRIPTION
`PropTypes.string` was only valid for the native `<textarea />`, but not neccessarily for other node `Type`s.