### PR TITLE
Add option to display Icon in text in button

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "style-guide",
-  "version": "146.2.3",
+  "version": "146.2.4",
   "description": "Brainly Front-End Style Guide",
   "author": "Brainly",
   "private": true,

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -31,11 +31,10 @@
   cursor: pointer;
   box-sizing: border-box;
 
-  // Added to align text in the center,
-  // as soon as Proxima is fixed we could remove it.
   &__text {
     position: relative;
-    top: 1px;
+    display: flex;
+    align-items: center;
   }
 
   &__icon {
@@ -70,6 +69,12 @@
     padding: 0 20px;
     font-size: 12px;
     line-height: 12px;
+
+    // Proxima is broken
+    // Added to align text in the center for this font-size
+    .sg-button__text {
+      top: 1px;
+    }
   }
 
   &--disabled {

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -127,9 +127,7 @@ export type IconColorType =
   | 'navy-blue'
   | 'peach';
 
-export type IconTagType =
-  | 'div'
-  | 'span';
+export type IconTagType = 'div' | 'span';
 
 export type IconSizeType =
   | 120
@@ -286,7 +284,7 @@ export const ICON_COLOR = {
 
 export const ICON_TAG_TYPE = {
   DIV: 'div',
-  SPAN: 'span'
+  SPAN: 'span',
 };
 
 // As soon as we change Avatars to new the new icon, we could clean up sizes of the icons.
@@ -353,7 +351,7 @@ export type IconPropsType =
                     />
                   </Button>
       */
-      tagType?: IconTagType
+      tagType?: IconTagType,
     }
   | {
       /**
@@ -390,7 +388,7 @@ export type IconPropsType =
                     />
                   </Button>
       */
-      tagType?: IconTagType
+      tagType?: IconTagType,
     };
 
 const Icon = ({
@@ -418,7 +416,6 @@ const Icon = ({
   const Tag = tagType;
 
   return (
-
     <Tag {...props} className={iconClass}>
       {type ? (
         <svg className="sg-icon__svg">

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -127,6 +127,10 @@ export type IconColorType =
   | 'navy-blue'
   | 'peach';
 
+export type IconTagType =
+  | 'div'
+  | 'span';
+
 export type IconSizeType =
   | 120
   | 118
@@ -280,6 +284,11 @@ export const ICON_COLOR = {
   PEACH: 'peach',
 };
 
+export const ICON_TAG_TYPE = {
+  DIV: 'div',
+  SPAN: 'span'
+};
+
 // As soon as we change Avatars to new the new icon, we could clean up sizes of the icons.
 export const SIZE = [
   120,
@@ -330,6 +339,21 @@ export type IconPropsType =
        * @see type="std-heart" https://styleguide.brainly.com/latest/docs/interactive.html?type=std-heart#icons
        */
       type: IconTypeType,
+      /**
+      * Option to change tag to span, which allows correct HTML structure
+      * @example  <Button
+                    type="secondary"
+                  >
+                    Get +50
+                    <Icon
+                      type={iconTypes.POINTS}
+                      color="dark"
+                      size={16}
+                      tagType="span"
+                    />
+                  </Button>
+      */
+      tagType?: IconTagType
     }
   | {
       /**
@@ -352,6 +376,21 @@ export type IconPropsType =
        * @see size="46" https://styleguide.brainly.com/latest/docs/interactive.html?size=46#icons
        */
       size?: ?IconSizeType,
+      /**
+      * Option to change tag to span, which allows correct HTML structure
+      * @example  <Button
+                    type="secondary"
+                  >
+                    Get +50
+                    <Icon
+                      type={iconTypes.POINTS}
+                      color="dark"
+                      size={16}
+                      tagType="span"
+                    />
+                  </Button>
+      */
+      tagType?: IconTagType
     };
 
 const Icon = ({
@@ -362,6 +401,7 @@ const Icon = ({
   type,
   // $FlowFixMe flow doesn't support refinements for non-exact types, but we can't make it exact for legacy reasons
   children,
+  tagType = 'div',
   className,
   ...props
 }: IconPropsType) => {
@@ -375,9 +415,11 @@ const Icon = ({
   );
 
   const iconType = `#icon-${type}`;
+  const Tag = tagType;
 
   return (
-    <div {...props} className={iconClass}>
+
+    <Tag {...props} className={iconClass}>
       {type ? (
         <svg className="sg-icon__svg">
           <use xlinkHref={iconType} />
@@ -385,7 +427,7 @@ const Icon = ({
       ) : (
         children
       )}
-    </div>
+    </Tag>
   );
 };
 

--- a/src/components/icons/Icon.spec.jsx
+++ b/src/components/icons/Icon.spec.jsx
@@ -59,6 +59,14 @@ test('size', () => {
   expect(icon.hasClass(`sg-icon--x${size}`)).toEqual(true);
 });
 
+test('tag type', () => {
+  const component = shallow(
+    <Icon type={TYPE.ANSWER} size="10" tagType="span" />
+  );
+
+  expect(component.find('span')).toHaveLength(1);
+});
+
 test('other props', () => {
   const type = TYPE.ANSWER;
   const icon = shallow(<Icon type={type} data-something="else" />);

--- a/src/components/icons/pages/icons.jsx
+++ b/src/components/icons/pages/icons.jsx
@@ -76,6 +76,10 @@ const icons = () => (
         </li>
       </ul>
     </DocsBlock>
+
+    <Icon color="dark" size="46" type="std-answer" tagType="div" />
+    <Text>Get +<Icon color="dark" size="16" type="std-points" tagType="span" /></Text>
+
   </div>
 );
 

--- a/src/components/icons/pages/icons.jsx
+++ b/src/components/icons/pages/icons.jsx
@@ -76,10 +76,6 @@ const icons = () => (
         </li>
       </ul>
     </DocsBlock>
-
-    <Icon color="dark" size="46" type="std-answer" tagType="div" />
-    <Text>Get +<Icon color="dark" size="16" type="std-points" tagType="span" /></Text>
-
   </div>
 );
 


### PR DESCRIPTION
Added to get the possibility to display an icon inside the button's text, like following:

<img width="158" alt="Screenshot 2019-08-16 at 11 10 21" src="https://user-images.githubusercontent.com/4272331/63157943-7703da00-c018-11e9-8606-8d7ed94489b8.png">

Additionally, adjustment for moving text in button - this issue happens only for Proxima 12px font size.