### PR TITLE
Fix unstyled links

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "143.4.0",
+  "version": "143.4.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -94,8 +94,8 @@ const Link = (props: LinkPropsType) => {
     'sg-text--link-unstyled': !underlined && unstyled,
     'sg-text--bold': emphasised,
     'sg-text--link-disabled': disabled,
-    [`sg-text--${String(color)}`]: color,
-    [`sg-text--${String(weight)}`]: weight !== LINK_WEIGHT.BOLD
+    [`sg-text--${String(color)}`]: color && !unstyled,
+    [`sg-text--${String(weight)}`]: weight
   }, className);
 
   if (!href) {

--- a/src/components/text/pages/text.jsx
+++ b/src/components/text/pages/text.jsx
@@ -130,7 +130,6 @@ const TextExamples = () => {
         >
           link / bold / mint / xlarge / underlined
         </Link>
-        <br />
       </DocsBlock>
       <DocsBlock info="Link color variants">
         {linkcolorVariant}

--- a/src/components/text/pages/text.jsx
+++ b/src/components/text/pages/text.jsx
@@ -131,13 +131,6 @@ const TextExamples = () => {
           link / bold / mint / xlarge / underlined
         </Link>
         <br />
-        <Link
-          href="#"
-          weight={LINK_WEIGHT.REGULAR}
-          unstyled
-        >
-          link / regular / default / normal / unstyled
-        </Link>
       </DocsBlock>
       <DocsBlock info="Link color variants">
         {linkcolorVariant}

--- a/src/components/text/pages/text.jsx
+++ b/src/components/text/pages/text.jsx
@@ -130,6 +130,14 @@ const TextExamples = () => {
         >
           link / bold / mint / xlarge / underlined
         </Link>
+        <br />
+        <Link
+          href="#"
+          weight={LINK_WEIGHT.REGULAR}
+          unstyled
+        >
+          link / regular / default / normal / unstyled
+        </Link>
       </DocsBlock>
       <DocsBlock info="Link color variants">
         {linkcolorVariant}


### PR DESCRIPTION
I need to fix links unstyled - It's for backward compatibility mainly - to not add default color class, as it breaks hover color. 
Also, a condition in weight is not needed.