### PR TITLE
Use std-close instead of x icon in TopLayer and Box

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "146.1.0",
+  "version": "146.2.0",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/box/Box.jsx
+++ b/src/components/box/Box.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import type {Node} from 'react';
 import classNames from 'classnames';
-import Icon, {TYPE as iconTypes, ICON_COLOR} from '../icons/Icon';
+import Icon, {ICON_COLOR} from '../icons/Icon';
 
 type ColorType =
   | 'blue'
@@ -227,7 +227,7 @@ const Box = ({color, padding, full, children, border = !color, imgSrc, noMinHeig
     <div {...props} className={boxClass}>
       {onClose ?
         <div className="sg-box__close" onClick={onClose}>
-          <Icon type={iconTypes.X} color={closeIconColor ? ICON_COLOR[closeIconColor] : ICON_COLOR.DARK} size={10} />
+          <Icon type="std-close" color={closeIconColor ? ICON_COLOR[closeIconColor] : ICON_COLOR.DARK} size={16} />
         </div> : null
       }
       {content}

--- a/src/components/box/pages/box.jsx
+++ b/src/components/box/pages/box.jsx
@@ -115,7 +115,7 @@ const Boxs = () => (
     />
 
     <DocsBlock info="Example of box usage">
-      <Box>
+      <Box onClose={closeCallback}>
         <ContentBox>
           <ContentBoxHeader>
             <Headline type={HEADLINE_TYPE.H3}>Ask a question about a school subject</Headline>

--- a/src/components/toplayer/TopLayer.jsx
+++ b/src/components/toplayer/TopLayer.jsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import type {Node} from 'react';
 import classnames from 'classnames';
-import Icon, {TYPE as iconTypes, ICON_COLOR} from '../icons/Icon';
+import Icon from '../icons/Icon';
 
 export type TopLayerSizeType =
   | 'small'

--- a/src/components/toplayer/TopLayer.jsx
+++ b/src/components/toplayer/TopLayer.jsx
@@ -72,7 +72,7 @@ const TopLayer = (props: PropsType) => {
     <div {...additionalProps} className={topLayerClassName}>
       {onClose ?
         <div className="sg-toplayer__close" onClick={onClose}>
-          <Icon type={iconTypes.X} color={ICON_COLOR.GRAY_SECONDARY} size={14} />
+          <Icon type="std-close" color="gray-secondary" size={24} />
         </div> : null
       }
       <div className={toplayerWrapperClassName}>

--- a/src/components/toplayer/pages/toplayer.jsx
+++ b/src/components/toplayer/pages/toplayer.jsx
@@ -12,6 +12,8 @@ import ListItem from 'list/ListItem';
 import ListItemIcon from 'list/ListItemIcon';
 import Icon, {ICON_COLOR, TYPE as ICON_TYPE} from 'icons/Icon';
 
+const closeCallback = () => undefined;
+
 const content = (
   <ContentBox>
     <ContentBoxContent spacedBottom={SPACING_SIZE.LARGE}>
@@ -68,7 +70,7 @@ const TopLayers = () => (
     </DocsBlock>
 
     <DocsBlock info="Example usage">
-      <TopLayer size={SIZE.MEDIUM} lead withBugbox>
+      <TopLayer size={SIZE.MEDIUM} lead withBugbox onClose={closeCallback}>
         <ContentBox>
           <ContentBoxContent spacedBottom={SPACING_SIZE.LARGE}>
             <Headline type={HEADLINE_TYPE.H2}>


### PR DESCRIPTION
before:
<img width="654" alt="Screenshot 2019-08-01 at 13 57 10" src="https://user-images.githubusercontent.com/1231144/62291965-8b1ad980-b465-11e9-9e17-97340cb04673.png">

<img width="765" alt="Screenshot 2019-08-01 at 14 09 09" src="https://user-images.githubusercontent.com/1231144/62292135-f5cc1500-b465-11e9-9990-fb955432b552.png">

after:

<img width="647" alt="Screenshot 2019-08-01 at 13 57 53" src="https://user-images.githubusercontent.com/1231144/62291966-8b1ad980-b465-11e9-9976-d411e7777926.png">

<img width="777" alt="Screenshot 2019-08-01 at 14 08 14" src="https://user-images.githubusercontent.com/1231144/62292108-e51b9f00-b465-11e9-8a8d-6905e8bf178f.png">




