### PR TITLE
Rollback: Add std-icons to exported icon type

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "145.2.2",
+  "version": "145.2.3",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -256,8 +256,7 @@ export const TYPE = {
   UNSEEN: 'unseen', // not needed in new set
   VERIFIED: 'verified',
   X: 'x',
-  FB: 'fb',
-  ...STD_TYPE
+  FB: 'fb'
 };
 
 export const ICON_COLOR = {


### PR DESCRIPTION
std-icons started being visible at deprecated icon list...
let's roll it back.

<img width="527" alt="Screenshot 2019-07-24 at 17 19 32" src="https://user-images.githubusercontent.com/1231144/61806077-58eef380-ae37-11e9-9d18-8483e1b7ddda.png">
