### PR TITLE
BUGFIX - Remove basic component mixin from headline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "139.0.1",
+  "version": "139.0.2",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -46,7 +46,6 @@ $headlineSizes: (
     display: block;
     color: $black;
     font-weight: $fontWeightBold;
-    letter-spacing: -1px;
     max-width: 100%;
 
     &--xsmall {
@@ -71,7 +70,6 @@ $headlineSizes: (
 
     &--extra-bold {
       font-weight: $fontWeightBlack;
-      letter-spacing: 0;
     }
 
     &--white {

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -42,14 +42,12 @@ $headlineSizes: (
 @if ($includeHtml) {
 
   .sg-headline {
-    @include component();
     @include headlineTypeSizeVariant(normal);
     display: block;
     color: $black;
     font-weight: $fontWeightBold;
     letter-spacing: -1px;
     max-width: 100%;
-    overflow: visible;
 
     &--xsmall {
       @include headlineTypeSizeVariant(xsmall);


### PR DESCRIPTION
Bugfix for headline component:
 - In the future, we would refactor this mixin or get rid of it
 - We will try to not overwrite letter-spacing. It was done in the past as for big headers in bold version. Let's see how it would work for us without it.
 - `component` mixing contains min-height that break headlines alignments like in this case:

<img width="346" alt="screen shot 2018-09-11 at 09 52 45" src="https://user-images.githubusercontent.com/4272331/45478163-9aa50d00-b743-11e8-87f3-139d61f66265.png">
