### PR TITLE
Update sizes of the icons in RoundButtons

### DIFF
--- a/src/components/round-buttons/RoundButton.jsx
+++ b/src/components/round-buttons/RoundButton.jsx
@@ -67,6 +67,7 @@ const RoundButton = ({
   className,
   ariaLabel,
   title,
+  type,
   ...props
 }: RoundButtonPropsType) => {
   const roundButtonClass = cx(

--- a/src/components/round-buttons/RoundButton.jsx
+++ b/src/components/round-buttons/RoundButton.jsx
@@ -2,7 +2,7 @@
 
 import React from 'react';
 import cx from 'classnames';
-import Icon, {ICON_COLOR, TYPE} from '../icons/Icon';
+import Icon, {TYPE} from '../icons/Icon';
 import {ROUND_BUTTON_SIZE, ROUND_BUTTON_COLOR} from './roundButtonsConsts';
 
 export {ROUND_BUTTON_SIZE, TYPE as ROUND_BUTTON_ICON_TYPE, ROUND_BUTTON_COLOR};

--- a/src/components/round-buttons/RoundButton.jsx
+++ b/src/components/round-buttons/RoundButton.jsx
@@ -49,6 +49,11 @@ export type RoundButtonPropsType = {
    */
   ariaLabel?: string,
   /**
+   * type for round button
+   * @example <RoundButton type="submit" filled/>
+   */
+  type?: string,
+  /**
    * Additional class names
    */
   className?: string,
@@ -76,9 +81,12 @@ const RoundButton = ({
 
   const buttonContent = (
     <Icon
-      size={size === 'small' ? '16' : '24'}
+      size={size === 'small' ? '16' : size === 'large' ? '32' : '24'}
       type={iconType}
-      color={filled !== undefined ? ICON_COLOR.LIGHT : ICON_COLOR.ADAPTIVE}
+      // to export it in an easy way to sketch
+      color={
+        filled !== undefined ? 'light' : color === 'black' ? 'dark' : color
+      }
     />
   );
 

--- a/src/components/round-buttons/RoundButton.jsx
+++ b/src/components/round-buttons/RoundButton.jsx
@@ -49,11 +49,6 @@ export type RoundButtonPropsType = {
    */
   ariaLabel?: string,
   /**
-   * type for round button
-   * @example <RoundButton type="submit" filled/>
-   */
-  type?: string,
-  /**
    * Additional class names
    */
   className?: string,
@@ -67,7 +62,6 @@ const RoundButton = ({
   className,
   ariaLabel,
   title,
-  type,
   ...props
 }: RoundButtonPropsType) => {
   const roundButtonClass = cx(


### PR DESCRIPTION
Change for size of the icon in large RoundButton and color set for easier export to sketch:

<img width="547" alt="Screenshot 2019-11-19 at 16 21 18" src="https://user-images.githubusercontent.com/4272331/69160060-31f4b580-0ae9-11ea-95d2-2c9f083fdfe6.png">
