### PR TITLE
Card changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "142.4.4",
+  "version": "142.5.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/card/CardHole.jsx
+++ b/src/components/card/CardHole.jsx
@@ -19,7 +19,7 @@ export const CARD_HOLE_COLOR = {
   GRAY_SECONDARY: 'gray-secondary',
   GRAY_SECONDARY_LIGHT: 'gray-secondary-light',
   GRAY_SECONDARY_LIGHTEST: 'gray-secondary-lightest',
-  SILVER_SECONDARY_LIGHT: 'silver-secondary-light'
+  GRAY_SECONDARY_ULTRA_LIGHT: 'gray-secondary-ultra-light'
 };
 
 const CardHole = ({color, children, className, ...props}) => {

--- a/src/components/card/CardHole.jsx
+++ b/src/components/card/CardHole.jsx
@@ -18,7 +18,8 @@ export const CARD_HOLE_COLOR = {
   GRAY: 'gray',
   GRAY_SECONDARY: 'gray-secondary',
   GRAY_SECONDARY_LIGHT: 'gray-secondary-light',
-  GRAY_SECONDARY_LIGHTEST: 'gray-secondary-lightest'
+  GRAY_SECONDARY_LIGHTEST: 'gray-secondary-lightest',
+  SILVER_SECONDARY_LIGHT: 'silver-secondary-light'
 };
 
 const CardHole = ({color, children, className, ...props}) => {

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -150,8 +150,8 @@ $includeHtml: false !default;
         background-color: $graySecondaryLightest;
       }
 
-      &--silver-secondary-light {
-        background-color: $silverSecondaryLight;
+      &--gray-secondary-ultra-light {
+        background-color: $graySecondaryUltraLight;
       }
     }
   }

--- a/src/components/card/_card.scss
+++ b/src/components/card/_card.scss
@@ -15,7 +15,6 @@ $includeHtml: false !default;
     border: $cardBorderColor solid $cardBorderSize;
     overflow: hidden;
     background-color: $white;
-    box-shadow: $containerShadow;
 
     &--transparent {
       background-color: transparent;
@@ -149,6 +148,10 @@ $includeHtml: false !default;
 
       &--gray-secondary-lightest {
         background-color: $graySecondaryLightest;
+      }
+
+      &--silver-secondary-light {
+        background-color: $silverSecondaryLight;
       }
     }
   }

--- a/src/components/colors/colors.js
+++ b/src/components/colors/colors.js
@@ -108,6 +108,11 @@ const color = {
       'name': 'Gray secondary lightest',
       'variable': '$graySecondaryLightest',
       'hex': 'f0f3f5'
+    },
+    {
+      'name': 'Gray secondary ultra light',
+      'variable': '$graySecondaryUltraLight',
+      'hex': 'f7f9fa'
     }
   ],
   'additional': [

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -24,6 +24,7 @@ $grayPrimary: #434e66;
 $graySecondary: #9fa6b5;
 $graySecondaryLight: #e1e8ed;
 $graySecondaryLightest: #f0f3f5;
+$graySecondaryUltraLight: #f7f9fa;
 
 // Special colors - for games
 $bronzePrimary: #a76a58;


### PR DESCRIPTION
delete unneeded box-shadow in Card (shadow available by props)
new color in Brainly palette graySecondaryUltraLight

![screenshot 2018-10-23 at 16 45 11](https://user-images.githubusercontent.com/17196505/47369118-464a6100-d6e3-11e8-89a3-7c3fd1615392.png)
