### PR TITLE
Selects same height as inputs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "136.5.0",
+  "version": "136.6.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -1,8 +1,8 @@
+$selectHeight: rhythm(3 / 2);
 $selectBackground: $white;
 $selectTextColor: $grayPrimary;
 $selectFontSize: fontSize(small);
 $selectIconSize: rhythm(1 / 3);
-$selectHeight: rhythm(5 / 4);
 $selectBorderRadius: 7px;
 $selectActiveBorderColor: $grayPrimary;
 $selectActiveInvalidBorderColor: $peachPrimary;
@@ -18,6 +18,7 @@ $includeHtml: false !default;
     color: $selectTextColor;
     box-shadow: $componentShadow;
     border-radius: $selectBorderRadius;
+    height: $selectHeight;
     padding-left: gutter(1 / 12);
 
     &__element {


### PR DESCRIPTION
Change height of selects to be aligned with inputs.

<img width="238" alt="screen shot 2018-07-16 at 22 42 55" src="https://user-images.githubusercontent.com/4272331/42782580-a67717d6-8949-11e8-9b9f-c3ab2a0b60ed.png">
BEFORE:
<img width="231" alt="screen shot 2018-07-16 at 22 42 44" src="https://user-images.githubusercontent.com/4272331/42782592-aff8606c-8949-11e8-861f-73174af1e92d.png">
AFTER:
<img width="190" alt="screen shot 2018-07-16 at 22 43 05" src="https://user-images.githubusercontent.com/4272331/42782593-b032d544-8949-11e8-91aa-133eef56283d.png">
