### PR TITLE
Add std-icons to exported icons type but do not present them in deprecated set

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "146.0.1",
+  "version": "146.0.2",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -262,7 +262,8 @@ export const TYPE = {
   UNSEEN: 'unseen', // not needed in new set
   VERIFIED: 'verified',
   X: 'x',
-  FB: 'fb'
+  FB: 'fb',
+  ...STD_TYPE
 };
 
 export const ICON_COLOR = {

--- a/src/components/icons/pages/icons.jsx
+++ b/src/components/icons/pages/icons.jsx
@@ -10,7 +10,7 @@ const icons = () => (
       <Text size="medium" color="peach-dark" weight="bold">This set of the icons is deprecated</Text>
       <ContrastBox>
         <ul className="icons-list">
-          {Object.values(TYPE).map(type => (
+          {Object.values(TYPE).filter(type => !type.includes('std')).map(type => (
             <li className="icons-list__element" key={type}>
               <Icon type={type} />
               <span>&nbsp; - {type}</span>


### PR DESCRIPTION
It's a second try after rolling back: https://github.com/brainly/style-guide/pull/1603
previously set of std-icons were visible in deprecated set of icons too.
now, there are no visual changes.

**Why this change?**
it's much easier to refactor and replace icons.

it makes it possible to use it i.e. in `Label`

```
import Label, {ICON_TYPE} from 'style-guide/src/components/labels/Label';

<Label
    iconType={ICON_TYPE.STD_HEART}
/>
```