### PR TITLE
Update bit and headline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "143.4.1",
+  "version": "143.5.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/text/Headline.jsx
+++ b/src/components/text/Headline.jsx
@@ -25,12 +25,11 @@ type HeadlineColorType =
   | 'gray'
   | 'gray-secondary'
   | 'gray-secondary-light'
-  | 'mint'
-  | 'peach'
-  | 'mustard'
-  | 'blue'
-  | 'blue-secondary'
-  | 'blue-secondary-light';
+  | 'mint-dark'
+  | 'peach-dark'
+  | 'lavender-dark'
+  | 'mustard-dark'
+  | 'blue-dark';
 
 type HeadlineTransformType =
   | 'uppercase'

--- a/src/components/text/TextBit.jsx
+++ b/src/components/text/TextBit.jsx
@@ -19,13 +19,20 @@ type TextBitSizeType =
   | 'xlarge';
 
 type TextBitColorType =
-  | 'blue-secondary'
-  | 'white'
-  | 'black'
-  | 'mint'
   | 'blue-primary'
+  | 'blue-secondary'
+  | 'mint-primary'
+  | 'mint-secondary'
+  | 'lavender-primary'
+  | 'lavender-secondary'
+  | 'peach-primary'
+  | 'peach-secondary'
+  | 'mustard-primary'
+  | 'mustard-secondary'
   | 'gray-secondary'
-  | 'peach-primary';
+  | 'gray-secondary-light'
+  | 'white'
+  | 'black';
 
 export const TEXT_BIT_TYPE = Object.freeze({
   H1: 'h1',
@@ -45,13 +52,20 @@ export const TEXT_BIT_SIZE = Object.freeze({
 });
 
 export const TEXT_BIT_COLOR = Object.freeze({
-  BLUE_SECONDARY: 'blue-secondary',
-  WHITE: 'white',
-  BLACK: 'black',
-  MINT: 'mint',
   BLUE_PRIMARY: 'blue-primary',
+  BLUE_SECONDARY: 'blue-secondary',
+  MINT_PRIMARY: 'mint-primary',
+  MINT_SECONDARY: 'mint-secondary',
+  PEACH_PRIMARY: 'peach-primary',
+  PEACH_SECONDARY: 'peach-secondary',
+  MUSTARAD_PRIMARY: 'mustard-primary',
+  MUSTARAD_SECONDARY: 'mustard-secondary',
+  LAVENDER_PRIMARY: 'lavender-primary',
+  LAVENDER_SECONDARY: 'lavender-secondary',
   GRAY_SECONDARY: 'gray-secondary',
-  PEACH_PRIMARY: 'peach-primary'
+  GRAY_SECONDARY_LIGHT: 'gray-secondary-light',
+  WHITE: 'white',
+  BLACK: 'black'
 });
 
 type TextBitPropsType = {

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -88,28 +88,43 @@ $headlineSizes: (
       color: $graySecondaryLight;
     }
 
+    &--mint-dark {
+      color: $mintPrimaryDark;
+    }
+
+    // backward compatibility for html, it should be replaced with sg-text--mint-dark
     &--mint {
-      color: $mintPrimary;
+      color: $mintPrimaryDark;
     }
 
+    &--blue-dark {
+      color: $bluePrimaryDark;
+    }
+
+    // backward compatibility for html, it should be replaced with sg-text--blue-dark
     &--blue {
-      color: $bluePrimary;
+      color: $bluePrimaryDark;
     }
 
-    &--blue-secondary {
-      color: $blueSecondary;
-    }
-
-    &--blue-secondary-light {
-      color: $blueSecondaryLight;
+    &--mustard-dark {
+      color: $mustardPrimaryDark;
     }
 
     &--mustard {
-      color: $mustardPrimary;
+      color: $mustardPrimaryDark;
     }
 
+    &--lavender-dark {
+      color: $lavenderPrimaryDark;
+    }
+
+    &--peach-dark {
+      color: $peachPrimaryDark;
+    }
+
+    // backward compatibility for html, it should be replaced with sg-text--peach-dark
     &--peach {
-      color: $peachPrimary;
+      color: $peachPrimaryDark;
     }
 
     &--uppercase {

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -38,8 +38,52 @@ $bitSizes: (
       line-height: getBitSize(xlarge);
     }
 
+    &--blue-primary {
+      color: $bluePrimary;
+    }
+
     &--blue-secondary {
       color: $blueSecondary;
+    }
+
+    &--mint-primary {
+      color: $mintPrimary;
+    }
+
+    &--mint-secondary {
+      color: $mintSecondary;
+    }
+
+    &--peach-primary {
+      color: $peachPrimary;
+    }
+
+    &--peach-secondary {
+      color: $peachSecondary;
+    }
+
+    &--lavender-primary {
+      color: $lavenderPrimary;
+    }
+
+    &--lavender-secondary {
+      color: $lavenderSecondary;
+    }
+
+    &--mustard-primary {
+      color: $mustardPrimary;
+    }
+
+    &--mustard-secondary {
+      color: $mustardSecondary;
+    }
+
+    &--gray-secondary {
+      color: $graySecondary;
+    }
+
+    &--gray-secondary-light {
+      color: $graySecondaryLight;
     }
 
     &--white {
@@ -48,22 +92,6 @@ $bitSizes: (
 
     &--black {
       color: $black;
-    }
-
-    &--gray-secondary {
-      color: $graySecondary;
-    }
-
-    &--peach-primary {
-      color: $peachPrimary;
-    }
-
-    &--blue-primary {
-      color: $bluePrimary;
-    }
-
-    &--mint {
-      color: $mintPrimary;
     }
   }
 }

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -6,7 +6,8 @@ export const HEADLINE_TYPE = Object.freeze({
   H3: 'h3',
   H4: 'h4',
   H5: 'h5',
-  H6: 'h6'
+  H6: 'h6',
+  SPAN: 'span'
 });
 
 export const HEADLINE_SIZE = Object.freeze({

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -19,15 +19,14 @@ export const HEADLINE_SIZE = {
 export const HEADLINE_COLOR = {
   DEFAULT: 'default',
   WHITE: 'white',
-  GRAY: 'gray',
+  BLUE_DARK: 'blue-dark',
+  MINT_DARK: 'mint-dark',
+  LAVENDER_DARK: 'lavender-dark',
+  MUSTARD_DARK: 'mustard-dark',
+  PEACH_DARK: 'peach-dark',
+  GRAY: 'gray', //this name should be changed into GRAY_PRIMARY in the future maybe
   GRAY_SECONDARY: 'gray-secondary',
-  GRAY_SECONDARY_LIGHT: 'gray-secondary-light',
-  MINT: 'mint',
-  PEACH: 'peach',
-  MUSTARD: 'mustard',
-  BLUE: 'blue',
-  BLUE_SECONDARY: 'blue-secondary',
-  BLUE_SECONDARY_LIGHT: 'blue-secondary-light'
+  GRAY_SECONDARY_LIGHT: 'gray-secondary-light'
 };
 
 export const HEADLINE_TRANSFORM = {

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -1,22 +1,22 @@
-export const HEADLINE_TYPE = {
+export const HEADLINE_TYPE = Object.freeze({
   H1: 'h1',
   H2: 'h2',
   H3: 'h3',
   H4: 'h4',
   H5: 'h5',
   H6: 'h6'
-};
+});
 
-export const HEADLINE_SIZE = {
+export const HEADLINE_SIZE = Object.freeze({
   XSMALL: 'xsmall',
   SMALL: 'small',
   NORMAL: 'normal',
   LARGE: 'large',
   XLARGE: 'xlarge',
   XXLARGE: 'xxlarge'
-};
+});
 
-export const HEADLINE_COLOR = {
+export const HEADLINE_COLOR = Object.freeze({
   DEFAULT: 'default',
   WHITE: 'white',
   BLUE_DARK: 'blue-dark',
@@ -27,17 +27,17 @@ export const HEADLINE_COLOR = {
   GRAY: 'gray', //this name should be changed into GRAY_PRIMARY in the future maybe
   GRAY_SECONDARY: 'gray-secondary',
   GRAY_SECONDARY_LIGHT: 'gray-secondary-light'
-};
+});
 
-export const HEADLINE_TRANSFORM = {
+export const HEADLINE_TRANSFORM = Object.freeze({
   UPPERCASE: 'uppercase',
   LOWERCASE: 'lowercase',
   CAPITALIZE: 'capitalize'
-};
+});
 
-export const HEADLINE_ALIGN = {
+export const HEADLINE_ALIGN = Object.freeze({
   LEFT: 'to-left',
   CENTER: 'to-center',
   RIGHT: 'to-right',
   JUSTIFY: 'justify'
-};
+});

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -1,3 +1,5 @@
+// @flow
+
 export const HEADLINE_TYPE = Object.freeze({
   H1: 'h1',
   H2: 'h2',

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -11,7 +11,7 @@ function getValues(object, addUndefined = true) {
 
 const Headlines = () => {
   const standard = [];
-  const light = [];
+  const colorsVariants = [];
 
   getValues(HEADLINE_SIZE, false).forEach(size => {
     [false, true].forEach(extraBold => {
@@ -21,42 +21,58 @@ const Headlines = () => {
           {text} - {size}
         </Headline>
       );
-
-      light.push(
-        <Headline type={HEADLINE_TYPE.H2} size={size} extraBold={extraBold} color={HEADLINE_COLOR.WHITE}>
-          {text} - {size}
-        </Headline>
-      );
     });
   });
 
+  getValues(HEADLINE_COLOR, false).forEach(color => {
+    if (color !== HEADLINE_COLOR.WHITE) {
+      colorsVariants.push(
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} color={color}>
+          {text} - {color}
+        </Headline>
+      );
+    } else {
+      colorsVariants.push(
+        <ContrastBox>
+          <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} color={color}>
+            {text} - {color}
+          </Headline>
+        </ContrastBox>
+      );
+    }
+
+  });
+
   return (
-    <DocsBlock info="Examples">
-      {standard}
-      <ContrastBox>
-        {light}
-      </ContrastBox>
-      <br />
-      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.CAPITALIZE}>
-        {text} - capitalize
-      </Headline>
-      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.LOWERCASE}>
-        {text} - lowercase
-      </Headline>
-      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.UPPERCASE}>
-        {text} - uppercase
-      </Headline>
-      <br />
-      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} align={HEADLINE_ALIGN.LEFT}>
-        {text} - align left
-      </Headline>
-      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} align={HEADLINE_ALIGN.CENTER}>
-        {text} - align center
-      </Headline>
-      <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} align={HEADLINE_ALIGN.RIGHT}>
-        {text} - align right
-      </Headline>
-    </DocsBlock>
+    <React.Fragment>
+      <DocsBlock info="Size and weight variant">
+        {standard}
+      </DocsBlock>
+      <DocsBlock info="Colors variants">
+        {colorsVariants}
+      </DocsBlock>
+      <DocsBlock info="Examples">
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.CAPITALIZE}>
+          {text} - capitalize
+        </Headline>
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.LOWERCASE}>
+          {text} - lowercase
+        </Headline>
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} transform={HEADLINE_TRANSFORM.UPPERCASE}>
+          {text} - uppercase
+        </Headline>
+        <br />
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} align={HEADLINE_ALIGN.LEFT}>
+          {text} - align left
+        </Headline>
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} align={HEADLINE_ALIGN.CENTER}>
+          {text} - align center
+        </Headline>
+        <Headline type={HEADLINE_TYPE.H2} size={HEADLINE_SIZE.NORMAL} align={HEADLINE_ALIGN.RIGHT}>
+          {text} - align right
+        </Headline>
+      </DocsBlock>
+    </React.Fragment>
   );
 
 };

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -5,6 +5,33 @@ import Headline, {HEADLINE_TYPE, HEADLINE_SIZE, HEADLINE_COLOR, HEADLINE_TRANSFO
 
 const text = 'We\'ve got your back!';
 
+const headlineSizesMap = [
+  {
+    type: 'xsmall',
+    fontSize: '14px'
+  },
+  {
+    type: 'small',
+    fontSize: '18px'
+  },
+  {
+    type: 'normal',
+    fontSize: '21px'
+  },
+  {
+    type: 'large',
+    fontSize: '28px'
+  },
+  {
+    type: 'xlarge',
+    fontSize: '39px'
+  },
+  {
+    type: 'xxlarge',
+    fontSize: '53px'
+  }
+];
+
 function getValues(object, addUndefined = true) {
   return addUndefined ? [undefined, ...Object.values(object)] : Object.values(object);
 }
@@ -15,10 +42,13 @@ const Headlines = () => {
 
   getValues(HEADLINE_SIZE, false).forEach(size => {
     [false, true].forEach(extraBold => {
+      let itemSize;
+
+      headlineSizesMap.map(item => (item.type === size ? itemSize = `${item.fontSize}` : null));
 
       standard.push(
         <Headline type={HEADLINE_TYPE.H2} size={size} extraBold={extraBold}>
-          {text} - {size}
+          {text} - {size} - {itemSize}
         </Headline>
       );
     });

--- a/src/components/text/pages/text-bit.jsx
+++ b/src/components/text/pages/text-bit.jsx
@@ -1,37 +1,39 @@
 import React from 'react';
 import DocsBlock from 'components/DocsBlock';
-import ContrastBox from 'components/ContrastBox';
 import TextBit, {TEXT_BIT_SIZE, TEXT_BIT_COLOR} from '../TextBit';
 
-const TextBitExamples = () => (
-  <DocsBlock info="Default">
-    <TextBit>
-      This is text bit default
-    </TextBit>
-    <TextBit size={TEXT_BIT_SIZE.LARGE} color={TEXT_BIT_COLOR.BLUE_SECONDARY}>
-      This is text bit large primary blue
-    </TextBit>
-    <TextBit size={TEXT_BIT_SIZE.SMALL} color={TEXT_BIT_COLOR.GRAY_SECONDARY}>
-      This is text bit small secondary gray
-    </TextBit>
-    <TextBit size={TEXT_BIT_SIZE.LARGE} color={TEXT_BIT_COLOR.BLUE_PRIMARY}>
-      This is text bit large primary blue
-    </TextBit>
-    <TextBit color={TEXT_BIT_COLOR.PEACH_PRIMARY}>
-      This is text bit default peach primary
-    </TextBit>
-    <TextBit size={TEXT_BIT_SIZE.SMALL} color={TEXT_BIT_COLOR.MINT}>
-      This is text bit small secondary gray
-    </TextBit>
-    <ContrastBox>
-      <TextBit size={TEXT_BIT_SIZE.LARGE} color={TEXT_BIT_COLOR.WHITE}>
-        This is text bit large white
+const text = 'We\'ve got your back!';
+
+function getValues(object, addUndefined = true) {
+  return addUndefined ? [undefined, ...Object.values(object)] : Object.values(object);
+}
+
+const TextBitExamples = () => {
+  const sizesVariants = [];
+  const colorsVariants = [];
+
+  getValues(TEXT_BIT_SIZE, false).forEach(size => {
+    sizesVariants.push(
+      <TextBit size={size} color={TEXT_BIT_COLOR.PEACH_PRIMARY}>
+        {text} - {size}
       </TextBit>
-    </ContrastBox>
-    <TextBit size={TEXT_BIT_SIZE.XLARGE} color={TEXT_BIT_COLOR.BLACK}>
-      This is text bit large black
-    </TextBit>
-  </DocsBlock>
-);
+    );
+  });
+
+  getValues(TEXT_BIT_COLOR, false).forEach(color => {
+    colorsVariants.push(
+      <TextBit size={TEXT_BIT_SIZE.NORMAL} color={color}>
+        {text} - {color}
+      </TextBit>
+    );
+  });
+
+  return (
+    <DocsBlock info="Default">
+      {sizesVariants}
+      {colorsVariants}
+    </DocsBlock>
+  );
+};
 
 export default TextBitExamples;


### PR DESCRIPTION
Requested changes in bits and headlines colors:

<img width="274" alt="Screenshot 2019-04-19 at 17 37 17" src="https://user-images.githubusercontent.com/4272331/56431790-5f674f80-62cb-11e9-8d69-8b28b05d582a.png">
<img width="250" alt="Screenshot 2019-04-19 at 17 37 23" src="https://user-images.githubusercontent.com/4272331/56431791-5fffe600-62cb-11e9-8247-916cc99ac0fe.png">

Implementation:

<img width="1036" alt="Screenshot 2019-04-19 at 17 45 45" src="https://user-images.githubusercontent.com/4272331/56431792-5fffe600-62cb-11e9-84fa-a03c36ddc8da.png">
<img width="828" alt="Screenshot 2019-04-19 at 17 45 53" src="https://user-images.githubusercontent.com/4272331/56431793-5fffe600-62cb-11e9-8680-37eee108e520.png">
<img width="1073" alt="Screenshot 2019-04-19 at 17 46 08" src="https://user-images.githubusercontent.com/4272331/56431794-5fffe600-62cb-11e9-8a34-f8f14ec6e298.png">
<img width="557" alt="Screenshot 2019-04-19 at 17 46 29" src="https://user-images.githubusercontent.com/4272331/56431795-5fffe600-62cb-11e9-96e8-3610d2c1cb45.png">
