### PR TITLE
Make basic icons sprite available as svg file

### DIFF
--- a/scripts/tasks/svgs-generate.js
+++ b/scripts/tasks/svgs-generate.js
@@ -86,6 +86,22 @@ module.exports = function(gulp, plugins, consts) {
       }
     };
 
+    const notTransformedIconsConfig = {
+      mode: {
+        symbol: {
+          sprite: '../icons.svg'
+        }
+      },
+      shape: {
+        id: {
+          generator: 'icon-%s'
+        },
+        transform: ['svgo', {
+          custom: svgSymbolCleanUp.bind(null, {removeClass: true})
+        }]
+      }
+    };
+
     const mathSymbolsConfig = {
       mode: {
         symbol: {
@@ -115,6 +131,10 @@ module.exports = function(gulp, plugins, consts) {
 
     gulp.src(mathSymbolsPath)
       .pipe(plugins.svgSprite(mathSymbolsConfig))
+      .pipe(gulp.dest(destPath));
+
+    gulp.src(iconsPath)
+      .pipe(plugins.svgSprite(notTransformedIconsConfig))
       .pipe(gulp.dest(destPath));
 
     return gulp.src(iconsPath)

--- a/src/docs/pages/index.jsx
+++ b/src/docs/pages/index.jsx
@@ -151,6 +151,11 @@ const index = () => (
       </a>.
     </p>
 
+    <input
+      type="hidden"
+      value="https://styleguide.brainly.com/%%images/icons.svg%%"
+    />
+
     <script dangerouslySetInnerHTML={{__html: 'hljs.initHighlightingOnLoad();'}} />
   </ArticlePage>
 );


### PR DESCRIPTION
in short: make svg sprite of basic icons available as a static svg file and test it.

it's not publicly available yet.

<img width="657" alt="Screenshot 2019-07-02 at 08 46 22" src="https://user-images.githubusercontent.com/1231144/60490429-ced3c500-9ca6-11e9-835d-d62fcae38e8d.png">

i'd like to add it and test how it could work with our client apps.

it's related to a research "how to include sg icons differently in our apps" and it allows to do sth like:
```
<svg class="sg-icon">
    <use href="STYLEGUIDE_PATH/icons.svg#icon-search"></use>
</svg>
```
pros:
- no need to inject svg sprite in JS
- nodes of all icons are not included in DOM
- svg sprite is cached

to support IE we'd need to use svg4everybody https://www.npmjs.com/package/svg4everybody