### PR TITLE
BUGFIX - Headline colors

### DIFF
--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -107,7 +107,7 @@ $headlineSizes: (
     &--peach {
       color: $peachPrimary;
     }
-    
+
     &--uppercase {
       text-transform: uppercase;
     }

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -76,6 +76,38 @@ $headlineSizes: (
       color: $white;
     }
 
+    &--gray {
+      color: $grayPrimary;
+    }
+
+    &--gray-secondary {
+      color: $graySecondary;
+    }
+
+    &--mint {
+      color: $mintPrimary;
+    }
+
+    &--blue {
+      color: $bluePrimary;
+    }
+
+    &--blue-secondary {
+      color: $blueSecondary;
+    }
+
+    &--blue-secondary-light {
+      color: $blueSecondaryLight;
+    }
+
+    &--mustard {
+      color: $mustardPrimary;
+    }
+
+    &--peach {
+      color: $peachPrimary;
+    }
+    
     &--uppercase {
       text-transform: uppercase;
     }

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -17,7 +17,16 @@ export const HEADLINE_SIZE = {
 };
 
 export const HEADLINE_COLOR = {
-  WHITE: 'white'
+  DEFAULT: 'default',
+  WHITE: 'white',
+  GRAY: 'gray',
+  GRAY_SECONDARY: 'gray-secondary',
+  MINT: 'mint',
+  PEACH: 'peach',
+  MUSTARD: 'mustard',
+  BLUE: 'blue',
+  BLUE_SECONDARY: 'blue-secondary',
+  BLUE_SECONDARY_LIGHT: 'blue-secondary-light'
 };
 
 export const HEADLINE_TRANSFORM = {

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -37,9 +37,6 @@ const Headlines = () => {
         {light}
       </ContrastBox>
       <br />
-      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} color={HEADLINE_COLOR.MINT} transform={HEADLINE_TRANSFORM.CAPITALIZE}>
-        {text} - capitalize
-      </Headline>
       <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.CAPITALIZE}>
         {text} - capitalize
       </Headline>

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -37,6 +37,9 @@ const Headlines = () => {
         {light}
       </ContrastBox>
       <br />
+      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} color={HEADLINE_COLOR.MINT} transform={HEADLINE_TRANSFORM.CAPITALIZE}>
+        {text} - capitalize
+      </Headline>
       <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.CAPITALIZE}>
         {text} - capitalize
       </Headline>


### PR DESCRIPTION
Colors of headlines should be adjusted to body text, as they can, and sometimes should, appears in pairs. To prevent from using body-text instead of headline, we need to support the same colors as for body text.