### PR TITLE
Add transparent modifier to TopLayer and Card

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "132.7.1",
+  "version": "132.8.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/card/Card.jsx
+++ b/src/components/card/Card.jsx
@@ -7,12 +7,13 @@ export const CARD_PADDING = {
   LARGE: 'padding-large'
 };
 
-const Card = ({children, full, centered, padding, shadow, noBorder, className, ...props}) => {
+const Card = ({children, full, centered, padding, shadow, noBorder, transparent, className, ...props}) => {
   const cardClass = classNames('sg-card', {
     'sg-card--full': full,
     'sg-card--with-shadow': shadow,
     'sg-card--no-border': noBorder,
     'sg-card--centered': centered,
+    'sg-card--transparent': transparent,
     [`sg-card--${padding}`]: padding
   }, className);
 
@@ -29,6 +30,7 @@ Card.propTypes = {
   centered: PropTypes.bool,
   noBorder: PropTypes.bool,
   shadow: PropTypes.bool,
+  transparent: PropTypes.bool,
   padding: PropTypes.oneOf(Object.values(CARD_PADDING)),
   className: PropTypes.string
 };

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -16,6 +16,10 @@ $includeHtml: false !default;
     overflow: hidden;
     background-color: $white;
 
+    &--transparent {
+      background-color: transparent;
+    }
+
     &--full {
       width: 100%;
 

--- a/src/components/card/pages/card-interactive.jsx
+++ b/src/components/card/pages/card-interactive.jsx
@@ -24,6 +24,10 @@ const Cards = () => {
       values: Boolean
     },
     {
+      name: 'transparent',
+      values: Boolean
+    },
+    {
       name: 'shadow',
       values: Boolean
     }

--- a/src/components/toplayer/TopLayer.jsx
+++ b/src/components/toplayer/TopLayer.jsx
@@ -23,6 +23,7 @@ const TopLayer = props => {
     limitedWidth,
     row,
     noPadding,
+    transparent,
     className,
     ...additionalProps
   } = props;
@@ -36,6 +37,7 @@ const TopLayer = props => {
     'sg-toplayer--splash-screen': splashScreen,
     'sg-toplayer--limited-width': limitedWidth,
     'sg-toplayer--row': row,
+    'sg-toplayer--transparent': transparent,
     [`sg-toplayer--${size}`]: size
   }, className);
 
@@ -69,6 +71,7 @@ TopLayer.propTypes = {
   limitedWidth: PropTypes.bool,
   row: PropTypes.bool,
   size: PropTypes.oneOf(Object.values(SIZE)),
+  transparent: PropTypes.bool,
   noPadding: PropTypes.bool,
   className: PropTypes.string
 };

--- a/src/components/toplayer/_toplayer.scss
+++ b/src/components/toplayer/_toplayer.scss
@@ -18,6 +18,10 @@ $includeHtml: false !default;
     background-color: $toplayerBackgroundColor;
     position: relative;
 
+    &--transparent {
+      background-color: transparent;
+    }
+
     &--lead {
       .sg-toplayer__wrapper {
         @include sgBreakpoint(medium-up) {

--- a/src/components/toplayer/pages/toplayer-interactive.jsx
+++ b/src/components/toplayer/pages/toplayer-interactive.jsx
@@ -53,6 +53,10 @@ const Toplayers = () => {
       values: Boolean
     },
     {
+      name: 'transparent',
+      values: Boolean
+    },
+    {
       name: 'noPadding',
       values: Boolean
     }


### PR DESCRIPTION
<img width="711" alt="screen shot 2018-04-10 at 15 26 52" src="https://user-images.githubusercontent.com/1231144/38559556-a3aa321c-3cd3-11e8-8e3f-350e200b3d20.png">
<img width="707" alt="screen shot 2018-04-10 at 15 26 58" src="https://user-images.githubusercontent.com/1231144/38559557-a3cf4fe8-3cd3-11e8-9286-076f081fab9b.png">

Added to avoid cases like following:
<img width="107" alt="screen shot 2018-04-10 at 15 30 00" src="https://user-images.githubusercontent.com/1231144/38559739-194a759a-3cd4-11e8-916f-1316f70d302e.png">
when TopLayer/Card's content has its own background-color and it's rounded
