### PR TITLE
Introduce new buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "143.9.3",
+  "version": "144.0.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/buttons/ButtonPrimary.jsx
+++ b/src/components/buttons/ButtonPrimary.jsx
@@ -18,7 +18,6 @@ export const BUTTON_PRIMARY_TYPE = {
   INVERSE: 'inverse',
   ALT_INVERSE: 'alt-inverse',
   DARK_INVERSE: 'dark-inverse',
-  PEACH: 'peach',
   FB: 'fb'
 };
 

--- a/src/components/buttons/ButtonSecondary.jsx
+++ b/src/components/buttons/ButtonSecondary.jsx
@@ -19,7 +19,7 @@ export const BUTTON_SECONDARY_TYPE = {
   ALT_INVERSE: 'alt-inverse',
   DARK_INVERSE: 'dark-inverse',
   ACTIVE_INVERSE: 'active-inverse',
-  PEACH: 'peach'
+  ACTIVE_MUSTRAD: 'active-mustard'
 };
 
 type ButtonSecondaryPropsType = {

--- a/src/components/buttons/ButtonSecondary.jsx
+++ b/src/components/buttons/ButtonSecondary.jsx
@@ -19,7 +19,7 @@ export const BUTTON_SECONDARY_TYPE = {
   ALT_INVERSE: 'alt-inverse',
   DARK_INVERSE: 'dark-inverse',
   ACTIVE_INVERSE: 'active-inverse',
-  ACTIVE_MUSTRAD: 'active-mustard'
+  ACTIVE_MUSTARD: 'active-mustard'
 };
 
 type ButtonSecondaryPropsType = {

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -76,7 +76,10 @@ $buttonPrimaryFbHoverColor: #4367a9;
   &--alt {
     background-color: $buttonAltColor;
 
-    &:hover {
+    &:hover,
+    &:focus,
+    &:active,
+    &:active:focus {
       background-color: mix($bluePrimaryDark, $buttonAltColor, 80%);
       border-color: mix($bluePrimaryDark, $buttonAltColor, 80%);
     }
@@ -95,7 +98,10 @@ $buttonPrimaryFbHoverColor: #4367a9;
   &--dark {
     background-color: $buttonDarkColor;
 
-    &:hover {
+    &:hover,
+    &:focus,
+    &:active,
+    &:active:focus {
       background-color: mix($grayPrimary, $buttonDarkColor, 80%);
       border-color: mix($grayPrimary, $buttonDarkColor, 80%);
     }
@@ -119,8 +125,9 @@ $buttonPrimaryFbHoverColor: #4367a9;
     background: none;
 
     &:hover,
+    &:focus,
     &:active,
-    &:focus {
+    &:active:focus {
       background-color: mix($black, $transparentWhite, 12%);
       border-color: $black;
     }
@@ -143,8 +150,9 @@ $buttonPrimaryFbHoverColor: #4367a9;
     border: 2px solid $white;
 
     &:hover,
+    &:focus,
     &:active,
-    &:focus {
+    &:active:focus {
       background-color: mix($graySecondaryUltraLight, $white, 80%);
       border-color: mix($graySecondaryUltraLight, $white, 80%);
     }
@@ -191,8 +199,9 @@ $buttonPrimaryFbHoverColor: #4367a9;
     }
 
     &:hover,
+    &:focus,
     &:active,
-    &:focus {
+    &:active:focus {
       border: none;
     }
   }
@@ -202,8 +211,9 @@ $buttonPrimaryFbHoverColor: #4367a9;
     color: $mustardPrimary;
 
     &:hover,
+    &:focus,
     &:active,
-    &:focus {
+    &:active:focus {
       background-color: mix($mustardPrimary, $transparentWhite, 12%);
       color: $mustardPrimary;
       fill: $mustardPrimary;
@@ -225,8 +235,9 @@ $buttonPrimaryFbHoverColor: #4367a9;
     color: $peachPrimary;
 
     &:hover,
+    &:focus,
     &:active,
-    &:focus {
+    &:active:focus {
       background-color: mix($peachPrimary, $transparentWhite, 12%);
       color: $peachPrimary;
       fill: $peachPrimary;

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -25,7 +25,6 @@ $buttonPrimaryFbHoverColor: #4367a9;
   white-space: nowrap;
   font-weight: $fontWeightBold;
   text-transform: uppercase;
-  box-shadow: none;
   transition-property: background-color, border-color;
   transition-duration: 0.3s;
   transition-timing-function: ease-in-out;

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -2,20 +2,10 @@ $buttonFontColor: $white;
 $buttonColor: $mintPrimary;
 $buttonAltColor: $bluePrimary;
 $buttonDarkColor: $black;
-$buttonInverseColor: $white;
-$buttonPeach: $peachPrimary;
-
-$buttonInverseFontColor: $mintPrimaryDark;
-$buttonInverseAltFontColor: $bluePrimaryDark;
-$buttonInverseDarkFontColor: $grayPrimary;
 
 $buttonActiveInverseColor: $white;
 $buttonActiveInverseFontColor: $peachPrimary;
-$buttonActiveInverseInteractionColor: $peachPrimary;
-$buttonActiveInverseInteractionFontColor: $white;
 
-$buttonBoxShadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
-$buttonActiveBoxShadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
 $buttonActiveScale: scale(0.985);
 $transparentWhite: rgba(255, 255, 255, 0);
 $buttonPrimaryFbColor: #3c5b96;

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -254,8 +254,19 @@ $buttonPrimaryFbHoverColor: #4367a9;
     padding: 0 $buttonPrimaryPadding 0 ($buttonPrimaryPadding / 2);
     background-color: $buttonPrimaryFbColor;
 
-    &:hover {
+    &:hover,
+    &:focus,
+    &:active,
+    &:active:focus {
       background-color: $buttonPrimaryFbHoverColor;
+    }
+
+    &.sg-button-secondary--disabled {
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: $buttonPrimaryFbColor;
+      }
     }
   }
 

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -17,6 +17,7 @@ $buttonActiveInverseInteractionFontColor: $white;
 $buttonBoxShadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
 $buttonActiveBoxShadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
 $buttonActiveScale: scale(0.985);
+$transparentWhite: rgba(255, 255, 255, 0);
 $buttonPrimaryFbColor: #3c5b96;
 $buttonPrimaryFbHoverColor: #4367a9;
 

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -1,7 +1,7 @@
 $buttonFontColor: $white;
 $buttonColor: $mintPrimary;
 $buttonAltColor: $bluePrimary;
-$buttonDarkColor: $grayPrimary;
+$buttonDarkColor: $black;
 $buttonInverseColor: $white;
 $buttonPeach: $peachPrimary;
 
@@ -32,37 +32,11 @@ $buttonActiveScale: scale(0.985);
   white-space: nowrap;
   font-weight: $fontWeightBold;
   text-transform: uppercase;
-  box-shadow: $componentShadow;
-  transition-property: box-shadow, transform, opacity;
+  box-shadow: none;
+  transition-property: background-color, border-color;
   transition-duration: 0.3s;
-
-  // hack for proper text centering on Safari related to inline-flex issue with <button> tag
-  &::before,
-  &::after {
-    content: '';
-    flex: 1 0 auto;
-  }
-
-  &:hover,
-  &:focus {
-    box-shadow: $elevatedComponentShadow;
-  }
-
-  &:active {
-    box-shadow: $componentShadow;
-    transform: $buttonActiveScale;
-  }
-
-  &:active:focus {
-    box-shadow: $buttonActiveBoxShadow;
-  }
-
-  &:active,
-  &:focus,
-  &:hover {
-    text-decoration: none;
-  }
-
+  transition-timing-function: ease-in-out;
+  
   &__container {
     display: flex;
     align-items: center;
@@ -73,44 +47,163 @@ $buttonActiveScale: scale(0.985);
     width: 100%;
   }
 
+  &:focus {
+    outline: none;
+  }
+
+  &:hover,
+  &:focus,
+  &:active,
+  &:active:focus {
+    box-shadow: none;
+    text-decoration: none;
+  }
+
+  &:hover {
+    background-color: mix($mintPrimaryDark, $mintPrimary, 80%);
+    border-color: mix($mintPrimaryDark, $mintPrimary, 80%);
+  }
+
+  &.sg-button-primary--disabled {
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: $mintPrimary;
+      border-color: $mintPrimary;
+    }
+  }
+
   &--alt {
     background-color: $buttonAltColor;
+
+    &:hover {
+      background-color: mix($bluePrimaryDark, $buttonAltColor, 80%);
+      border-color: mix($bluePrimaryDark, $buttonAltColor, 80%);
+    }
+
+    &.sg-button-primary--disabled {
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: $buttonAltColor;
+        border-color: $buttonAltColor;
+      }
+    }
   }
 
   &--dark {
     background-color: $buttonDarkColor;
+
+    &:hover {
+      background-color: mix($grayPrimary, $buttonDarkColor, 80%);
+      border-color: mix($grayPrimary, $buttonDarkColor, 80%);
+    }
+
+    &.sg-button-primary--disabled {
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: $buttonDarkColor;
+        border-color: $buttonDarkColor;
+      }
+    }
   }
 
-  &--inverse {
-    background-color: $buttonInverseColor;
-    color: $buttonInverseFontColor;
-    fill: $buttonInverseFontColor;
-  }
-
+  &--inverse,
   &--alt-inverse {
-    background-color: $buttonInverseColor;
-    color: $buttonInverseAltFontColor;
-    fill: $buttonInverseAltFontColor;
-  }
-
-  &--dark-inverse {
-    background-color: $buttonInverseColor;
-    color: $buttonInverseDarkFontColor;
-    fill: $buttonInverseDarkFontColor;
-  }
-
-  &--active-inverse {
-    background-color: $buttonActiveInverseColor;
-    color: $buttonActiveInverseFontColor;
-    fill: $buttonActiveInverseFontColor;
-    transition-property: box-shadow, transform, background-color, color, fill, opacity;
+    border: 2px solid;
+    border-color: $black;
+    color: $black;
+    background: none;
 
     &:hover,
     &:active,
     &:focus {
-      background-color: $buttonActiveInverseInteractionColor;
-      color: $buttonActiveInverseInteractionFontColor;
-      fill: $buttonActiveInverseInteractionFontColor;
+      background-color: mix($black, $transparentWhite, 12%);
+      border-color: $black;
+    }
+  }
+
+  &--dark-inverse {
+    background-color: $white;
+    color: $black;
+    border: 2px solid $white;
+
+    &:hover {
+      background-color: mix($graySecondaryUltraLight, $white, 80%);
+      border-color: mix($graySecondaryUltraLight, $white, 80%);
+    }
+  }
+
+  // thank you button and mark as best
+  &--active-inverse,
+  &--active-mustard {
+    background-color: $white;
+    border: none;
+    height: 40px;
+    font-size: 15px;
+    line-height: 15px;
+    border-radius: 20px;
+
+    .sg-label__text,
+    .sg-label__number {
+      font-size: 15px;
+      cursor: pointer;
+    }
+
+    .sg-label .sg-label__icon {
+      margin-right: spacing(xs);
+      width: 24px;
+      height: 24px;
+    }
+
+    .sg-icon {
+      width: 24px;
+      height: 24px;
+      max-width: 24px;
+      max-height: 24px;
+    }
+
+    &:hover,
+    &:active,
+    &:focus {
+      border: none;
+    }
+  }
+
+  // mark as best answer
+  &--active-mustard {
+    color: $mustardPrimary;
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: mix($mustardPrimary, $transparentWhite, 12%);
+      color: $mustardPrimary;
+      fill: $mustardPrimary;
+    }
+
+    &.sg-button-secondary--disabled {
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: $buttonActiveInverseColor;
+        color: $mustardPrimary;
+        fill: $mustardPrimary;
+      }
+    }
+  }
+
+  // thank you button
+  &--active-inverse {
+    color: $peachPrimary;
+
+    &:hover,
+    &:active,
+    &:focus {
+      background-color: mix($peachPrimary, $transparentWhite, 12%);
+      color: $peachPrimary;
+      fill: $peachPrimary;
     }
 
     &.sg-button-secondary--disabled {
@@ -124,33 +217,18 @@ $buttonActiveScale: scale(0.985);
     }
   }
 
-  & .sg-label__text {
+  &.sg-label__text {
     cursor: pointer;
+    display: flex;
+    align-items: center;
   }
 
   &--disabled {
     opacity: 0.45;
     cursor: default;
-    box-shadow: $buttonBoxShadow;
-
-    &:active {
-      transform: none;
-    }
-
-    &:active,
-    &:focus,
-    &:hover {
-      box-shadow: $buttonBoxShadow;
-    }
 
     & .sg-label__text {
       cursor: default;
     }
-  }
-
-  &--peach {
-    background-color: $buttonPeach;
-    color: $buttonActiveInverseInteractionFontColor;
-    fill: $buttonActiveInverseInteractionFontColor;
   }
 }

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -17,6 +17,8 @@ $buttonActiveInverseInteractionFontColor: $white;
 $buttonBoxShadow: 0 1px 4px 0 rgba(0, 0, 0, 0.2);
 $buttonActiveBoxShadow: 0 1px 3px 0 rgba(0, 0, 0, 0.2);
 $buttonActiveScale: scale(0.985);
+$buttonPrimaryFbColor: #3c5b96;
+$buttonPrimaryFbHoverColor: #4367a9;
 
 @mixin sgButtonBasics() {
   display: inline-flex;
@@ -36,7 +38,7 @@ $buttonActiveScale: scale(0.985);
   transition-property: background-color, border-color;
   transition-duration: 0.3s;
   transition-timing-function: ease-in-out;
-  
+
   &__container {
     display: flex;
     align-items: center;
@@ -57,14 +59,12 @@ $buttonActiveScale: scale(0.985);
   &:active:focus {
     box-shadow: none;
     text-decoration: none;
-  }
-
-  &:hover {
     background-color: mix($mintPrimaryDark, $mintPrimary, 80%);
     border-color: mix($mintPrimaryDark, $mintPrimary, 80%);
   }
 
-  &.sg-button-primary--disabled {
+  &.sg-button-primary--disabled,
+  &.sg-button-secondary--disabled {
     &:hover,
     &:active,
     &:focus {
@@ -81,7 +81,8 @@ $buttonActiveScale: scale(0.985);
       border-color: mix($bluePrimaryDark, $buttonAltColor, 80%);
     }
 
-    &.sg-button-primary--disabled {
+    &.sg-button-primary--disabled,
+    &.sg-button-secondary--disabled {
       &:hover,
       &:active,
       &:focus {
@@ -99,7 +100,8 @@ $buttonActiveScale: scale(0.985);
       border-color: mix($grayPrimary, $buttonDarkColor, 80%);
     }
 
-    &.sg-button-primary--disabled {
+    &.sg-button-primary--disabled,
+    &.sg-button-secondary--disabled {
       &:hover,
       &:active,
       &:focus {
@@ -122,6 +124,17 @@ $buttonActiveScale: scale(0.985);
       background-color: mix($black, $transparentWhite, 12%);
       border-color: $black;
     }
+
+    &.sg-button-primary--disabled,
+    &.sg-button-secondary--disabled {
+      &:hover,
+      &:active,
+      &:focus {
+        border-color: $black;
+        color: $black;
+        background: none;
+      }
+    }
   }
 
   &--dark-inverse {
@@ -129,9 +142,22 @@ $buttonActiveScale: scale(0.985);
     color: $black;
     border: 2px solid $white;
 
-    &:hover {
+    &:hover,
+    &:active,
+    &:focus {
       background-color: mix($graySecondaryUltraLight, $white, 80%);
       border-color: mix($graySecondaryUltraLight, $white, 80%);
+    }
+
+    &.sg-button-primary--disabled,
+    &.sg-button-secondary--disabled {
+      &:hover,
+      &:active,
+      &:focus {
+        background-color: $white;
+        color: $black;
+        border: 2px solid $white;
+      }
     }
   }
 
@@ -221,6 +247,15 @@ $buttonActiveScale: scale(0.985);
     cursor: pointer;
     display: flex;
     align-items: center;
+  }
+
+  &--fb {
+    padding: 0 $buttonPrimaryPadding 0 ($buttonPrimaryPadding / 2);
+    background-color: $buttonPrimaryFbColor;
+
+    &:hover {
+      background-color: $buttonPrimaryFbHoverColor;
+    }
   }
 
   &--disabled {

--- a/src/components/buttons/_buttons_primary.scss
+++ b/src/components/buttons/_buttons_primary.scss
@@ -2,8 +2,6 @@ $buttonPrimaryHeight: 40px;
 $buttonPrimaryFontSize: 15px;
 $buttonPrimaryBorderRadius: 20px;
 $buttonPrimaryPadding: gutter(1);
-$buttonPrimaryFbColor: #3c5b96;
-$buttonPrimaryFbHoverColor: #4367a9;
 
 $includeHtml: false !default;
 
@@ -24,5 +22,6 @@ $includeHtml: false !default;
       display: inline-flex;
       margin-right: $buttonPrimaryPadding / 2;
     }
+
   }
 }

--- a/src/components/buttons/_buttons_primary.scss
+++ b/src/components/buttons/_buttons_primary.scss
@@ -1,8 +1,9 @@
-$buttonPrimaryHeight: rhythm(3 / 2);
-$buttonPrimaryFontSize: fontSize(default);
-$buttonPrimaryBorderRadius: 9px;
+$buttonPrimaryHeight: 40px;
+$buttonPrimaryFontSize: 15px;
+$buttonPrimaryBorderRadius: 20px;
 $buttonPrimaryPadding: gutter(1);
-$buttonPrimaryFbColor: #3b5998;
+$buttonPrimaryFbColor: #3c5b96;
+$buttonPrimaryFbHoverColor: #4367a9;
 
 $includeHtml: false !default;
 
@@ -14,14 +15,10 @@ $includeHtml: false !default;
     height: $buttonPrimaryHeight;
     padding: 0 $buttonPrimaryPadding;
     font-size: $buttonPrimaryFontSize;
+    line-height: $buttonPrimaryFontSize;
     color: $buttonFontColor;
     fill: $buttonFontColor;
     background-color: $buttonColor;
-
-    &--fb {
-      padding: 0 $buttonPrimaryPadding 0 ($buttonPrimaryPadding / 2);
-      background-color: $buttonPrimaryFbColor;
-    }
 
     &__icon {
       display: inline-flex;

--- a/src/components/buttons/_buttons_primary.scss
+++ b/src/components/buttons/_buttons_primary.scss
@@ -1,7 +1,7 @@
 $buttonPrimaryHeight: 40px;
 $buttonPrimaryFontSize: 15px;
 $buttonPrimaryBorderRadius: 20px;
-$buttonPrimaryPadding: gutter(1);
+$buttonPrimaryPadding: spacing(m);
 
 $includeHtml: false !default;
 

--- a/src/components/buttons/_buttons_secondary.scss
+++ b/src/components/buttons/_buttons_secondary.scss
@@ -3,11 +3,6 @@ $buttonSecondaryFontSize: 12px;
 $buttonSecondaryBorderRadius: 16px;
 $buttonSecondaryPadding: gutter(3 / 4);
 
-$buttonSecondarySmallHeight: rhythm(1);
-$buttonSecondarySmallFontSize: fontSize(obscure);
-$buttonSecondarySmallBorderRadius: 5px;
-$buttonSecondarySmallPadding: 14px;
-
 $includeHtml: false !default;
 
 @if ($includeHtml) {

--- a/src/components/buttons/_buttons_secondary.scss
+++ b/src/components/buttons/_buttons_secondary.scss
@@ -1,6 +1,6 @@
-$buttonSecondaryHeight: rhythm(5 / 4);
-$buttonSecondaryFontSize: fontSize(small);
-$buttonSecondaryBorderRadius: 7px;
+$buttonSecondaryHeight: 32px;
+$buttonSecondaryFontSize: 12px;
+$buttonSecondaryBorderRadius: 16px;
 $buttonSecondaryPadding: gutter(3 / 4);
 
 $buttonSecondarySmallHeight: rhythm(1);
@@ -11,8 +11,10 @@ $buttonSecondarySmallPadding: 14px;
 $includeHtml: false !default;
 
 @if ($includeHtml) {
-  .sg-button-secondary {
+  .sg-button-secondary,
+  .sg-button-secondary--small {
     @include sgButtonBasics();
+    line-height: $buttonSecondaryFontSize;
     border-radius: $buttonSecondaryBorderRadius;
     height: $buttonSecondaryHeight;
     padding: 0 $buttonSecondaryPadding;
@@ -20,12 +22,5 @@ $includeHtml: false !default;
     color: $buttonFontColor;
     fill: $buttonFontColor;
     background-color: $buttonColor;
-
-    &--small {
-      padding: 0 $buttonSecondarySmallPadding;
-      height: $buttonSecondarySmallHeight;
-      border-radius: $buttonSecondarySmallBorderRadius;
-      font-size: $buttonSecondarySmallFontSize;
-    }
   }
 }

--- a/src/components/buttons/_buttons_secondary.scss
+++ b/src/components/buttons/_buttons_secondary.scss
@@ -1,7 +1,7 @@
 $buttonSecondaryHeight: 32px;
 $buttonSecondaryFontSize: 12px;
 $buttonSecondaryBorderRadius: 16px;
-$buttonSecondaryPadding: gutter(3 / 4);
+$buttonSecondaryPadding: 20px;
 
 $includeHtml: false !default;
 

--- a/src/components/buttons/pages/buttons-interactive.jsx
+++ b/src/components/buttons/pages/buttons-interactive.jsx
@@ -52,10 +52,6 @@ const Buttons = () => {
       values: BUTTON_SECONDARY_TYPE
     },
     {
-      name: 'small',
-      values: Boolean
-    },
-    {
       name: 'wide',
       values: Boolean
     },
@@ -73,8 +69,13 @@ const Buttons = () => {
     <div>
       <DocsActiveBlock settings={primarySettings}>
         <ButtonPrimary>
-          Add your answer
+          Add your answer primary
         </ButtonPrimary>
+      </DocsActiveBlock>
+      <DocsActiveBlock settings={secondarySettings}>
+        <ButtonSecondary>
+          Add your answer secondary
+        </ButtonSecondary>
       </DocsActiveBlock>
       <DocsActiveBlock settings={primarySettings}>
         <ButtonPrimary
@@ -91,34 +92,6 @@ const Buttons = () => {
         </ButtonRound>
       </DocsActiveBlock>
 
-      <DocsActiveBlock settings={secondarySettings}>
-        <ButtonSecondary>
-          <Icon type={ICON_TYPES.SEARCH} color={ICON_COLOR.ADAPTIVE} size={14} />
-        </ButtonSecondary>
-      </DocsActiveBlock>
-      <DocsActiveBlock settings={secondarySettings} backgroundColor="dark">
-        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.INVERSE} small>
-          <Label
-            text="Comment"
-            number={21}
-            iconType={ICON_TYPE.COMMENT}
-            iconColor={ICON_COLOR.LAVENDER}
-            secondary
-          />
-        </ButtonSecondary>
-      </DocsActiveBlock>
-      <DocsActiveBlock settings={secondarySettings} backgroundColor="dark">
-        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_INVERSE} small>
-          <Label
-            text="Thank you"
-            number={331}
-            iconType={ICON_TYPE.HEART}
-            iconColor={ICON_COLOR.ADAPTIVE}
-            secondary
-            unstyled
-          />
-        </ButtonSecondary>
-      </DocsActiveBlock>
     </div>
   );
 };

--- a/src/components/buttons/pages/buttons-interactive.jsx
+++ b/src/components/buttons/pages/buttons-interactive.jsx
@@ -3,7 +3,6 @@ import ButtonPrimary, {BUTTON_PRIMARY_TYPE} from '../ButtonPrimary';
 import ButtonSecondary, {BUTTON_SECONDARY_TYPE} from '../ButtonSecondary';
 import ButtonRound from '../ButtonRound';
 import Icon, {TYPE as ICON_TYPES, ICON_COLOR} from 'icons/Icon';
-import Label, {ICON_TYPE} from 'labels/Label';
 import DocsActiveBlock from 'components/DocsActiveBlock';
 
 const Buttons = () => {

--- a/src/components/buttons/pages/buttons.jsx
+++ b/src/components/buttons/pages/buttons.jsx
@@ -14,25 +14,32 @@ const Buttons = () => (
         Add your answer
       </ButtonPrimary>
       &nbsp;
-      <ButtonPrimary buttonType={BUTTON_PRIMARY_TYPE.ALT}>
-        Search
-      </ButtonPrimary>
-      &nbsp;
-      <ButtonPrimary buttonType={BUTTON_PRIMARY_TYPE.DARK}>
-        Search
-      </ButtonPrimary>
-      &nbsp;
-      <ButtonPrimary buttonType={BUTTON_PRIMARY_TYPE.PEACH}>
-        reject
-      </ButtonPrimary>
-      &nbsp;
       <ButtonPrimary disabled>
-        Disabled
+        Add your answer disabled
       </ButtonPrimary>
-
+      &nbsp;
       <br />
       <br />
-
+      <ButtonPrimary buttonType={BUTTON_PRIMARY_TYPE.ALT}>
+        Ask your question
+      </ButtonPrimary>
+      &nbsp;
+      <ButtonPrimary disabled buttonType={BUTTON_PRIMARY_TYPE.ALT}>
+        Ask your question disabled
+      </ButtonPrimary>
+      &nbsp;
+      <br />
+      <br />
+      <ButtonPrimary buttonType={BUTTON_PRIMARY_TYPE.DARK}>
+        join now
+      </ButtonPrimary>
+      &nbsp;
+      <ButtonPrimary disabled buttonType={BUTTON_PRIMARY_TYPE.DARK}>
+        Join now disabled
+      </ButtonPrimary>
+      &nbsp;
+      <br />
+      <br />
       <ButtonPrimary
         icon={<Icon type={iconTypes.FB} color={ICON_COLOR.ADAPTIVE} size={16} />}
         buttonType={BUTTON_PRIMARY_TYPE.FB}
@@ -42,7 +49,9 @@ const Buttons = () => (
     </DocsBlock>
 
     <DocsBlock info="Primary buttons wide">
-      <ButtonPrimary wide>Search</ButtonPrimary>
+      <ButtonPrimary wide>Primary wide</ButtonPrimary>
+      &nbsp;
+      <ButtonPrimary wide disabled>Primary wide disabled</ButtonPrimary>
     </DocsBlock>
 
     <DocsBlock info="Primary buttons inverted">
@@ -51,16 +60,18 @@ const Buttons = () => (
           Add your answer
         </ButtonPrimary>
         &nbsp;
-        <ButtonPrimary buttonType={BUTTON_PRIMARY_TYPE.ALT_INVERSE}>
-          Ask your question
+        <ButtonPrimary disabled buttonType={BUTTON_PRIMARY_TYPE.INVERSE}>
+          Add your answer disabled
         </ButtonPrimary>
         &nbsp;
+        <br />
+        <br />
         <ButtonPrimary buttonType={BUTTON_PRIMARY_TYPE.DARK_INVERSE}>
           Search
         </ButtonPrimary>
         &nbsp;
-        <ButtonPrimary disabled buttonType={BUTTON_PRIMARY_TYPE.INVERSE}>
-          Disabled
+        <ButtonPrimary buttonType={BUTTON_PRIMARY_TYPE.DARK_INVERSE} disabled>
+          Search
         </ButtonPrimary>
       </ContrastBox>
     </DocsBlock>
@@ -76,30 +87,44 @@ const Buttons = () => (
         <Icon type={iconTypes.SEARCH} color={ICON_COLOR.ADAPTIVE} size={14} />
       </ButtonSecondary>
       &nbsp;
+      <br />
+      <br />
       <ButtonSecondary>
-        Search
-      </ButtonSecondary>
-      &nbsp;
-      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ALT}>
-        Search
-      </ButtonSecondary>
-      &nbsp;
-      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.DARK}>
-        Search
-      </ButtonSecondary>
-      &nbsp;
-      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.PEACH}>
-        reject
+        Add your answer
       </ButtonSecondary>
       &nbsp;
       <ButtonSecondary disabled>
-        Disabled
+        Add your answer
       </ButtonSecondary>
-
+      &nbsp;
+      <br />
+      <br />
+      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ALT}>
+        Ask your question
+      </ButtonSecondary>
+      &nbsp;
+      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ALT} disabled>
+        Ask your question
+      </ButtonSecondary>
+      &nbsp;
+      <br />
+      <br />
+      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.DARK}>
+        Log in
+      </ButtonSecondary>
+      &nbsp;
+      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.DARK} disabled>
+        Log in
+      </ButtonSecondary>
+      &nbsp;
+      <br />
+      <br />
     </DocsBlock>
 
     <DocsBlock info="Secondary buttons wide">
       <ButtonSecondary wide>Search</ButtonSecondary>
+      &nbsp;
+      <ButtonSecondary wide disabled>Search disabled</ButtonSecondary>
     </DocsBlock>
 
     <DocsBlock info="Secondary buttons inverted">
@@ -108,110 +133,67 @@ const Buttons = () => (
           <Icon type={iconTypes.SEARCH} color={ICON_COLOR.ADAPTIVE} size={14} />
         </ButtonSecondary>
         &nbsp;
+        <br />
+        <br />
         <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.INVERSE}>
-          Search
+          Answer
         </ButtonSecondary>
         &nbsp;
-        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ALT_INVERSE}>
-          Search
+        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.INVERSE} disabled>
+          Answer
         </ButtonSecondary>
         &nbsp;
+        <br />
+        <br />
         <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.DARK_INVERSE}>
-          Search
+          Log in
         </ButtonSecondary>
         &nbsp;
-        <ButtonSecondary disabled buttonType={BUTTON_SECONDARY_TYPE.INVERSE}>
-          Disabled
+        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.DARK_INVERSE} disabled>
+          Log in
         </ButtonSecondary>
+        &nbsp;
       </ContrastBox>
     </DocsBlock>
 
-    <DocsBlock info="Secondary buttons small">
-      <ButtonSecondary small>
-        <Icon type={iconTypes.SEARCH} color={ICON_COLOR.ADAPTIVE} size={14} />
-      </ButtonSecondary>
-      &nbsp;
-      <ButtonSecondary small>
-        Search
-      </ButtonSecondary>
-      &nbsp;
-      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ALT} small>
-        Search
-      </ButtonSecondary>
-      &nbsp;
-      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.DARK} small>
-        Search
-      </ButtonSecondary>
-      &nbsp;
-      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.PEACH} small>
-        reject
-      </ButtonSecondary>
-      &nbsp;
-      <ButtonSecondary disabled small>
-        Disabled
-      </ButtonSecondary>
-    </DocsBlock>
-
-    <DocsBlock info="Secondary buttons inverted small">
-      <ContrastBox>
-        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.INVERSE} small>
-          Search
-        </ButtonSecondary>
-        &nbsp;
-        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ALT_INVERSE} small>
-          Search
-        </ButtonSecondary>
-        &nbsp;
-        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.DARK_INVERSE} small>
-          Search
-        </ButtonSecondary>
-        &nbsp;
-        <ButtonSecondary disabled type={BUTTON_SECONDARY_TYPE.INVERSE} small>
-          Disabled
-        </ButtonSecondary>
-
-        <br /><br />
-
-        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.INVERSE} small>
-          <Label
-            text="Comment"
-            number={21}
-            iconType={ICON_TYPE.COMMENT}
-            iconColor={ICON_COLOR.LAVENDER}
-            secondary
-          />
-        </ButtonSecondary>
-        &nbsp;
-        <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.INVERSE} small>
-          <Label
-            text="Mark as brainliest"
-            iconType={ICON_TYPE.EXCELLENT}
-            iconColor={ICON_COLOR.MUSTARD}
-            secondary
-          />
-        </ButtonSecondary>
-
-      </ContrastBox>
-    </DocsBlock>
-
-    <DocsBlock info="Secondary buttons small active and inverted">
-      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_INVERSE} small>
+    <DocsBlock info="Custom buttons with icons examples">
+      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_INVERSE}>
         <Label
           text="Thank you"
-          number={21}
+          number={24}
           iconType={ICON_TYPE.HEART}
-          iconColor={ICON_COLOR.ADAPTIVE}
+          iconColor={ICON_COLOR.PEACH}
           secondary
           unstyled
         />
       </ButtonSecondary>
       &nbsp;
-      <ButtonSecondary disabled buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_INVERSE} small>
+      <ButtonSecondary disabled buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_INVERSE}>
         <Label
           text="Thank you"
-          number={21}
+          number={2}
           iconType={ICON_TYPE.HEART}
-          iconColor={ICON_COLOR.ADAPTIVE}
+          iconColor={ICON_COLOR.PEACH}
+          secondary
+          unstyled
+        />
+      </ButtonSecondary>
+      <br /><br />
+      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_MUSTRAD} small>
+        <Label
+          text="Mark as brainliest"
+          iconType={ICON_TYPE.EXCELLENT}
+          iconColor={ICON_COLOR.MUSTARD}
+          secondary
+          unstyled
+        />
+      </ButtonSecondary>
+      &nbsp;
+      <ButtonSecondary disabled buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_MUSTRAD} small>
+        <Label
+          text="Mark as brainliest"
+          iconType={ICON_TYPE.EXCELLENT}
+          iconColor={ICON_COLOR.MUSTARD}
           secondary
           unstyled
         />

--- a/src/components/buttons/pages/buttons.jsx
+++ b/src/components/buttons/pages/buttons.jsx
@@ -179,7 +179,7 @@ const Buttons = () => (
         />
       </ButtonSecondary>
       <br /><br />
-      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_MUSTRAD} small>
+      <ButtonSecondary buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_MUSTARD} small>
         <Label
           text="Mark as brainliest"
           iconType={ICON_TYPE.EXCELLENT}
@@ -189,7 +189,7 @@ const Buttons = () => (
         />
       </ButtonSecondary>
       &nbsp;
-      <ButtonSecondary disabled buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_MUSTRAD} small>
+      <ButtonSecondary disabled buttonType={BUTTON_SECONDARY_TYPE.ACTIVE_MUSTARD} small>
         <Label
           text="Mark as brainliest"
           iconType={ICON_TYPE.EXCELLENT}


### PR DESCRIPTION
Intorduction of the new buttons:

 - **Primary buttons** - they do not change at all in terms of colors, just adjustments of sizes (buttons are bigger form 36px to 40px) with no shadow, border radius and so on. Additionally, I removed all the peach buttons, as they are not used in any place in the application (neither in JSX or in twig):

BEFORE:
![Screenshot 2019-05-24 at 08 32 33](https://user-images.githubusercontent.com/4272331/58307346-ab437200-7dfe-11e9-97a2-9c56717bcd26.png)

AFTER:
<img width="1038" alt="Screenshot 2019-05-24 at 08 32 41" src="https://user-images.githubusercontent.com/4272331/58307347-ab437200-7dfe-11e9-8209-9810358c2222.png">

 - **Primary buttons inverted** - for this type of the buttons we have the biggest change. Buttons type `INVERSE` and `ALT_INVERSE` were merged into one in terms of the look, `DARK_INVERSE` changes it's styling:

BEFORE:
![Screenshot 2019-05-24 at 09 34 16](https://user-images.githubusercontent.com/4272331/58310548-26a92180-7e07-11e9-8d6d-f068b651a538.png)

AFTER:
<img width="813" alt="Screenshot 2019-05-24 at 09 34 26" src="https://user-images.githubusercontent.com/4272331/58310550-26a92180-7e07-11e9-94ca-0afd60a41240.png">

 - **Secondary and secondary small** - these buttons ware merged in terms of the size - they are both 32px now. Regarding styling changes, secondary buttons are exactly the same as the primary once:

BEFORE:
![Screenshot 2019-05-24 at 09 38 00](https://user-images.githubusercontent.com/4272331/58310787-c23a9200-7e07-11e9-9761-609d39f11e59.png)

AFTER:
<img width="1052" alt="Screenshot 2019-05-24 at 09 40 52" src="https://user-images.githubusercontent.com/4272331/58310913-0cbc0e80-7e08-11e9-90f3-650641db068c.png">

We have 2 additional cases where we use buttons secondary with icons: it's `THANK YOU` and `MARK AS BRAINLIEST` which I prepare as custom cases. the second one gets its own type, which makes it easier for me to replace it in the application.

BEFORE:
![Screenshot 2019-05-24 at 09 48 21](https://user-images.githubusercontent.com/4272331/58311370-1abe5f00-7e09-11e9-9bad-f7f6b5057ef8.png)

AFTER:
<img width="810" alt="Screenshot 2019-05-24 at 09 43 40" src="https://user-images.githubusercontent.com/4272331/58311094-7c31fe00-7e08-11e9-9c5c-66dc893d4895.png">

hover/active:
<img width="784" alt="Screenshot 2019-05-24 at 09 49 40" src="https://user-images.githubusercontent.com/4272331/58311460-522d0b80-7e09-11e9-80e6-f2d4b6aa07e7.png">

All of the above changes are temporary. The main goal here is to adjust current styles to the new styling of the buttons without changing too much on the application side. In the next step, I will introduce a new component `Button.jsx` (to rule them all), which would have final naming and separate styles. I will replace existing buttons with the new slowly.