### PR TITLE
Fix Zooming to Input and Select on Focus in iOS Devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "143.9.0",
+  "version": "143.9.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -1,7 +1,7 @@
 $selectHeight: rhythm(3 / 2);
 $selectBackground: $white;
 $selectTextColor: $grayPrimary;
-$selectFontSize: fontSize(small);
+$selectFontSize: 16px; // fix zooming to select on focus in iOS devices
 $selectIconSize: rhythm(1 / 3);
 $selectBorderRadius: 7px;
 $selectActiveBorderColor: $grayPrimary;

--- a/src/components/form-elements/_text-input.scss
+++ b/src/components/form-elements/_text-input.scss
@@ -4,7 +4,7 @@ $inputSmallHeight: rhythm(5 / 4);
 
 $inputBackground: $white;
 $inputTextColor: $black;
-$inputFontSize: fontSize(small);
+$inputFontSize: 16px; // fix zooming to input on focus in iOS devices
 $inputLargeFontSize: fontSize(standout);
 $inputPlaceholderTextColor: $graySecondary;
 $inputFocusValidBorderColor: $mintPrimaryDark;

--- a/src/components/form-elements/_text-input.scss
+++ b/src/components/form-elements/_text-input.scss
@@ -10,7 +10,7 @@ $inputPlaceholderTextColor: $graySecondary;
 $inputFocusValidBorderColor: $mintPrimaryDark;
 $inputFocusInvalidBorderColor: $peachPrimaryDark;
 $inputStandardBorderRadius: 9px;
-$inputPlaceholderFontSize: 14px;
+$inputPlaceholderFontSize: 16px;
 
 $inputSmallBorderRadius: 7px;
 $inputSmallPlaceholderFontSize: 12px;


### PR DESCRIPTION
The font size of inputs and selects should be equal or greater than `16px` for iOS to not zooming. We agreed with design to go with it for all inputs.