### PR TITLE
Update sizes and default icon of Avatar

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "145.2.3",
+  "version": "146.0.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/avatar/Avatar.jsx
+++ b/src/components/avatar/Avatar.jsx
@@ -21,17 +21,17 @@ export const SIZE = {
 export const ICON_SIZE_FOR_AVATARS_WITH_BORDER = {
   [SIZE.SMALL]: 22,
   [SIZE.NORMAL]: 30,
-  [SIZE.LARGE]: 46,
-  [SIZE.XLARGE]: 62,
-  [SIZE.XXLARGE]: 118
+  [SIZE.LARGE]: 54,
+  [SIZE.XLARGE]: 78,
+  [SIZE.XXLARGE]: 102
 };
 
 export const ICON_SIZE = {
   [SIZE.SMALL]: 24,
   [SIZE.NORMAL]: 32,
-  [SIZE.LARGE]: 48,
-  [SIZE.XLARGE]: 64,
-  [SIZE.XXLARGE]: 120
+  [SIZE.LARGE]: 56,
+  [SIZE.XLARGE]: 80,
+  [SIZE.XXLARGE]: 104
 };
 
 type PropsType = {
@@ -59,8 +59,8 @@ const Avatar = ({size = SIZE.NORMAL, border = false, spaced, imgSrc, className, 
     avatarContent = (
       <div className="sg-avatar__image sg-avatar__image--icon">
         <Icon
-          type="profile"
-          color="gray-secondary"
+          type="std-profile"
+          color="gray-light"
           size={border ? ICON_SIZE_FOR_AVATARS_WITH_BORDER[size] : ICON_SIZE[size]}
         />
       </div>

--- a/src/components/avatar/Avatar.spec.jsx
+++ b/src/components/avatar/Avatar.spec.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Avatar, {SIZE} from './Avatar';
-import Icon, {TYPE} from 'icons/Icon';
+import Icon from 'icons/Icon';
 
 import {shallow, mount} from 'enzyme';
 
@@ -39,11 +39,10 @@ test('no error when render without image', () => {
 });
 
 test('default icon profile', () => {
-  const iconType = TYPE.PROFILE;
   const avatar = mount(<Avatar />);
   const icoProps = avatar.find(Icon).props();
 
-  expect(icoProps.type).toEqual(iconType);
+  expect(icoProps.type).toEqual('std-profile');
 });
 
 test('SIZE', () => {

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -1,9 +1,9 @@
-$avatarDefaultBackgroundColor: $graySecondaryLight;
+$avatarDefaultBackgroundColor: $graySecondary;
 $avatarSmallSize: 24px;
 $avatarMediumSize: 32px;
-$avatarBigSize: 48px;
-$avatarXLargeSize: 64px;
-$avatarXXLargeSize: 120px;
+$avatarBigSize: 56px;
+$avatarXLargeSize: 80px;
+$avatarXXLargeSize: 104px;
 $avatarSpacedMargin: 4px;
 $avatarBorderWidth: 1px;
 $avatarBorderColor: $white;

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -130,8 +130,14 @@ export type IconColorType =
 export type IconSizeType =
   | 120
   | 118
+  | 104
+  | 102
+  | 80
+  | 78
   | 64
   | 62
+  | 56
+  | 54
   | 48
   | 46
   | 32
@@ -274,7 +280,7 @@ export const ICON_COLOR = {
 };
 
 // As soon as we change Avatars to new the new icon, we could clean up sizes of the icons.
-export const SIZE = [120, 118, 64, 62, 48, 46, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10];
+export const SIZE = [120, 118, 104, 102, 80, 78, 64, 62, 56, 54, 48, 46, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10];
 
 export type IconPropsType =
   | {

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -2,15 +2,21 @@
 
 $includeHtml: false !default;
 
-$iconSizes: 120, 118, 64, 62, 48, 46, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10;
+$iconSizes: 120, 118, 104, 102, 80, 78, 64, 62, 56, 54, 48, 46, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10;
 
 // Icon sizes :(
-// 120 - avatar xxxlarge
-// 118 - avatar xxxlarge with border
-// 64 - avatar xlarge
-// 62 - avatar xlarge with border
-// 48 - avatar large
-// 46 - avatar large with border
+// 120 - DEPRECATED
+// 118 - DEPRECATED
+// 104 - avatar xxxlarge
+// 102 - avatar xxxlarge with border
+// 80 - avatar xlarge
+// 78 - avatar xlarge with border
+// 64 - DEPRECATED
+// 62 - DEPRECATED
+// 56 - avatar large
+// 54 - avatar large with border
+// 48 - DEPRECATED
+// 46 - DEPRECATED
 // 32 - avatar default,
 // 30 - avatar default with border,
 // 26 - icon as button default,


### PR DESCRIPTION
**before**:

<img width="1118" alt="Screenshot 2019-07-25 at 10 54 52" src="https://user-images.githubusercontent.com/1231144/61861060-5d64ec00-aecb-11e9-95f5-86bcebaca8bf.png">

**after**:
<img width="1053" alt="Screenshot 2019-07-25 at 10 54 36" src="https://user-images.githubusercontent.com/1231144/61861057-5ccc5580-aecb-11e9-9d0f-ed19ac2e3fa0.png">


1. Sizes are updated according to:
<img width="466" alt="avatars" src="https://user-images.githubusercontent.com/1231144/61860900-0a8b3480-aecb-11e9-8520-caf3a2727cdc.png">

2. Default avatar icon (profile) was replaced with a one from a new set (std-profile).


Icon sizes are adjusted too to be aligned with new avatar sizes.
The deprecated sizes will be removed in a separated step.


