### PR TITLE
Upgrade rating component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "132.11.0",
+  "version": "133.0.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "133.0.0",
+  "version": "134.0.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/rating/Rating.jsx
+++ b/src/components/rating/Rating.jsx
@@ -83,11 +83,11 @@ class Rating extends Component {
 
   render() {
     const {metricSize, rate, size = RATING_SIZE.NORMAL,
-      active, toBottom, className, counterText, activeText} = this.props;
+      active, className, counterText, activeText, altLabels} = this.props;
     const ratingClass = classnames('sg-rate-box', {
       'sg-rate-box--large': size === RATING_SIZE.LARGE,
       'sg-rate-box--small': size === RATING_SIZE.SMALL,
-      'sg-rate-box--to-bottom': toBottom,
+      'sg-rate-box--with-alt-labels': altLabels,
       'sg-rate-box--active': active
     }, className);
 
@@ -127,7 +127,7 @@ Rating.propTypes = {
   rate: PropTypes.number,
   metricSize: PropTypes.number,
   active: PropTypes.bool,
-  toBottom: PropTypes.bool,
+  altLabels: PropTypes.bool,
   onChange: PropTypes.func,
   onStarMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,

--- a/src/components/rating/Rating.jsx
+++ b/src/components/rating/Rating.jsx
@@ -5,7 +5,6 @@ import Star from './subcomponents/Star';
 import RateCounter from './subcomponents/RateCounter';
 
 export const RATING_SIZE = {
-  SMALL: 14,
   NORMAL: 16,
   LARGE: 24
 };
@@ -83,11 +82,9 @@ class Rating extends Component {
 
   render() {
     const {metricSize, rate, size = RATING_SIZE.NORMAL,
-      active, className, counterText, activeText, altLabels} = this.props;
+      active, className, counterText, activeText} = this.props;
     const ratingClass = classnames('sg-rate-box', {
       'sg-rate-box--large': size === RATING_SIZE.LARGE,
-      'sg-rate-box--small': size === RATING_SIZE.SMALL,
-      'sg-rate-box--with-alt-labels': altLabels,
       'sg-rate-box--active': active
     }, className);
 
@@ -127,7 +124,6 @@ Rating.propTypes = {
   rate: PropTypes.number,
   metricSize: PropTypes.number,
   active: PropTypes.bool,
-  altLabels: PropTypes.bool,
   onChange: PropTypes.func,
   onStarMouseEnter: PropTypes.func,
   onMouseLeave: PropTypes.func,

--- a/src/components/rating/Rating.jsx
+++ b/src/components/rating/Rating.jsx
@@ -4,9 +4,10 @@ import classnames from 'classnames';
 import Star from './subcomponents/Star';
 import RateCounter from './subcomponents/RateCounter';
 
-const ICO_SIZE = {
+export const RATING_SIZE = {
   SMALL: 14,
-  NORMAL: 16
+  NORMAL: 16,
+  LARGE: 24
 };
 
 const generateArrayRange = function(range) {
@@ -22,22 +23,26 @@ const generateArrayRange = function(range) {
 class Rating extends Component {
   static defaultProps = {
     onChange: () => undefined,
+    onStarMouseEnter: () => undefined,
+    onMouseLeave: () => undefined,
     metricSize: 5,
     rate: 0
   };
 
   constructor(props) {
     super(props);
+
     this.createStarsOnClickFunctions(this.props.metricSize);
+    this.createStarsMouseEnterFunctions(this.props.metricSize);
   }
 
-  state = {
-    hoveringStars: false
-  };
+  starsOnClickFunctions = null;
+  starsOnIconMouseEnterFunctions = null;
 
   componentWillReciveProps(nextProps) {
     if (this.props.metricSize !== nextProps.metricSize) {
       this.createStarsOnClickFunctions(nextProps.metricSize);
+      this.createStarsMouseEnterFunctions(this.props.metricSize);
     }
   }
 
@@ -45,42 +50,50 @@ class Rating extends Component {
     this.starsOnClickFunctions = generateArrayRange(metricSize).map(rangeIndex => () => this.onClick(rangeIndex));
   }
 
+  createStarsMouseEnterFunctions(metricSize) {
+    this.starsMouseEnterFunctions = generateArrayRange(metricSize).map(rangeIndex =>
+      event => this.onStarMouseEnter(rangeIndex, event)
+    );
+  }
+
   onClick = index => {
-    const {onChange, rate, active} = this.props;
+    const {onChange, active} = this.props;
 
     if (!active) {
       return;
     }
     const ratedStarIndex = index + 1;
 
-    if (ratedStarIndex !== rate) {
-      onChange(ratedStarIndex);
-    }
+    onChange(ratedStarIndex);
   };
 
-  onMouseEnter = () => {
-    if (!this.props.active) {
+  onStarMouseEnter = (index, event) => {
+    const {onStarMouseEnter, active} = this.props;
+
+    if (!active) {
       return;
     }
 
-    this.setState({hoveringStars: true});
+    onStarMouseEnter(index + 1, event);
   };
 
   onMouseLeave = () => {
-    this.setState({hoveringStars: false});
+    this.props.onMouseLeave();
   };
 
   render() {
-    const {metricSize, rate, small, active, className, counterText, activeText} = this.props;
-    const {hoveringStars} = this.state;
+    const {metricSize, rate, size = RATING_SIZE.NORMAL,
+      active, toBottom, className, counterText, activeText} = this.props;
     const ratingClass = classnames('sg-rate-box', {
-      'sg-rate-box--small': small,
+      'sg-rate-box--large': size === RATING_SIZE.LARGE,
+      'sg-rate-box--small': size === RATING_SIZE.SMALL,
+      'sg-rate-box--to-bottom': toBottom,
       'sg-rate-box--active': active
     }, className);
 
     const starsProps = generateArrayRange(metricSize).map(rangeIndex => ({
       key: rangeIndex,
-      size: small ? ICO_SIZE.SMALL : ICO_SIZE.NORMAL,
+      size,
       onClick: this.starsOnClickFunctions[rangeIndex]
     }));
 
@@ -91,18 +104,18 @@ class Rating extends Component {
         <div className="sg-rate-box__rate">
           {rateString}
         </div>
-        <div className="sg-rate-box__stars-container" onMouseEnter={this.onMouseEnter} onMouseLeave={this.onMouseLeave}>
+        <div className="sg-rate-box__stars-container" onMouseLeave={this.onMouseLeave}>
           <div className="sg-rate-box__filled-stars" style={{width: `${100 * rate / metricSize}%`}}>
             {starsProps.map(props => <Star key={props.key} {...props} />)}
           </div>
           <div className="sg-rate-box__background-stars">
-            {starsProps.map(props => <Star key={props.key} {...props} />)}
+            {starsProps.map(props =>
+              <Star key={props.key} onMouseEnter={this.starsMouseEnterFunctions[props.key]} {...props} />)}
           </div>
         </div>
         <RateCounter
           activeText={activeText}
           counterText={counterText}
-          showActiveText={hoveringStars || active && rate === 0}
         />
       </div>
     );
@@ -110,11 +123,14 @@ class Rating extends Component {
 }
 
 Rating.propTypes = {
-  small: PropTypes.bool,
+  size: PropTypes.number,
   rate: PropTypes.number,
   metricSize: PropTypes.number,
   active: PropTypes.bool,
+  toBottom: PropTypes.bool,
   onChange: PropTypes.func,
+  onStarMouseEnter: PropTypes.func,
+  onMouseLeave: PropTypes.func,
   counterText: PropTypes.string,
   activeText: PropTypes.string,
   className: PropTypes.string

--- a/src/components/rating/Rating.spec.jsx
+++ b/src/components/rating/Rating.spec.jsx
@@ -120,31 +120,16 @@ describe('rating', () => {
     spy.mockRestore();
   });
 
-  it('small', () => {
-    const sizeOfSmallStar = 14;
+  it('large', () => {
     const rating = shallow(
-      <Rating size={RATING_SIZE.SMALL} />
+      <Rating size={RATING_SIZE.LARGE} />
     );
     const stars = rating.find(Star);
 
-    expect(rating.hasClass('sg-rate-box--small')).toEqual(true);
+    expect(rating.hasClass('sg-rate-box--large')).toEqual(true);
 
     stars.forEach(star => {
-      expect(star.props().size).toEqual(sizeOfSmallStar);
-    });
-  });
-
-  it('small isn\'t defined', () => {
-    const sizeOfNormalStar = 16;
-    const rating = shallow(
-      <Rating />
-    );
-    const stars = rating.find(Star);
-
-    expect(rating.hasClass('sg-rate-box--small')).toEqual(false);
-
-    stars.forEach(star => {
-      expect(star.props().size).toEqual(sizeOfNormalStar);
+      expect(star.props().size).toEqual(RATING_SIZE.LARGE);
     });
   });
 

--- a/src/components/rating/Rating.spec.jsx
+++ b/src/components/rating/Rating.spec.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {shallow, mount} from 'enzyme';
 import Icon from 'icons/Icon';
-import Rating from './Rating';
+import Rating, {RATING_SIZE} from './Rating';
 import RateCounter from './subcomponents/RateCounter';
 import Star from './subcomponents/Star';
 
@@ -95,12 +95,6 @@ describe('rating', () => {
 
     stars.at(1).simulate('click');
     expect(onChange.mock.calls).toHaveLength(2);
-
-    const lastRatedStarIndex = rate - 1;
-
-    //shouldn't call onChange when same rate clicked
-    stars.at(lastRatedStarIndex).simulate('click');
-    expect(onChange.mock.calls).toHaveLength(2);
   });
 
   it('doesn\'t throw error when onChange isn\'t defined', () => {
@@ -129,7 +123,7 @@ describe('rating', () => {
   it('small', () => {
     const sizeOfSmallStar = 14;
     const rating = shallow(
-      <Rating small />
+      <Rating size={RATING_SIZE.SMALL} />
     );
     const stars = rating.find(Star);
 
@@ -164,15 +158,6 @@ describe('rating', () => {
       expect(rateCounter).toHaveLength(1);
     });
 
-    it('displays active text when active and haven\'t been rated', () => {
-      const rating = shallow(
-        <Rating active />
-      );
-      const rateCounter = rating.find(RateCounter);
-
-      expect(rateCounter.props().showActiveText).toBeTruthy();
-    });
-
     it('displays counter text when no active and haven\'t been rated', () => {
       const rating = shallow(
         <Rating />
@@ -197,25 +182,6 @@ describe('rating', () => {
       );
       const rateCounter = rating.find(RateCounter);
 
-      expect(rateCounter.props().showActiveText).toBeFalsy();
-    });
-
-    // check if let is needed, looks like a bug on enzyme side
-    it('displays active text when active and mouse over stars', () => {
-      const rating = mount(
-        <Rating rate={3} active />
-      );
-      const stars = rating.find('.sg-rate-box__stars-container');
-      let rateCounter = rating.find(RateCounter);
-
-      expect(rateCounter.props().showActiveText).toBeFalsy();
-
-      stars.simulate('mouseEnter');
-      rateCounter = rating.find(RateCounter);
-      expect(rateCounter.props().showActiveText).toBeTruthy();
-
-      stars.simulate('mouseLeave');
-      rateCounter = rating.find(RateCounter);
       expect(rateCounter.props().showActiveText).toBeFalsy();
     });
 
@@ -266,17 +232,6 @@ describe('star', () => {
 
     star.simulate('click');
     expect(onClick.mock.calls).toHaveLength(1);
-  });
-
-  it('throws error when onClick isn\'t defined', () => {
-    const spy = jest.spyOn(console, 'error');
-
-    console.error = jest.fn();
-    mount(<Star />);
-
-    expect(console.error.mock.calls).toHaveLength(1);
-
-    spy.mockRestore();
   });
 
   it('passes size to icon', () => {

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -100,10 +100,6 @@ $includeHtml: false !default;
     &__counter-item-dynamic {
       position: absolute;
       left: 0;
-
-      &--hidden {
-        display: none;
-      }
     }
 
     &__rate {

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -3,11 +3,9 @@ $rateStarColor: $graySecondary;
 $rateStarCheckedColor: $mustardPrimary;
 $rateStarActiveColor: $graySecondaryLight;
 $rateStarActiveCheckedColor: $mustardSecondary;
-$rateCounterColor: $grayPrimary;
+$rateCounterColor: $graySecondary;
 $rateFontSize: fontSize(obscure);
 $rateIconSize: rhythm(0.75);
-$rateSmallFontSize: fontSize(xsmall);
-$rateSmallIconSize: rhythm(2 / 3);
 $rateLargeFontSize: fontSize(small);
 $rateLargeIconSize: rhythm(1);
 
@@ -18,7 +16,7 @@ $includeHtml: false !default;
   .sg-rate-box {
     @include component();
     display: flex;
-    align-items: center;
+    align-items: flex-end;
     height: $rateHeight;
     overflow: visible;
 
@@ -97,10 +95,9 @@ $includeHtml: false !default;
     &__counter {
       @include fixText($rateFontSize, 0.125rem);
       @include fixOperaMiniLabelText();
-
+      font-weight: $fontWeightBold;
       color: $rateCounterColor;
       margin: 0 0 0 gutter(1 / 4);
-
       position: relative;
     }
 
@@ -127,22 +124,6 @@ $includeHtml: false !default;
       margin: 0 gutter(1 / 4) 0 0;
     }
 
-    &--small {
-      height: rhythm(2 / 3);
-      min-height: 0;
-
-      .sg-rate-box__star {
-        height: $rateSmallIconSize;
-        width: $rateSmallIconSize;
-      }
-
-      .sg-rate-box__counter,
-      .sg-rate-box__rate {
-        @include fixText($rateSmallFontSize, 0.125rem);
-        @include fixOperaMiniLabelText();
-      }
-    }
-
     &--large {
       .sg-rate-box__star {
         height: $rateLargeIconSize;
@@ -154,16 +135,6 @@ $includeHtml: false !default;
       .sg-rate-box__rate {
         @include fixText($rateLargeFontSize, 0.125rem);
         @include fixOperaMiniLabelText();
-      }
-    }
-
-    &--with-alt-labels {
-      align-items: flex-end;
-
-      .sg-rate-box__rate,
-      .sg-rate-box__counter {
-        font-weight: $fontWeightBold;
-        color: $graySecondary;
       }
     }
   }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -8,6 +8,8 @@ $rateFontSize: fontSize(obscure);
 $rateIconSize: rhythm(0.75);
 $rateSmallFontSize: fontSize(xsmall);
 $rateSmallIconSize: rhythm(2 / 3);
+$rateLargeFontSize: fontSize(small);
+$rateLargeIconSize: rhythm(1);
 
 $includeHtml: false !default;
 
@@ -18,8 +20,20 @@ $includeHtml: false !default;
     display: flex;
     align-items: center;
     height: $rateHeight;
+    overflow: visible;
 
     &--active {
+      &:hover {
+        .sg-rate-box__counter {
+          .sg-rate-box__counter-item-dynamic:nth-child(2) {
+            display: none;
+          }
+  
+          .sg-rate-box__counter-item-dynamic:nth-child(4) {
+            display: block;
+          }
+        }
+      }
 
       .sg-rate-box__star {
         cursor: pointer;
@@ -51,7 +65,6 @@ $includeHtml: false !default;
           transition: none;
         }
       }
-
     }
 
     &__stars-container {
@@ -81,7 +94,6 @@ $includeHtml: false !default;
     }
 
     // counter
-
     &__counter {
       @include fixText($rateFontSize, 0.125rem);
       @include fixOperaMiniLabelText();
@@ -100,6 +112,10 @@ $includeHtml: false !default;
     &__counter-item-dynamic {
       position: absolute;
       left: 0;
+
+      &:nth-child(4) {
+        display: none;
+      }
     }
 
     &__rate {
@@ -124,6 +140,29 @@ $includeHtml: false !default;
       .sg-rate-box__rate {
         @include fixText($rateSmallFontSize, 0.125rem);
         @include fixOperaMiniLabelText();
+      }
+    }
+
+    &--large {
+      .sg-rate-box__star {
+        height: $rateLargeIconSize;
+        width: $rateLargeIconSize + 0.125rem; // more whitespace between large icons
+      }
+    
+      .sg-rate-box__counter,
+      .sg-rate-box__rate {
+        @include fixText($rateLargeFontSize, 0.125rem);
+        @include fixOperaMiniLabelText();
+      }
+    }
+
+    &--with-alt-labels {
+      align-items: flex-end;
+
+      .sg-rate-box__rate,
+      .sg-rate-box__counter {
+        font-weight: $fontWeightBold;
+        color: $graySecondary;
       }
     }
   }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -28,7 +28,7 @@ $includeHtml: false !default;
           .sg-rate-box__counter-item-dynamic:nth-child(2) {
             display: none;
           }
-  
+
           .sg-rate-box__counter-item-dynamic:nth-child(4) {
             display: block;
           }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -146,9 +146,10 @@ $includeHtml: false !default;
     &--large {
       .sg-rate-box__star {
         height: $rateLargeIconSize;
-        width: $rateLargeIconSize + 0.125rem; // more whitespace between large icons
+        // more whitespace between large icons
+        width: $rateLargeIconSize + 0.125rem;
       }
-    
+
       .sg-rate-box__counter,
       .sg-rate-box__rate {
         @include fixText($rateLargeFontSize, 0.125rem);

--- a/src/components/rating/pages/rating-interactive.jsx
+++ b/src/components/rating/pages/rating-interactive.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import DocsActiveBlock from 'components/DocsActiveBlock';
-import Rating from '../Rating';
+import Rating, {RATING_SIZE} from '../Rating';
 
 const Ratings = () => {
   const settings = [
@@ -9,7 +9,11 @@ const Ratings = () => {
       values: Boolean
     },
     {
-      name: 'small',
+      name: 'size',
+      values: RATING_SIZE
+    },
+    {
+      name: 'altLabels',
       values: Boolean
     },
     {

--- a/src/components/rating/pages/rating.jsx
+++ b/src/components/rating/pages/rating.jsx
@@ -16,14 +16,6 @@ const ratings = () => (
       <Rating rate={3} active counter={34} counterText="Hover to rate" activeText="Rate me!" />
     </DocsBlock>
 
-    <DocsBlock info="Small">
-      <Rating rate={3} size={RATING_SIZE.SMALL} counter={34} />
-    </DocsBlock>
-
-    <DocsBlock info="Small Active">
-      <Rating rate={3} size={RATING_SIZE.SMALL} active counter={34} />
-    </DocsBlock>
-
     <DocsBlock info="Large">
       <Rating rate={3} size={RATING_SIZE.LARGE} counter={34} />
     </DocsBlock>

--- a/src/components/rating/pages/rating.jsx
+++ b/src/components/rating/pages/rating.jsx
@@ -1,10 +1,9 @@
 import React from 'react';
 import DocsBlock from 'components/DocsBlock';
-import Rating from '../Rating';
+import Rating, {RATING_SIZE} from '../Rating';
 
 const ratings = () => (
   <div>
-
     <DocsBlock info="Default">
       <Rating rate={3} counter={34} />
     </DocsBlock>
@@ -13,12 +12,32 @@ const ratings = () => (
       <Rating rate={3} active counter={34} />
     </DocsBlock>
 
+    <DocsBlock info="Active with counters">
+      <Rating rate={3} active counter={34} counterText="Hover to rate" activeText="Rate me!" />
+    </DocsBlock>
+
     <DocsBlock info="Small">
-      <Rating rate={3} small counter={34} />
+      <Rating rate={3} size={RATING_SIZE.SMALL} counter={34} />
     </DocsBlock>
 
     <DocsBlock info="Small Active">
-      <Rating rate={3} small active counter={34} />
+      <Rating rate={3} size={RATING_SIZE.SMALL} active counter={34} />
+    </DocsBlock>
+
+    <DocsBlock info="Large">
+      <Rating rate={3} size={RATING_SIZE.LARGE} counter={34} />
+    </DocsBlock>
+
+    <DocsBlock info="Large Active with alt labels">
+      <Rating
+        rate={3}
+        size={RATING_SIZE.LARGE}
+        altLabels
+        active
+        counter={34}
+        counterText="Hover to rate"
+        activeText="Rate me!"
+      />
     </DocsBlock>
 
   </div>

--- a/src/components/rating/subcomponents/RateCounter.jsx
+++ b/src/components/rating/subcomponents/RateCounter.jsx
@@ -2,17 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import RateCounterItem from './RateCounterItem';
 
-const RateCounter = ({activeText, counterText, showActiveText}) => (
+const RateCounter = ({activeText, counterText}) => (
   <div className="sg-rate-box__counter">
-    <RateCounterItem text={counterText} hidden={showActiveText} />
-    <RateCounterItem text={activeText} hidden={!showActiveText} />
+    <RateCounterItem text={counterText} />
+    <RateCounterItem text={activeText} />
   </div>
 );
 
 RateCounter.propTypes = {
   counterText: PropTypes.string,
-  activeText: PropTypes.string,
-  showActiveText: PropTypes.bool
+  activeText: PropTypes.string
 };
 
 export default RateCounter;

--- a/src/components/rating/subcomponents/RateCounterItem.jsx
+++ b/src/components/rating/subcomponents/RateCounterItem.jsx
@@ -1,27 +1,19 @@
 import React, {Fragment} from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
 
-const RateCounterItem = ({text, hidden = false}) => {
-  const dynamicItemClassName = classnames('sg-rate-box__counter-item-dynamic', {
-    'sg-rate-box__counter-item-dynamic--hidden': hidden
-  });
-
-  return (
-    <Fragment>
-      <div className="sg-rate-box__counter-item-static">
-        {text}
-      </div>
-      <div className={dynamicItemClassName}>
-        {text}
-      </div>
-    </Fragment>
-  );
-};
+const RateCounterItem = ({text}) => (
+  <Fragment>
+    <div className="sg-rate-box__counter-item-static">
+      {text}
+    </div>
+    <div className="sg-rate-box__counter-item-dynamic">
+      {text}
+    </div>
+  </Fragment>
+);
 
 RateCounterItem.propTypes = {
-  text: PropTypes.string,
-  hidden: PropTypes.bool
+  text: PropTypes.string
 };
 
 export default RateCounterItem;

--- a/src/components/rating/subcomponents/Star.jsx
+++ b/src/components/rating/subcomponents/Star.jsx
@@ -2,15 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Icon, {TYPE, ICON_COLOR} from '../../icons/Icon';
 
-const Star = ({size, onClick}) => (
-  <span className="sg-rate-box__star" onClick={onClick}>
+const Star = ({size, ...props}) => (
+  <span className="sg-rate-box__star" {...props}>
     <Icon type={TYPE.STAR} size={size} color={ICON_COLOR.ADAPTIVE} />
   </span>
 );
 
 Star.propTypes = {
-  size: PropTypes.number,
-  onClick: PropTypes.func.isRequired
+  size: PropTypes.number
 };
 
 export default Star;


### PR DESCRIPTION
- added `LARGE` size, change way the props are setting size,
- removed `SMALL` size,
- added more power: component allows to listen on star events - example usage:
![mar-16-2018 09-24-50](https://user-images.githubusercontent.com/1142999/38735476-2e696c22-3f29-11e8-8c90-bb049a41a741.gif)
- counter visibility now done in CSS,
- closes https://github.com/brainly/style-guide/issues/1413
- closes https://github.com/brainly/style-guide/issues/1435

**Screenshot**
<img width="552" alt="screen shot 2018-04-17 at 09 55 12" src="https://user-images.githubusercontent.com/1142999/38856266-48e2fba4-4226-11e8-8d30-ca57c0c9af6a.png">


**Styles change for visual comparison:**
<img width="240" alt="screen shot 2018-04-16 at 15 55 12" src="https://user-images.githubusercontent.com/1142999/38813381-12770084-418f-11e8-9f38-ba8b8d11b62d.png">
<img width="240" alt="screen shot 2018-04-16 at 15 55 31" src="https://user-images.githubusercontent.com/1142999/38813382-1294b98a-418f-11e8-8754-62f002ca7dd0.png">

