### PR TITLE
Fix components after palette update

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "142.8.3",
+  "version": "142.9.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/avatar/Avatar.jsx
+++ b/src/components/avatar/Avatar.jsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import Icon, {TYPE as ICON_TYPE, ICON_COLOR} from '../icons/Icon';
 
 const DEFAULT_ICON = ICON_TYPE.PROFILE;
-const DEFAULT_COLOR = ICON_COLOR.GRAY;
+const DEFAULT_COLOR = ICON_COLOR.GRAY_SECONDARY;
 const BORDER_SIZE = 2;
 
 export const SIZE = {

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -1,4 +1,4 @@
-$avatarDefaultBackgroundColor: $graySecondary;
+$avatarDefaultBackgroundColor: $graySecondaryLight;
 $avatarXSmallSize: 16px;
 $avatarSmallSize: 24px;
 $avatarMediumSize: 32px;

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -5,8 +5,8 @@ $buttonDarkColor: $grayPrimary;
 $buttonInverseColor: $white;
 $buttonPeach: $peachPrimary;
 
-$buttonInverseFontColor: $mintPrimary;
-$buttonInverseAltFontColor: $bluePrimary;
+$buttonInverseFontColor: $mintPrimaryDark;
+$buttonInverseAltFontColor: $bluePrimaryDark;
 $buttonInverseDarkFontColor: $grayPrimary;
 
 $buttonActiveInverseColor: $white;

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -5,8 +5,8 @@ $selectFontSize: fontSize(small);
 $selectIconSize: rhythm(1 / 3);
 $selectBorderRadius: 7px;
 $selectActiveBorderColor: $grayPrimary;
-$selectActiveInvalidBorderColor: $peachPrimary;
-$selectActiveValidBorderColor: $mintPrimary;
+$selectActiveInvalidBorderColor: $peachPrimaryDark;
+$selectActiveValidBorderColor: $mintPrimaryDark;
 $arrowColor: $graySecondary;
 
 $includeHtml: false !default;

--- a/src/components/form-elements/_text-input.scss
+++ b/src/components/form-elements/_text-input.scss
@@ -7,8 +7,8 @@ $inputTextColor: $black;
 $inputFontSize: fontSize(small);
 $inputLargeFontSize: fontSize(standout);
 $inputPlaceholderTextColor: $graySecondary;
-$inputFocusValidBorderColor: $mintPrimary;
-$inputFocusInvalidBorderColor: $peachPrimary;
+$inputFocusValidBorderColor: $mintPrimaryDark;
+$inputFocusInvalidBorderColor: $peachPrimaryDark;
 $inputStandardBorderRadius: 9px;
 $inputPlaceholderFontSize: 14px;
 

--- a/src/components/form-elements/_textarea.scss
+++ b/src/components/form-elements/_textarea.scss
@@ -7,8 +7,8 @@ $textareaPadding: gutter(1 / 2);
 $textareaPaddingSmaller: gutter(1 / 3);
 $textareaPlaceholderTextColor: $graySecondary;
 $textareaPlaceholderFontSize: fontSize(medium);
-$textareaFocusValid: $mintPrimary;
-$textareaFocusInvalid: $peachPrimary;
+$textareaFocusValid: $mintPrimaryDark;
+$textareaFocusInvalid: $peachPrimaryDark;
 $textareaStandardBorderRadius: 9px;
 
 $includeHtml: false !default;

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -42,7 +42,7 @@ const Link = (props: LinkPropsType) => {
   const {
     children,
     href,
-    color = LINK_COLOR.BLUE,
+    color = LINK_COLOR.BLUE_DARK,
     underlined = false,
     unstyled = false,
     emphasised = true, //backward compability

--- a/src/components/text/_links.scss
+++ b/src/components/text/_links.scss
@@ -5,7 +5,7 @@ $includeHtml: false !default;
   .sg-link {
     @include removeDescenders();
     cursor: pointer;
-    color: $bluePrimary;
+    color: $bluePrimaryDark;
     text-decoration: none;
     font-weight: $fontWeightBold;
 

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -154,11 +154,11 @@ $bodyTextSizes: (
     }
 
     &--mint-dark {
-      color: $mintPrimary;
+      color: $mintPrimaryDark;
     }
 
     &--mint {
-      color: $mintPrimaryDark;
+      color: $mintPrimary;
     }
 
     &--white {
@@ -186,11 +186,11 @@ $bodyTextSizes: (
     }
 
     &--peach-dark {
-      color: $peachPrimary;
+      color: $peachPrimaryDark;
     }
 
     &--peach {
-      color: $peachPrimaryDark;
+      color: $peachPrimary;
     }
 
     // TODO to be removed when changes in twig template would be changed

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -153,12 +153,20 @@ $bodyTextSizes: (
       color: $graySecondary;
     }
 
-    &--mint {
+    &--mint-dark {
       color: $mintPrimary;
+    }
+
+    &--mint {
+      color: $mintPrimaryDark;
     }
 
     &--white {
       color: $white;
+    }
+
+    &--blue-dark {
+      color: $bluePrimaryDark;
     }
 
     &--blue {
@@ -177,8 +185,12 @@ $bodyTextSizes: (
       color: $mustardPrimary;
     }
 
-    &--peach {
+    &--peach-dark {
       color: $peachPrimary;
+    }
+
+    &--peach {
+      color: $peachPrimaryDark;
     }
 
     // TODO to be removed when changes in twig template would be changed

--- a/src/components/text/pages/text.jsx
+++ b/src/components/text/pages/text.jsx
@@ -56,7 +56,7 @@ const TextExamples = () => {
           weight={LINK_WEIGHT.BOLD}
           size={LINK_SIZE.LARGE}
         >
-          link / bold / standard / xlarge /  la la
+          link / bold / standard / xlarge / standard
         </Link>
         <br />
         <Link

--- a/src/components/text/pages/text.jsx
+++ b/src/components/text/pages/text.jsx
@@ -56,7 +56,7 @@ const TextExamples = () => {
           weight={LINK_WEIGHT.BOLD}
           size={LINK_SIZE.LARGE}
         >
-          link / bold / standard / xlarge / standard
+          link / bold / standard / xlarge /  la la
         </Link>
         <br />
         <Link

--- a/src/components/text/textConsts.js
+++ b/src/components/text/textConsts.js
@@ -36,9 +36,12 @@ export const TEXT_COLOR = Object.freeze({
   LIGHT: 'white', //backward compability
   GRAY: 'gray',
   GRAY_SECONDARY: 'gray-secondary',
+  MINT_DARK: 'mint-dark',
   MINT: 'mint',
+  PEACH_DARK: 'peach-dark',
   PEACH: 'peach',
   MUSTARD: 'mustard',
+  BLUE_DARK: 'blue-dark',
   BLUE: 'blue',
   BLUE_SECONDARY: 'blue-secondary',
   BLUE_SECONDARY_LIGHT: 'blue-secondary-light'


### PR DESCRIPTION
After refreshing palette we need to update some components:

 - Buttons to use a dark color on inverse version
 - option to use dark colors in texts  - e.g used for errors
 - valid and invalid selects, inputs and text area to use dark colors
 - refresh avatar to use brighter colors
 - deep blue links