### PR TITLE
Replace answer and heart icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "143.3.6",
+  "version": "143.3.7",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/images/icons/answer.svg
+++ b/src/images/icons/answer.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" preserveAspectRatio="xMidYMid" width="32" height="32">
   <title>answer</title>
-  <path fill-rule="evenodd" d="M28.6 0H4c-.6 0-1 .4-1 1v30c0 .6.4 1 1 1h24.6c.7 0 1-.4 1-1V1c0-.6-.3-1-1-1zM14.3 24h-4c-.7 0-1-.4-1-1s.3-1 1-1h4c.6 0 1 .4 1 1s-.4 1-1 1zm8.2-5H10.2c-.6 0-1-.4-1-1s.4-1 1-1h12.3c.6 0 1 .4 1 1s-.4 1-1 1zm0-5H10.2c-.6 0-1-.4-1-1s.4-1 1-1h12.3c.6 0 1 .4 1 1s-.4 1-1 1zm0-5H10.2c-.6 0-1-.4-1-1s.4-1 1-1h12.3c.6 0 1 .4 1 1s-.4 1-1 1z"/>
+  <path d="M28.42 0H3.58A3.58 3.58 0 0 0 0 3.58v24.84A3.58 3.58 0 0 0 3.58 32h24.84A3.58 3.58 0 0 0 32 28.42V3.58A3.58 3.58 0 0 0 28.42 0zM14 26H6a2 2 0 0 1 0-4h8a2 2 0 0 1 0 4zm12-8H6a2 2 0 0 1 0-4h20a2 2 0 0 1 0 4zm0-8H6a2 2 0 0 1 0-4h20a2 2 0 0 1 0 4z" data-name="Layer 36"/>
 </svg>

--- a/src/images/icons/heart.svg
+++ b/src/images/icons/heart.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" preserveAspectRatio="xMidYMid" width="32" height="32" viewBox="0 0 32 32">
+<svg xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid" width="32" height="32" viewBox="0 0 32 32">
   <title>heart</title>
-  <path d="M16.039,5.193 C10.504,-0.952 0.011,2.297 0.011,10.914 C0.011,19.602 9.570,23.770 16.039,29.985 C22.507,23.770 31.995,19.602 31.995,10.914 C31.995,2.297 21.573,-0.952 16.039,5.193 Z"/>
+  <path d="M18.16 29.39a3.17 3.17 0 0 1-4.3-.02l-.18-.16C5.28 21.56-.2 16.54.01 10.3a8.82 8.82 0 0 1 3.74-6.92A9.22 9.22 0 0 1 16 5.15a9.2 9.2 0 0 1 12.25-1.78A8.82 8.82 0 0 1 32 10.3c.23 6.25-5.27 11.27-13.67 18.96z" data-name="Layer 8"/>
 </svg>


### PR DESCRIPTION
Changes of two icons:

answer icon BEFORE:
<img width="129" alt="Screenshot 2019-04-12 at 12 11 54" src="https://user-images.githubusercontent.com/4272331/56030156-754da100-5d1c-11e9-8a6f-233521bb6c81.png">

answer icon AFTER:
<img width="136" alt="Screenshot 2019-04-12 at 12 13 41" src="https://user-images.githubusercontent.com/4272331/56030194-8ac2cb00-5d1c-11e9-9dc3-8e2e6e4d267f.png">

heart icon BEFORE:
<img width="120" alt="Screenshot 2019-04-12 at 12 11 59" src="https://user-images.githubusercontent.com/4272331/56030218-9d3d0480-5d1c-11e9-8c57-df9a3376ae0c.png">

heart icon AFTER:
<img width="114" alt="Screenshot 2019-04-12 at 12 13 45" src="https://user-images.githubusercontent.com/4272331/56030230-a4641280-5d1c-11e9-8a5b-bac399640d18.png">
