### PR TITLE
Default size should not add any class

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "141.0.2",
+  "version": "141.0.3",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/text/TextBit.jsx
+++ b/src/components/text/TextBit.jsx
@@ -15,7 +15,6 @@ export const TEXT_BIT_TYPE = Object.freeze({
 
 export const TEXT_BIT_SIZE = Object.freeze({
   SMALL: 'small',
-  NORMAL: 'normal',
   LARGE: 'large',
   XLARGE: 'xlarge'
 });


### PR DESCRIPTION
After consideration - the standard size should be just `sg-text-bit`, we actually don't need to add any additional class for that.
In projects, we would just not add size property when we would like to get standard/default size of the text bit.
In statements it can be used as follows:
`{...(showSmall ? {size: TEXT_BIT_SIZE.SMALL} : {})}`