### PR TITLE
Fix typo in icon name

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "145.2.1",
+  "version": "145.2.2",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -187,7 +187,7 @@ export const STD_TYPE = {
   STD_PENCIL: 'std-pencil',
   STD_PLAY: 'std-play', // new
   STD_PLUS: 'std-plus',
-  STD_PONITS: 'std-points',
+  STD_POINTS: 'std-points',
   STD_PROFILE: 'std-profile', // new
   STD_RECENT_QUESTIONS: 'std-recent_questions', // new
   STD_REPORT_FLAG: 'std-report_flag',


### PR DESCRIPTION
👁 `STD_PONITS` => `STD_POINTS`
 