### PR TITLE
consistent messages for fallback on feed 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "135.4.0",
+  "version": "135.3.3",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "135.3.3",
+  "version": "135.4.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/box/Box.jsx
+++ b/src/components/box/Box.jsx
@@ -36,7 +36,7 @@ const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeig
     'sg-box--no-min-height': noMinHeight,
     'sg-box--with-shadow': shadow && !message,
     'sg-box--message': message,
-    'sg-box--with-onclose': onClose
+    'sg-box--with-close': onClose
 
   }, className);
 

--- a/src/components/box/Box.jsx
+++ b/src/components/box/Box.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import Icon, {TYPE as iconTypes, ICON_COLOR} from '../icons/Icon';
 
 export const COLOR = {
   BLUE: 'blue',
@@ -10,6 +11,7 @@ export const COLOR = {
   MINT_SECONDARY: 'mint-secondary',
   MINT_SECONDARY_LIGHT: 'mint-secondary-light',
   NAVYBLUE_SECONDARY: 'navyblue-secondary',
+  BLUE_SECONDARY: 'blue-secondary',
   BLUE_SECONDARY_LIGHT: 'blue-secondary-light',
   GRAY_SECONDARY_LIGHT: 'gray-secondary-lightest',
   PEACH: 'peach'
@@ -23,15 +25,19 @@ export const PADDING = {
   LARGE: 'large-padding'
 };
 
-const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeight, shadow, className, ...props}) => {
+const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeight, shadow,
+  message, onClose, className, ...props}) => {
   const boxClass = classNames('sg-box', {
     [`sg-box--${color}`]: color,
     'sg-box--no-border': !border,
     'sg-box--full': full,
-    [`sg-box--${padding}`]: padding,
+    [`sg-box--${padding}`]: padding && !message,
     'sg-box--image-wrapper': imgSrc,
     'sg-box--no-min-height': noMinHeight,
-    'sg-box--with-shadow': shadow
+    'sg-box--with-shadow': shadow && !message,
+    'sg-box--message': message,
+    'sg-box--with-onClose': onClose
+
   }, className);
 
   let content;
@@ -44,6 +50,11 @@ const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeig
 
   return (
     <div {...props} className={boxClass}>
+      {onClose ?
+        <div className="sg-box--message__close" onClick={onClose}>
+          <Icon type={iconTypes.X} color={ICON_COLOR.DARK} size={14} />
+        </div> : null
+      }
       {content}
     </div>
   );
@@ -58,6 +69,8 @@ Box.propTypes = {
   padding: PropTypes.oneOf(Object.values(PADDING)),
   imgSrc: PropTypes.string,
   shadow: PropTypes.bool,
+  message: PropTypes.bool,
+  onClose: PropTypes.bool,
   className: PropTypes.string
 };
 

--- a/src/components/box/Box.jsx
+++ b/src/components/box/Box.jsx
@@ -36,7 +36,7 @@ const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeig
     'sg-box--no-min-height': noMinHeight,
     'sg-box--with-shadow': shadow && !message,
     'sg-box--message': message,
-    'sg-box--with-onClose': onClose
+    'sg-box--with-onclose': onClose
 
   }, className);
 
@@ -51,7 +51,7 @@ const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeig
   return (
     <div {...props} className={boxClass}>
       {onClose ?
-        <div className="sg-box--message__close" onClick={onClose}>
+        <div className="sg-box--message__close" onClose={onClose}>
           <Icon type={iconTypes.X} color={ICON_COLOR.DARK} size={14} />
         </div> : null
       }
@@ -70,7 +70,7 @@ Box.propTypes = {
   imgSrc: PropTypes.string,
   shadow: PropTypes.bool,
   message: PropTypes.bool,
-  onClose: PropTypes.bool,
+  onClose: PropTypes.func,
   className: PropTypes.string
 };
 

--- a/src/components/box/Box.jsx
+++ b/src/components/box/Box.jsx
@@ -51,7 +51,7 @@ const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeig
   return (
     <div {...props} className={boxClass}>
       {onClose ?
-        <div className="sg-box--message__close" onClose={onClose}>
+        <div className="sg-box__close" onClose={onClose}>
           <Icon type={iconTypes.X} color={ICON_COLOR.DARK} size={14} />
         </div> : null
       }

--- a/src/components/box/Box.spec.jsx
+++ b/src/components/box/Box.spec.jsx
@@ -122,6 +122,28 @@ test('full width', () => {
   expect(box.hasClass('sg-box--full')).toEqual(true);
 });
 
+test('message', () => {
+  const box = shallow(
+    <Box message>some text</Box>
+  );
+
+  expect(box.hasClass('sg-box--message')).toEqual(true);
+});
+
+test('close button', () => {
+  const mockCallback = jest.fn();
+  const box = shallow(<Box message onClose={mockCallback} />);
+
+  expect(box.find('.sg-box__close')).toHaveLength(1);
+});
+
+test('padding-right when close button', () => {
+  const mockCallback = jest.fn();
+  const box = shallow(<Box message onClose={mockCallback} />);
+
+  expect(box.hasClass('sg-box--with-close')).toEqual(true);
+});
+
 test('image container', () => {
   const imgSrc = 'https://source.unsplash.com/100x100/?man';
 

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -127,12 +127,12 @@ $includeHtml: false !default;
       align-items: center;
       justify-content: center;
     }
-    
+
     &--message {
       padding: gutter(1);
     }
-    
-    &--with-onClose {
+
+    &--with-onclose {
       padding-right: gutter(5/3);
     }
 

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -91,6 +91,10 @@ $includeHtml: false !default;
       background-color: $bluePrimary;
     }
 
+    &--blue-secondary {
+      background-color: $blueSecondary;
+    }
+
     &--blue-secondary-light {
       background-color: $blueSecondaryLight;
     }
@@ -122,6 +126,24 @@ $includeHtml: false !default;
       padding: (gutter(0.5) - $boxBorderSize);
       align-items: center;
       justify-content: center;
+    }
+    
+    &--message {
+      padding: gutter(1);
+    }
+    
+    &--with-onClose {
+      padding-right: gutter(5/3);
+    }
+
+    &--message__close {
+      display: flex;
+      position: absolute;
+      right: 0;
+      top: 0;
+      padding: gutter(1 / 2);
+      cursor: pointer;
+      z-index: 1;
     }
   }
 

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -136,7 +136,7 @@ $includeHtml: false !default;
       padding-right: gutter(5/3);
     }
 
-    &--message__close {
+    &__close {
       display: flex;
       position: absolute;
       right: 0;

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -132,7 +132,7 @@ $includeHtml: false !default;
       padding: gutter(1);
     }
 
-    &--with-onclose {
+    &--with-close {
       padding-right: gutter(5/3);
     }
 

--- a/src/components/box/pages/box-interactive.jsx
+++ b/src/components/box/pages/box-interactive.jsx
@@ -37,6 +37,10 @@ const Boxes = () => {
     {
       name: 'imgSrc',
       values: String
+    },
+    {
+      name: 'message',
+      values: Boolean
     }
   ];
 

--- a/src/components/box/pages/box-interactive.jsx
+++ b/src/components/box/pages/box-interactive.jsx
@@ -37,10 +37,6 @@ const Boxes = () => {
     {
       name: 'imgSrc',
       values: String
-    },
-    {
-      name: 'message',
-      values: Boolean
     }
   ];
 

--- a/src/components/box/pages/box.jsx
+++ b/src/components/box/pages/box.jsx
@@ -3,12 +3,13 @@ import Box, {COLOR, PADDING} from '../Box';
 import DocsBlock from 'components/DocsBlock';
 import ButtonPrimary, {BUTTON_PRIMARY_TYPE} from 'buttons/ButtonPrimary';
 import ContentBox from 'content-box/ContentBox';
+import ContentBoxContent, {SIZE as CONTENT_BOX_CONTENT_SPACING_SIZE} from 'content-box/ContentBoxContent';
 import ContentBoxHeader from 'content-box/ContentBoxHeader';
 import ContentBoxActions from 'content-box/ContentBoxActions';
 import HeaderSecondary, {HEADER_TYPE} from 'text/HeaderSecondary';
-import ActionList, {DIRECTION} from 'action-list/ActionList';
+import ActionList from 'action-list/ActionList';
 import ActionListHole from 'action-list/ActionListHole';
-import Text, {WEIGHT as TEXT_WEIGHT} from 'text/Text';
+import Text, {WEIGHT as TEXT_WEIGHT, SIZE as TEXT_SIZE} from 'text/Text';
 import Icon, {TYPE as ICON_TYPE, ICON_COLOR} from 'icons/Icon';
 
 const Boxs = () => (
@@ -115,25 +116,25 @@ const Boxs = () => (
 
     <DocsBlock info="Example of message box usage">
       <Box message onClose full color={COLOR.BLUE_SECONDARY}>
-        <ActionList direction={DIRECTION.SPACE_BETWEEN}>
+        <ActionList noWrap toTop>
           <ActionListHole>
-            <Icon type={ICON_TYPE.POINTS} color={ICON_COLOR.DARK} size={32} />
+            <Icon type={ICON_TYPE.POINTS} color={ICON_COLOR.DARK} size={30} />
           </ActionListHole>
           <ActionListHole>
-            <Text weight={TEXT_WEIGHT.BOLD}>
-              Title for a message with valuable information for a user
-            </Text>
-            <Text>
-              This is a description for users in appropriate situation.
-              This is a description for users in appropriate situation.
-              This is a description for users in appropriate situation.
-              This is a description for users in appropriate situation.
-              This is a description for users in appropriate situation.
-              This is a description for users in appropriate situation.
-              This is a description for users in appropriate situation.
-              This is a description for users in appropriate situation.
-
-            </Text>
+            <ContentBox>
+              <ContentBoxContent spacedBottom={CONTENT_BOX_CONTENT_SPACING_SIZE.XSMALL}>
+                <Text weight={TEXT_WEIGHT.BOLD} size={TEXT_SIZE.SMALL}>
+                Title for a message with valuable information for a user.
+                </Text>
+              </ContentBoxContent>
+              <ContentBoxContent>
+                <Text size={TEXT_SIZE.SMALL}>
+                This is valuable information for users in a specific situation. For example:
+                we want to let you know that in 24h Brainly will disable some feature.
+                You can find more information about this change on our blog.
+                </Text>
+              </ContentBoxContent>
+            </ContentBox>
           </ActionListHole>
         </ActionList>
       </Box>

--- a/src/components/box/pages/box.jsx
+++ b/src/components/box/pages/box.jsx
@@ -35,6 +35,12 @@ const Boxs = () => (
     ))}
 
     <DocsBlock info="With message">
+      <Box message color={COLOR.BLUE_SECONDARY}>
+        This is a box with message
+      </Box>
+    </DocsBlock>
+
+    <DocsBlock info="With message">
       <Box message onClose={closeCallback} color={COLOR.BLUE_SECONDARY}>
         This is a box with message and onClose
       </Box>

--- a/src/components/box/pages/box.jsx
+++ b/src/components/box/pages/box.jsx
@@ -6,6 +6,10 @@ import ContentBox from 'content-box/ContentBox';
 import ContentBoxHeader from 'content-box/ContentBoxHeader';
 import ContentBoxActions from 'content-box/ContentBoxActions';
 import HeaderSecondary, {HEADER_TYPE} from 'text/HeaderSecondary';
+import ActionList, {DIRECTION} from 'action-list/ActionList';
+import ActionListHole from 'action-list/ActionListHole';
+import Text, {WEIGHT as TEXT_WEIGHT} from 'text/Text';
+import Icon, {TYPE as ICON_TYPE, ICON_COLOR} from 'icons/Icon';
 
 const Boxs = () => (
   <div>
@@ -26,6 +30,12 @@ const Boxs = () => (
         <Box color={color}>{color} (no border by default)</Box>
       </DocsBlock>
     ))}
+
+    <DocsBlock info="With message">
+      <Box message onClose color={COLOR.BLUE_SECONDARY}>
+        This is a box with message and onClose
+      </Box>
+    </DocsBlock>
 
     <DocsBlock
       info="Image"
@@ -88,7 +98,7 @@ const Boxs = () => (
       ]}
     />
 
-    <DocsBlock info="Example of usage">
+    <DocsBlock info="Example of box usage">
       <Box>
         <ContentBox>
           <ContentBoxHeader>
@@ -100,6 +110,32 @@ const Boxs = () => (
             </ButtonPrimary>
           </ContentBoxActions>
         </ContentBox>
+      </Box>
+    </DocsBlock>
+
+    <DocsBlock info="Example of message box usage">
+      <Box message onClose full color={COLOR.BLUE_SECONDARY}>
+        <ActionList direction={DIRECTION.SPACE_BETWEEN}>
+          <ActionListHole>
+            <Icon type={ICON_TYPE.POINTS} color={ICON_COLOR.DARK} size={32} />
+          </ActionListHole>
+          <ActionListHole>
+            <Text weight={TEXT_WEIGHT.BOLD}>
+              Title for a message with valuable information for a user
+            </Text>
+            <Text>
+              This is a description for users in appropriate situation.
+              This is a description for users in appropriate situation.
+              This is a description for users in appropriate situation.
+              This is a description for users in appropriate situation.
+              This is a description for users in appropriate situation.
+              This is a description for users in appropriate situation.
+              This is a description for users in appropriate situation.
+              This is a description for users in appropriate situation.
+
+            </Text>
+          </ActionListHole>
+        </ActionList>
       </Box>
     </DocsBlock>
   </div>

--- a/src/components/box/pages/box.jsx
+++ b/src/components/box/pages/box.jsx
@@ -12,6 +12,8 @@ import ActionListHole from 'action-list/ActionListHole';
 import Text, {WEIGHT as TEXT_WEIGHT, SIZE as TEXT_SIZE} from 'text/Text';
 import Icon, {TYPE as ICON_TYPE, ICON_COLOR} from 'icons/Icon';
 
+const closeCallback = () => undefined;
+
 const Boxs = () => (
   <div>
     <DocsBlock info="Simple">
@@ -33,7 +35,7 @@ const Boxs = () => (
     ))}
 
     <DocsBlock info="With message">
-      <Box message onClose color={COLOR.BLUE_SECONDARY}>
+      <Box message onClose={closeCallback} color={COLOR.BLUE_SECONDARY}>
         This is a box with message and onClose
       </Box>
     </DocsBlock>
@@ -115,7 +117,7 @@ const Boxs = () => (
     </DocsBlock>
 
     <DocsBlock info="Example of message box usage">
-      <Box message onClose full color={COLOR.BLUE_SECONDARY}>
+      <Box message onClose={closeCallback} full color={COLOR.BLUE_SECONDARY}>
         <ActionList noWrap toTop>
           <ActionListHole>
             <Icon type={ICON_TYPE.POINTS} color={ICON_COLOR.DARK} size={30} />


### PR DESCRIPTION
Design for consistent messages for users in case of: disabling some feature in Brainly, "your search include questions with Verified Answers", info about patron of a subject etc.
It is actually a Box with new modifiers: 'message' and 'onClose' - function on 'X' closing a message.
'Message' excludes shadow and different padding - to stay consistent.

Design:
![image](https://user-images.githubusercontent.com/39903772/41404132-b0980b72-6fc6-11e8-9058-8e9be6b99943.png)

Implementation:
![image](https://user-images.githubusercontent.com/39903772/41404148-beb23750-6fc6-11e8-8d3e-b29ad5728980.png)
