### PR TITLE
Headline component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "138.0.0",
+  "version": "139.0.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/text/Headline.jsx
+++ b/src/components/text/Headline.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import {HEADLINE_COLOR, HEADLINE_SIZE, HEADLINE_TYPE, HEADLINE_TRANSFORM} from './headlineConsts';
+
+const Headline = ({
+  children,
+  type = HEADLINE_TYPE.H1,
+  size = HEADLINE_SIZE.NORMAL,
+  extraBold,
+  transform,
+  color,
+  className,
+  ...props
+}) => {
+  const Type = type;
+  const headlineClass = classNames('sg-headline', {
+    [`sg-headline--${size}`]: size !== HEADLINE_SIZE.NORMAL,
+    [`sg-headline--${color}`]: color,
+    [`sg-headline--${transform}`]: transform,
+    'sg-headline--extra-bold': extraBold
+  }, className);
+
+  return (
+    <Type {...props} className={headlineClass}>
+      {children}
+    </Type>
+  );
+};
+
+Headline.propTypes = {
+  children: PropTypes.node,
+  type: PropTypes.oneOf(Object.values(HEADLINE_TYPE)),
+  size: PropTypes.oneOf(Object.values(HEADLINE_SIZE)),
+  transform: PropTypes.oneOf(Object.values(HEADLINE_TRANSFORM)),
+  extraBold: PropTypes.bool,
+  color: PropTypes.oneOf(Object.values(HEADLINE_COLOR)),
+  className: PropTypes.string
+};
+
+export default Headline;
+export {HEADLINE_TYPE, HEADLINE_SIZE, HEADLINE_COLOR, HEADLINE_TRANSFORM};

--- a/src/components/text/Headline.spec.jsx
+++ b/src/components/text/Headline.spec.jsx
@@ -28,10 +28,10 @@ test('type', () => {
 
 test('light', () => {
   const text = shallow(
-    <Headline color={HEADLINE_COLOR.LIGHT}>Test</Headline>
+    <Headline color={HEADLINE_COLOR.WHITE}>Test</Headline>
   );
 
-  expect(text.hasClass('sg-headline--light')).toBeTruthy();
+  expect(text.hasClass('sg-headline--white')).toBeTruthy();
 });
 
 test('default size', () => {

--- a/src/components/text/Headline.spec.jsx
+++ b/src/components/text/Headline.spec.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import Headline, {HEADLINE_SIZE, HEADLINE_TYPE, HEADLINE_COLOR, HEADLINE_TRANSFORM} from './Headline';
+import {shallow, mount} from 'enzyme';
+
+test('render', () => {
+  const headline = shallow(
+    <Headline>Test</Headline>
+  );
+
+  expect(headline.hasClass('sg-headline')).toBeTruthy();
+});
+
+test('size', () => {
+  const headline = shallow(
+    <Headline size={HEADLINE_SIZE.SMALL}>Test</Headline>
+  );
+
+  expect(headline.hasClass('sg-headline--small')).toBeTruthy();
+});
+
+test('type', () => {
+  const headline = mount(
+    <Headline type={HEADLINE_TYPE.H3}>Test</Headline>
+  );
+
+  expect(headline.props().type).toEqual(HEADLINE_TYPE.H3);
+});
+
+test('light', () => {
+  const text = shallow(
+    <Headline color={HEADLINE_COLOR.LIGHT}>Test</Headline>
+  );
+
+  expect(text.hasClass('sg-headline--light')).toBeTruthy();
+});
+
+test('default size', () => {
+  const headline = shallow(
+    <Headline size={HEADLINE_SIZE.NORMAL}>Test</Headline>
+  );
+
+  expect(headline.hasClass('sg-headline--normal')).toBeFalsy();
+});
+
+test('transform uppercase', () => {
+  const headline = shallow(
+    <Headline transform={HEADLINE_TRANSFORM.UPPERCASE}>Test</Headline>
+  );
+
+  expect(headline.hasClass('sg-headline--uppercase')).toBeTruthy();
+});
+
+test('extra bold', () => {
+  const headline = shallow(
+    <Headline extraBold>Test</Headline>
+  );
+
+  expect(headline.hasClass('sg-headline--extra-bold')).toBeTruthy();
+});

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -1,67 +1,74 @@
 $includeHtml: false !default;
 
-$headlineFontSizes: (
-  xxlarge: 53px,
-  xlarge: 39px,
-  large: 28px,
-  normal: 21px,
-  small: 18px,
-  xsmall: 14px
+$headlineSizes: (
+  xxlarge: (
+    fontSize: 53px,
+    lineHeight: 60px
+  ),
+  xlarge: (
+    fontSize: 39px,
+    lineHeight: 44px
+  ),
+  large: (
+    fontSize: 28px,
+    lineHeight: 32px
+  ),
+  normal: (
+    fontSize: 21px,
+    lineHeight: 24px
+  ),
+  small: (
+    fontSize: 18px,
+    lineHeight: 20px
+  ),
+  xsmall: (
+    fontSize: 14px,
+    lineHeight: 15px
+  )
 );
 
-$headlineLineHeight: (
-  xxlarge: 60px,
-  xlarge: 44px,
-  large: 32px,
-  normal: 24px,
-  small: 20px,
-  xsmall: 15px
-);
-
-@function getHeadlineFontSize($fontsizeKey) {
-  @return map-get($headlineFontSizes, $fontsizeKey);
+@function getSizeFromMap($map, $keys...) {
+  @each $key in $keys {
+    $map: map-get($map, $key);
+  }
+  @return $map;
 }
 
-@function getHeadlineLineHeight($fontsizeKey) {
-  @return map-get($headlineLineHeight, $fontsizeKey);
+@mixin typeSizeVariant($size) {
+  font-size: getSizeFromMap($headlineSizes, $size, 'fontSize');
+  line-height: getSizeFromMap($headlineSizes, $size, 'lineHeight');
 }
 
 @if ($includeHtml) {
 
   .sg-headline {
     @include component();
+    @include typeSizeVariant(normal);
     display: block;
     color: $black;
-    font-size: getHeadlineFontSize(normal);
-    line-height: getHeadlineLineHeight(normal);
     font-weight: $fontWeightBold;
     letter-spacing: -1px;
     max-width: 100%;
     overflow: visible;
 
     &--xsmall {
-      font-size: getHeadlineFontSize(xsmall);
-      line-height: getHeadlineLineHeight(xsmall);
+      @include typeSizeVariant(xsmall);
     }
 
     &--small {
-      font-size: getHeadlineFontSize(small);
-      line-height: getHeadlineLineHeight(small);
+      @include typeSizeVariant(small);
     }
 
     &--large {
-      font-size: getHeadlineFontSize(large);
-      line-height: getHeadlineLineHeight(large);
+      @include typeSizeVariant(large);
     }
 
     &--xlarge {
-      font-size: getHeadlineFontSize(xlarge);
-      line-height: getHeadlineLineHeight(xlarge);
+      @include typeSizeVariant(xlarge);
     }
 
     &--xxlarge {
-      font-size: getHeadlineFontSize(xxlarge);
-      line-height: getHeadlineLineHeight(xxlarge);
+      @include typeSizeVariant(xxlarge);
     }
 
     &--extra-bold {

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -63,7 +63,7 @@ $headlineLineHeight: (
       font-size: getHeadlineFontSize(xxlarge);
       line-height: getHeadlineLineHeight(xxlarge);
     }
-    
+
     &--extra-bold {
       font-weight: $fontWeightBlack;
     }

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -68,7 +68,7 @@ $headlineLineHeight: (
       font-weight: $fontWeightBlack;
     }
 
-    &--light {
+    &--white {
       color: $white;
     }
 

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -27,23 +27,23 @@ $headlineSizes: (
   )
 );
 
-@function getSizeFromMap($map, $keys...) {
+@function getHeadLineSizeFromMap($map, $keys...) {
   @each $key in $keys {
     $map: map-get($map, $key);
   }
   @return $map;
 }
 
-@mixin typeSizeVariant($size) {
-  font-size: getSizeFromMap($headlineSizes, $size, 'fontSize');
-  line-height: getSizeFromMap($headlineSizes, $size, 'lineHeight');
+@mixin headlineTypeSizeVariant($size) {
+  font-size: getHeadLineSizeFromMap($headlineSizes, $size, 'fontSize');
+  line-height: getHeadLineSizeFromMap($headlineSizes, $size, 'lineHeight');
 }
 
 @if ($includeHtml) {
 
   .sg-headline {
     @include component();
-    @include typeSizeVariant(normal);
+    @include headlineTypeSizeVariant(normal);
     display: block;
     color: $black;
     font-weight: $fontWeightBold;
@@ -52,23 +52,23 @@ $headlineSizes: (
     overflow: visible;
 
     &--xsmall {
-      @include typeSizeVariant(xsmall);
+      @include headlineTypeSizeVariant(xsmall);
     }
 
     &--small {
-      @include typeSizeVariant(small);
+      @include headlineTypeSizeVariant(small);
     }
 
     &--large {
-      @include typeSizeVariant(large);
+      @include headlineTypeSizeVariant(large);
     }
 
     &--xlarge {
-      @include typeSizeVariant(xlarge);
+      @include headlineTypeSizeVariant(xlarge);
     }
 
     &--xxlarge {
-      @include typeSizeVariant(xxlarge);
+      @include headlineTypeSizeVariant(xxlarge);
     }
 
     &--extra-bold {

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -1,0 +1,87 @@
+$includeHtml: false !default;
+
+$headlineFontSizes: (
+  xxlarge: 53px,
+  xlarge: 39px,
+  large: 28px,
+  normal: 21px,
+  small: 18px,
+  xsmall: 14px
+);
+
+$headlineLineHeight: (
+  xxlarge: 60px,
+  xlarge: 44px,
+  large: 32px,
+  normal: 24px,
+  small: 20px,
+  xsmall: 15px
+);
+
+@function getHeadlineFontSize($fontsizeKey) {
+  @return map-get($headlineFontSizes, $fontsizeKey);
+}
+
+@function getHeadlineLineHeight($fontsizeKey) {
+  @return map-get($headlineLineHeight, $fontsizeKey);
+}
+
+@if ($includeHtml) {
+
+  .sg-headline {
+    @include component();
+    display: block;
+    color: $black;
+    font-size: getHeadlineFontSize(normal);
+    line-height: getHeadlineLineHeight(normal);
+    font-weight: $fontWeightBold;
+    letter-spacing: -1px;
+    max-width: 100%;
+    overflow: visible;
+
+    &--xsmall {
+      font-size: getHeadlineFontSize(xsmall);
+      line-height: getHeadlineLineHeight(xsmall);
+    }
+
+    &--small {
+      font-size: getHeadlineFontSize(small);
+      line-height: getHeadlineLineHeight(small);
+    }
+
+    &--large {
+      font-size: getHeadlineFontSize(large);
+      line-height: getHeadlineLineHeight(large);
+    }
+
+    &--xlarge {
+      font-size: getHeadlineFontSize(xlarge);
+      line-height: getHeadlineLineHeight(xlarge);
+    }
+
+    &--xxlarge {
+      font-size: getHeadlineFontSize(xxlarge);
+      line-height: getHeadlineLineHeight(xxlarge);
+    }
+    
+    &--extra-bold {
+      font-weight: $fontWeightBlack;
+    }
+
+    &--light {
+      color: $white;
+    }
+
+    &--uppercase {
+      text-transform: uppercase;
+    }
+
+    &--lowercase {
+      text-transform: lowercase;
+    }
+
+    &--capitalize {
+      text-transform: capitalize;
+    }
+  }
+}

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -1,0 +1,27 @@
+export const HEADLINE_TYPE = {
+  H1: 'h1',
+  H2: 'h2',
+  H3: 'h3',
+  H4: 'h4',
+  H5: 'h5',
+  H6: 'h6'
+};
+
+export const HEADLINE_SIZE = {
+  XSMALL: 'xsmall',
+  SMALL: 'small',
+  NORMAL: 'normal',
+  LARGE: 'large',
+  XLARGE: 'xlarge',
+  XXLARGE: 'xxlarge'
+};
+
+export const HEADLINE_COLOR = {
+  LIGHT: 'light'
+};
+
+export const HEADLINE_TRANSFORM = {
+  UPPERCASE: 'uppercase',
+  LOWERCASE: 'lowercase',
+  CAPITALIZE: 'capitalize'
+};

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -17,7 +17,7 @@ export const HEADLINE_SIZE = {
 };
 
 export const HEADLINE_COLOR = {
-  LIGHT: 'light'
+  WHITE: 'white'
 };
 
 export const HEADLINE_TRANSFORM = {

--- a/src/components/text/pages/headlines-interactive.jsx
+++ b/src/components/text/pages/headlines-interactive.jsx
@@ -32,7 +32,7 @@ const Headlines = () => {
         <Headline>Lorem Ipsum</Headline>
       </DocsActiveBlock>
       <DocsActiveBlock settings={settings} backgroundColor="dark">
-        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.SMALL} color={HEADLINE_COLOR.LIGHT}>
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.SMALL} color={HEADLINE_COLOR.WHITE}>
           We&apos;ve got your back!
         </Headline>
       </DocsActiveBlock>

--- a/src/components/text/pages/headlines-interactive.jsx
+++ b/src/components/text/pages/headlines-interactive.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import Headline, {HEADLINE_TYPE, HEADLINE_SIZE, HEADLINE_COLOR, HEADLINE_TRANSFORM} from '../Headline';
+import DocsActiveBlock from 'components/DocsActiveBlock';
+
+const Headlines = () => {
+  const settings = [
+    {
+      name: 'type',
+      values: HEADLINE_TYPE
+    },
+    {
+      name: 'size',
+      values: HEADLINE_SIZE
+    },
+    {
+      name: 'color',
+      values: HEADLINE_COLOR
+    },
+    {
+      name: 'transform',
+      values: HEADLINE_TRANSFORM
+    },
+    {
+      name: 'extraBold',
+      values: Boolean
+    }
+  ];
+
+  return (
+    <div>
+      <DocsActiveBlock settings={settings}>
+        <Headline>Lorem Ipsum</Headline>
+      </DocsActiveBlock>
+      <DocsActiveBlock settings={settings} backgroundColor="dark">
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.SMALL} color={HEADLINE_COLOR.LIGHT}>
+          We&apos;ve got your back!
+        </Headline>
+      </DocsActiveBlock>
+    </div>
+  );
+};
+
+export default Headlines;

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -36,6 +36,15 @@ const Headlines = () => {
       <ContrastBox>
         {light}
       </ContrastBox>
+      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.CAPITALIZE}>
+        {text} - capitalize
+      </Headline>
+      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.LOWERCASE}>
+        {text} - lowercase
+      </Headline>
+      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.UPPERCASE}>
+        {text} - uppercase
+      </Headline>
     </DocsBlock>
   );
 

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -23,7 +23,7 @@ const Headlines = () => {
       );
 
       light.push(
-        <Headline type={HEADLINE_TYPE.H2} size={size} extraBold={extraBold} color={HEADLINE_COLOR.LIGHT}>
+        <Headline type={HEADLINE_TYPE.H2} size={size} extraBold={extraBold} color={HEADLINE_COLOR.WHITE}>
           {text} - {size}
         </Headline>
       );

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import DocsBlock from 'components/DocsBlock';
+import ContrastBox from 'components/ContrastBox';
+import Headline, {HEADLINE_TYPE, HEADLINE_SIZE, HEADLINE_COLOR, HEADLINE_TRANSFORM} from '../Headline';
+
+const text = 'We\'ve got your back!';
+
+function getValues(object, addUndefined = true) {
+  return addUndefined ? [undefined, ...Object.values(object)] : Object.values(object);
+}
+
+const Headlines = () => {
+  const standard = [];
+  const light = [];
+
+  getValues(HEADLINE_SIZE, false).forEach(size => {
+    [false, true].forEach(extraBold => {
+
+      standard.push(
+        <Headline type={HEADLINE_TYPE.H2} size={size} extraBold={extraBold}>
+          {text} - {size}
+        </Headline>
+      );
+
+      light.push(
+        <Headline type={HEADLINE_TYPE.H2} size={size} extraBold={extraBold} color={HEADLINE_COLOR.LIGHT}>
+          {text} - {size}
+        </Headline>
+      );
+    });
+  });
+
+  return (
+    <DocsBlock info="Examples">
+      {standard}
+      <ContrastBox>
+        {light}
+      </ContrastBox>
+    </DocsBlock>
+  );
+
+};
+
+export default Headlines;

--- a/src/docs/navigation.js
+++ b/src/docs/navigation.js
@@ -15,6 +15,7 @@ import rating from '../components/rating/pages/rating';
 import buttons from '../components/buttons/pages/buttons';
 import text from '../components/text/pages/text';
 import headers from '../components/text/pages/headers';
+import headlines from '../components/text/pages/headlines';
 import textBit from '../components/text/pages/text-bit';
 import links from '../components/text/pages/links';
 import header from '../components/header/pages/header';
@@ -62,6 +63,11 @@ const navigation = [
         'name': 'Headers',
         'location': 'text/headers',
         component: headers
+      },
+      {
+        'name': 'Headlines',
+        'location': 'text/headlines',
+        component: headlines
       },
       {
         'name': 'Link',

--- a/src/docs/page-components.jsx
+++ b/src/docs/page-components.jsx
@@ -20,6 +20,7 @@ import Dropdowns from 'dropdowns/pages/dropdowns-interactive';
 import Separators from 'separators/pages/separators-interactive';
 import Texts from 'text/pages/text-interactive';
 import Headers from 'text/pages/headers-interactive';
+import Headlines from 'text/pages/headlines-interactive';
 import Links from 'text/pages/links-interactive';
 import TextBits from 'text/pages/text-bit-interactive';
 import PopupMenus from 'popup-menu/pages/popup-menu-interactive';
@@ -64,6 +65,7 @@ const demos = {
   'Separators': <Separators />,
   'Text': <Texts />,
   'Headers': <Headers />,
+  'Headlines': <Headlines />,
   'Links': <Links />,
   'Text Bit': <TextBits />,
   'Popup Menu': <PopupMenus />,

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -27,6 +27,7 @@ $sgFontsPath: 'fonts/' !default;
 @import '../components/dropdowns/dropdowns';
 @import '../components/text/text';
 @import '../components/text/headers';
+@import '../components/text/headlines';
 @import '../components/text/text-bits';
 @import '../components/text/links';
 @import '../components/bubble/bubble';


### PR DESCRIPTION
**Will be merged as soon as implementation of BIT's is finished**

The second part of refactoring of texts contains:

 - new Headline component. It will replace HeaderPrimary and HeaderSecondary. After refactoring in projects and making sure we have a new component in place on production, I will remove Headers from style guide.

 - We will support extra-bold for each size of a headline.
 - `--light` modifier is replaced with `--white`
 - a new component will not have any responsive behavior. I will replace existing headers with 2xheadlines if needed - for small and large screens.

![screen shot 2018-09-03 at 16 54 29](https://user-images.githubusercontent.com/4272331/45026190-e10cb480-b03d-11e8-84b3-a210c60028c8.png)

You can have a look on the implementation map here:
![typography-handoff-map](https://user-images.githubusercontent.com/4272331/45026335-45c80f00-b03e-11e8-93a0-dbead2b20905.jpg)

