### PR TITLE
Add std-icons to exported icon type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "145.2.0",
+  "version": "145.2.1",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -256,7 +256,8 @@ export const TYPE = {
   UNSEEN: 'unseen', // not needed in new set
   VERIFIED: 'verified',
   X: 'x',
-  FB: 'fb'
+  FB: 'fb',
+  ...STD_TYPE
 };
 
 export const ICON_COLOR = {


### PR DESCRIPTION
to make it possible to use it i.e. in `Label`

```
import Label, {ICON_TYPE} from 'style-guide/src/components/labels/Label';

<Label
    iconType={ICON_TYPE.STD_HEART}
/>
```