### PR TITLE
export colors as a hex values

### DIFF
--- a/src/components/colors/hex.js
+++ b/src/components/colors/hex.js
@@ -1,0 +1,11 @@
+import colors from './colors';
+
+const hex = {};
+
+Object.keys(colors).forEach(groupName => {
+  colors[groupName].forEach(color => {
+    hex[color.variable.slice(1)] = `#${color.hex}`;
+  });
+});
+
+export default hex;

--- a/src/components/colors/hex.spec.js
+++ b/src/components/colors/hex.spec.js
@@ -1,0 +1,7 @@
+import colors from './colors';
+import hex from './hex';
+
+test('should export colors as a hex values', () => {
+  expect(hex.black).toBe(`#${colors.primary[0].hex}`);
+  expect(hex.lavenderPrimary).toBe(`#${colors.secondary[0].hex}`);
+});


### PR DESCRIPTION
and now we will be able to import like that:
```javascript
import hex from 'style-guide/src/components/colors/hex';

hex.mintPrimary  // #53cf92
hex.mustardPrimary  // #fec83c
```
