### PR TITLE
Capitalize select option

### DIFF
--- a/src/components/form-elements/Select.jsx
+++ b/src/components/form-elements/Select.jsx
@@ -6,6 +6,7 @@ const Select = props => {
   const {
     valid,
     invalid,
+    capitalized,
     fullWidth,
     value,
     className,
@@ -23,6 +24,7 @@ const Select = props => {
   const selectClass = classnames('sg-select', {
     'sg-select--valid': valid,
     'sg-select--invalid': invalid,
+    'sg-select--capitalized': capitalized,
     'sg-select--full-width': fullWidth
   }, className);
   const optionsElements = options.map(({value, text}) =>
@@ -48,6 +50,7 @@ Select.propTypes = {
   value: PropTypes.string,
   valid: PropTypes.bool,
   invalid: PropTypes.bool,
+  capitalized: PropTypes.bool,
   fullWidth: PropTypes.bool,
   options: PropTypes.arrayOf(optionShape),
   className: PropTypes.string

--- a/src/components/form-elements/Select.spec.jsx
+++ b/src/components/form-elements/Select.spec.jsx
@@ -72,6 +72,14 @@ test('invalid', () => {
   expect(select.hasClass('sg-select--invalid')).toEqual(true);
 });
 
+test('invalid', () => {
+  const select = shallow(
+    <Select capitalized />
+  );
+
+  expect(select.hasClass('sg-select--capitalized')).toEqual(true);
+});
+
 test('error when both valid and invalid', () => {
   expect(() => {
     shallow(<Select valid invalid />);

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -76,9 +76,9 @@ $includeHtml: false !default;
     }
 
     &--capitalized {
-      select {
+      .sg-select__element {
         text-transform: capitalize;
-      } 
+      }
     }
   }
 }

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -74,5 +74,11 @@ $includeHtml: false !default;
     &--invalid {
       color: $selectActiveInvalidBorderColor;
     }
+
+    &--capitalized {
+      select {
+        text-transform: capitalize;
+      } 
+    }
   }
 }

--- a/src/components/form-elements/pages/select.jsx
+++ b/src/components/form-elements/pages/select.jsx
@@ -4,7 +4,7 @@ import DocsBlock from 'components/DocsBlock';
 
 const exampleOptions = [
   {value: 'option1', text: 'Option1'},
-  {value: 'option2', text: 'Select Selector'}
+  {value: 'option2', text: 'Select selector'}
 ];
 const exampleProps = {
   options: exampleOptions,
@@ -22,6 +22,9 @@ const selects = () => (
     </DocsBlock>
     <DocsBlock info="Invalid">
       <Select {...exampleProps} invalid />
+    </DocsBlock>
+    <DocsBlock info="Capitalized">
+      <Select {...exampleProps} capitalized />
     </DocsBlock>
     <DocsBlock info="Full width">
       <Select {...exampleProps} fullWidth />


### PR DESCRIPTION
As we are getting rid off dropdown, we would need to have more control over Select text. Probably also uppercase would be needed in the future.
Capitalize currently used in Filters on feed and Content Optimization
Fixes #1482