### PR TITLE
added babel v7.x config, with compatibility with v6.x

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
       {
         "modules": false
       }
-    ], 
+    ],
     "react",
     "flow"
   ],

--- a/src/.babelrc.js
+++ b/src/.babelrc.js
@@ -1,3 +1,6 @@
+// this file will be used only by babel 7;
+// babel 6 will still use .babelrc in the root folder
+// it makes repo code compatible both with babel 6 and 7
 const babelEnv = modules => [
   '@babel/preset-env',
   {

--- a/src/.babelrc.js
+++ b/src/.babelrc.js
@@ -1,0 +1,24 @@
+const babelEnv = modules => [
+  '@babel/preset-env',
+  {
+    modules,
+    targets: '> 0.2%, not dead, not ie < 11'
+  }
+];
+
+module.exports = (api) => {
+  api.cache(true);
+  return {
+    presets: [babelEnv(false), '@babel/preset-react'],
+    plugins: [
+      '@babel/plugin-transform-flow-strip-types',
+      '@babel/plugin-proposal-object-rest-spread',
+      '@babel/plugin-proposal-class-properties',
+    ],
+    env: {
+      test: {
+        presets: [babelEnv('auto')],
+      }
+    }
+  }
+};


### PR DESCRIPTION
added babel v7.x config, with compatibility with v6.x
`.babelrc` will be used by babel 6 until this repo will be upgraded to v7, while all consumers will be able to use styleguide by consuming `.babelrc.js` config