### PR TITLE
add no border radius to box and change examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "136.0.2",
+  "version": "136.1.2",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/box/Box.jsx
+++ b/src/components/box/Box.jsx
@@ -25,7 +25,7 @@ export const PADDING = {
   LARGE: 'large-padding'
 };
 
-const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeight, shadow,
+const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeight, shadow, noBorderRadius,
   onClose, className, ...props}) => {
   const boxClass = classNames('sg-box', {
     [`sg-box--${color}`]: color,
@@ -34,7 +34,8 @@ const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeig
     [`sg-box--${padding}`]: padding,
     'sg-box--image-wrapper': imgSrc,
     'sg-box--no-min-height': noMinHeight,
-    'sg-box--with-shadow': shadow
+    'sg-box--with-shadow': shadow,
+    'sg-box--no-border-radius': noBorderRadius
   }, className);
 
   let content;
@@ -66,6 +67,7 @@ Box.propTypes = {
   padding: PropTypes.oneOf(Object.values(PADDING)),
   imgSrc: PropTypes.string,
   shadow: PropTypes.bool,
+  noBorderRadius: PropTypes.bool,
   onClose: PropTypes.func,
   className: PropTypes.string
 };

--- a/src/components/box/_box.scss
+++ b/src/components/box/_box.scss
@@ -55,6 +55,10 @@ $includeHtml: false !default;
       box-shadow: $containerShadow;
     }
 
+    &--no-border-radius {
+      border-radius: 0;
+    }
+
     &--no-padding {
       padding: 0;
     }

--- a/src/components/box/pages/box-interactive.jsx
+++ b/src/components/box/pages/box-interactive.jsx
@@ -37,6 +37,10 @@ const Boxes = () => {
     {
       name: 'imgSrc',
       values: String
+    },
+    {
+      name: 'noBorderRadius',
+      values: Boolean
     }
   ];
 

--- a/src/components/box/pages/box.jsx
+++ b/src/components/box/pages/box.jsx
@@ -10,7 +10,7 @@ import HeaderSecondary, {HEADER_TYPE} from 'text/HeaderSecondary';
 import ActionList from 'action-list/ActionList';
 import ActionListHole from 'action-list/ActionListHole';
 import Text, {WEIGHT as TEXT_WEIGHT, SIZE as TEXT_SIZE} from 'text/Text';
-import Icon, {TYPE as ICON_TYPE, ICON_COLOR} from 'icons/Icon';
+import Avatar from 'avatar/Avatar';
 
 const closeCallback = () => undefined;
 
@@ -33,6 +33,12 @@ const Boxs = () => (
         <Box color={color}>{color} (no border by default)</Box>
       </DocsBlock>
     ))}
+
+    <DocsBlock info="No border radius">
+      <Box noBorderRadius>
+        This is a box with no border radius
+      </Box>
+    </DocsBlock>
 
     <DocsBlock info="With onClose">
       <Box onClose={closeCallback} >
@@ -117,21 +123,24 @@ const Boxs = () => (
     </DocsBlock>
 
     <DocsBlock info="Example of message box usage">
-      <Box border={false} onClose={closeCallback} full color={COLOR.BLUE_SECONDARY}>
+      <Box color={COLOR.BLUE_SECONDARY} full border={false} onClose={closeCallback}>
         <ActionList noWrap toTop>
           <ActionListHole>
-            <Icon type={ICON_TYPE.POINTS} color={ICON_COLOR.DARK} size={30} />
+            <Avatar spaced />
           </ActionListHole>
-          <ActionListHole>
+          <ActionListHole grow>
             <ContentBox>
-              <ContentBoxContent spacedBottom={CONTENT_BOX_CONTENT_SPACING_SIZE.XSMALL}>
+              <ContentBoxContent
+                spacedBottom={CONTENT_BOX_CONTENT_SPACING_SIZE.XSMALL}
+                spacedTop={CONTENT_BOX_CONTENT_SPACING_SIZE.SMALL}
+              >
                 <Text weight={TEXT_WEIGHT.BOLD} size={TEXT_SIZE.SMALL}>
-                Title for a message with valuable information for a user.
+                  Title for a message with valuable information for a user.
                 </Text>
               </ContentBoxContent>
-              <ContentBoxContent>
+              <ContentBoxContent spacedBottom={CONTENT_BOX_CONTENT_SPACING_SIZE.SMALL}>
                 <Text size={TEXT_SIZE.SMALL}>
-                This is valuable information for users in a specific situation. For example:
+                  This is valuable information for users in a specific situation. For example:
                 we want to let you know that in 24h Brainly will disable some feature.
                 You can find more information about this change on our blog.
                 </Text>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/39903772/42203937-91119686-7ea0-11e8-82d7-7dd507bd8c93.png)
![image](https://user-images.githubusercontent.com/39903772/42203942-9541c17c-7ea0-11e8-959a-a5a5ea6bebe2.png)
noBorderRadius will be used in mobile view in patronages, fallback messages, information messages (no private messages, verified answers)