### PR TITLE
Make overlay blue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "136.8.0",
+  "version": "136.9.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/overlay/_overlay.scss
+++ b/src/components/overlay/_overlay.scss
@@ -1,4 +1,4 @@
-$overlayBackgroundColor: rgba(0, 0, 0, 0.6);
+$overlayBackgroundColor: rgba($bluePrimary, 0.9);
 $includeHtml: false !default;
 
 @if ($includeHtml) {


### PR DESCRIPTION
Toplayer shadow should stay as it is (confirmed with Patrycja)

After:
<img width="971" alt="screen shot 2018-07-20 at 09 51 34" src="https://user-images.githubusercontent.com/1040733/43009048-e30a9b6e-8c3c-11e8-8b34-b8d6f6d959c5.png">

Before:
<img width="888" alt="screen shot 2018-07-20 at 09 51 38" src="https://user-images.githubusercontent.com/1040733/43009049-e32cccca-8c3c-11e8-8810-e01ac7e021e0.png">
