### PR TITLE
Final fix for BIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "141.0.4",
+  "version": "141.0.5",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "141.0.3",
+  "version": "141.0.4",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/text/TextBit.jsx
+++ b/src/components/text/TextBit.jsx
@@ -45,7 +45,7 @@ const TextBit = ({
   ...props}: TextBitPropsType) => {
   const Type = type;
   const textClass = classNames('sg-text-bit', {
-    [`sg-text-bit--${size}`]: size,
+    [`sg-text-bit--${size}`]: size && size !== TEXT_BIT_SIZE.NORMAL,
     [`sg-text-bit--${color || ''}`]: color
   }, className);
 

--- a/src/components/text/TextBit.jsx
+++ b/src/components/text/TextBit.jsx
@@ -45,7 +45,7 @@ const TextBit = ({
   ...props}: TextBitPropsType) => {
   const Type = type;
   const textClass = classNames('sg-text-bit', {
-    [`sg-text-bit--${size}`]: size && size !== TEXT_BIT_SIZE.NORMAL,
+    [`sg-text-bit--${size}`]: size,
     [`sg-text-bit--${color || ''}`]: color
   }, className);
 

--- a/src/components/text/TextBit.jsx
+++ b/src/components/text/TextBit.jsx
@@ -15,6 +15,7 @@ export const TEXT_BIT_TYPE = Object.freeze({
 
 export const TEXT_BIT_SIZE = Object.freeze({
   SMALL: 'small',
+  NORMAL: 'normal',
   LARGE: 'large',
   XLARGE: 'xlarge'
 });
@@ -44,7 +45,7 @@ const TextBit = ({
   ...props}: TextBitPropsType) => {
   const Type = type;
   const textClass = classNames('sg-text-bit', {
-    [`sg-text-bit--${size || ''}`]: size,
+    [`sg-text-bit--${size || ''}`]: size !== TEXT_BIT_SIZE.NORMAL,
     [`sg-text-bit--${color || ''}`]: color
   }, className);
 

--- a/src/components/text/TextBit.jsx
+++ b/src/components/text/TextBit.jsx
@@ -39,13 +39,13 @@ type TextBitPropsType = {
 const TextBit = ({
   children,
   type = TEXT_BIT_TYPE.H1,
-  size,
+  size = TEXT_BIT_SIZE.NORMAL,
   color,
   className,
   ...props}: TextBitPropsType) => {
   const Type = type;
   const textClass = classNames('sg-text-bit', {
-    [`sg-text-bit--${size || ''}`]: size !== TEXT_BIT_SIZE.NORMAL,
+    [`sg-text-bit--${size}`]: size && size !== TEXT_BIT_SIZE.NORMAL,
     [`sg-text-bit--${color || ''}`]: color
   }, className);
 

--- a/src/components/text/TextBit.spec.jsx
+++ b/src/components/text/TextBit.spec.jsx
@@ -10,12 +10,20 @@ test('render', () => {
   expect(textBit.hasClass('sg-text-bit')).toBeTruthy();
 });
 
-test('sie', () => {
+test('size', () => {
   const textBit = shallow(
     <TextBit size={TEXT_BIT_SIZE.XLARGE}>Test</TextBit>
   );
 
   expect(textBit.hasClass('sg-text-bit--xlarge')).toBeTruthy();
+});
+
+test('should not pass size when default passed', () => {
+  const textBit = shallow(
+    <TextBit size={TEXT_BIT_SIZE.NORMAL}>Test</TextBit>
+  );
+
+  expect(textBit.hasClass('sg-text-bit--normal')).toBeFalsy();
 });
 
 test('type', () => {


### PR DESCRIPTION
Rollback to a previous version where the default value is exported - seem's like more intuitive also in terms of usage. Normal value does not append a modifier to the class `sg-text-bit`, it just points to this default (just `sg-text-bit`)
Example of usage:
`size={screenInfo.isSmallOnly ? TEXT_BIT_SIZE.SMALL : TEXT_BIT_SIZE.NORMAL}`