### PR TITLE
Use relative path for importing logo in home button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "136.0.0",
+  "version": "136.0.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/home-button/HomeButton.jsx
+++ b/src/components/home-button/HomeButton.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import {TYPE, BASE_URL, LOGOS} from 'logo/Logo';
+import {TYPE, BASE_URL, LOGOS} from '../logo/Logo';
 
 const ICONS = {
   'brainly': 'brainly-mobile-426ef8718f',


### PR DESCRIPTION
This is short term fix, long term I believe we should stop treating component folder as node path.