### PR TITLE
Rename Label to LabelDeprecated

### DIFF
--- a/src/components/action-list/pages/action-list.jsx
+++ b/src/components/action-list/pages/action-list.jsx
@@ -6,7 +6,9 @@ import Headline, {
   HEADLINE_TYPE,
   HEADLINE_COLOR,
 } from 'text/Headline';
-import LabelDeprecated, {SIZE as LABEL_SIZE, ICON_COLOR, ICON_TYPE} from 'labels-deprecated/LabelDeprecated';
+import LabelDeprecated, {
+  SIZE as LABEL_SIZE, ICON_COLOR, ICON_TYPE,
+} from 'labels-deprecated/LabelDeprecated';
 import Icon from 'icons/Icon';
 import Text, {TEXT_TYPE, TEXT_SIZE, TEXT_COLOR, TEXT_WEIGHT} from 'text/Text';
 

--- a/src/components/action-list/pages/action-list.jsx
+++ b/src/components/action-list/pages/action-list.jsx
@@ -7,7 +7,9 @@ import Headline, {
   HEADLINE_COLOR,
 } from 'text/Headline';
 import LabelDeprecated, {
-  SIZE as LABEL_SIZE, ICON_COLOR, ICON_TYPE,
+  SIZE as LABEL_SIZE,
+  ICON_COLOR,
+  ICON_TYPE,
 } from 'labels-deprecated/LabelDeprecated';
 import Icon from 'icons/Icon';
 import Text, {TEXT_TYPE, TEXT_SIZE, TEXT_COLOR, TEXT_WEIGHT} from 'text/Text';

--- a/src/components/action-list/pages/action-list.jsx
+++ b/src/components/action-list/pages/action-list.jsx
@@ -6,7 +6,7 @@ import Headline, {
   HEADLINE_TYPE,
   HEADLINE_COLOR,
 } from 'text/Headline';
-import Label, {SIZE as LABEL_SIZE, ICON_COLOR, ICON_TYPE} from 'labels/Label';
+import LabelDeprecated, {SIZE as LABEL_SIZE, ICON_COLOR, ICON_TYPE} from 'labels-deprecated/LabelDeprecated';
 import Icon from 'icons/Icon';
 import Text, {TEXT_TYPE, TEXT_SIZE, TEXT_COLOR, TEXT_WEIGHT} from 'text/Text';
 
@@ -100,7 +100,7 @@ const ActionLists = () => (
     <DocsBlock info="Space between">
       <ActionList direction={DIRECTION.SPACE_BETWEEN}>
         <ActionListHole>
-          <Label
+          <LabelDeprecated
             iconType={ICON_TYPE.ANSWER}
             iconColor={ICON_COLOR.GRAY_SECONDARY}
             secondary
@@ -114,10 +114,10 @@ const ActionLists = () => (
             >
               0/5
             </Text>
-          </Label>
+          </LabelDeprecated>
         </ActionListHole>
         <ActionListHole>
-          <Label
+          <LabelDeprecated
             iconType={ICON_TYPE.COUNTER}
             iconColor={ICON_COLOR.GRAY_SECONDARY}
             secondary
@@ -131,7 +131,7 @@ const ActionLists = () => (
             >
               2d: 00h
             </Text>
-          </Label>
+          </LabelDeprecated>
         </ActionListHole>
         <ActionListHole>
           <Button type="secondary" size="small">
@@ -144,7 +144,7 @@ const ActionLists = () => (
     <DocsBlock info="Space around">
       <ActionList direction={DIRECTION.SPACE_AROUND}>
         <ActionListHole>
-          <Label
+          <LabelDeprecated
             iconType={ICON_TYPE.ANSWER}
             iconColor={ICON_COLOR.GRAY_SECONDARY}
             secondary
@@ -158,10 +158,10 @@ const ActionLists = () => (
             >
               0/5
             </Text>
-          </Label>
+          </LabelDeprecated>
         </ActionListHole>
         <ActionListHole>
-          <Label
+          <LabelDeprecated
             iconType={ICON_TYPE.COUNTER}
             iconColor={ICON_COLOR.GRAY_SECONDARY}
             secondary
@@ -175,7 +175,7 @@ const ActionLists = () => (
             >
               2d: 00h
             </Text>
-          </Label>
+          </LabelDeprecated>
         </ActionListHole>
         <ActionListHole>
           <Button type="secondary" size="small">
@@ -188,7 +188,7 @@ const ActionLists = () => (
     <DocsBlock info="Space evenly">
       <ActionList direction={DIRECTION.SPACE_EVENLY}>
         <ActionListHole>
-          <Label
+          <LabelDeprecated
             iconType={ICON_TYPE.ANSWER}
             iconColor={ICON_COLOR.GRAY_SECONDARY}
             secondary
@@ -202,10 +202,10 @@ const ActionLists = () => (
             >
               0/5
             </Text>
-          </Label>
+          </LabelDeprecated>
         </ActionListHole>
         <ActionListHole>
-          <Label
+          <LabelDeprecated
             iconType={ICON_TYPE.COUNTER}
             iconColor={ICON_COLOR.GRAY_SECONDARY}
             secondary
@@ -219,7 +219,7 @@ const ActionLists = () => (
             >
               2d: 00h
             </Text>
-          </Label>
+          </LabelDeprecated>
         </ActionListHole>
         <ActionListHole>
           <Button type="secondary" size="small">

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -167,13 +167,13 @@ $buttonPrimaryFbHoverColor: #4367a9;
     line-height: 15px;
     border-radius: 20px;
 
-    .sg-label__text,
-    .sg-label__number {
+    .sg-label-deprecated__text,
+    .sg-label-deprecated__number {
       font-size: 15px;
       cursor: pointer;
     }
 
-    .sg-label .sg-label__icon {
+    .sg-label-deprecated .sg-label-deprecated__icon {
       margin-right: spacing(xs);
       width: 24px;
       height: 24px;
@@ -242,7 +242,7 @@ $buttonPrimaryFbHoverColor: #4367a9;
     }
   }
 
-  &.sg-label__text {
+  &.sg-label-deprecated__text {
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -272,7 +272,7 @@ $buttonPrimaryFbHoverColor: #4367a9;
     opacity: 0.45;
     cursor: default;
 
-    & .sg-label__text {
+    & .sg-label-deprecated__text {
       cursor: default;
     }
   }

--- a/src/components/content-box/pages/content-box.jsx
+++ b/src/components/content-box/pages/content-box.jsx
@@ -8,7 +8,10 @@ import ContentBoxHeader from '../ContentBoxHeader';
 import Button from 'buttons/Button';
 import Breadcrumbs from 'breadcrumbs/Breadcrumb';
 import Avatar, {SIZE as AVATAR_SIZE} from 'avatar/Avatar';
-import LabelDeprecated, {ICON_COLOR, ICON_TYPE} from 'labels-deprecated/LabelDeprecated';
+import LabelDeprecated, {
+  ICON_COLOR,
+  ICON_TYPE,
+} from 'labels-deprecated/LabelDeprecated';
 import Rating from 'rating/Rating';
 import Text from 'text/Text';
 import Link, {LINK_COLOR} from 'text/Link';

--- a/src/components/content-box/pages/content-box.jsx
+++ b/src/components/content-box/pages/content-box.jsx
@@ -8,7 +8,7 @@ import ContentBoxHeader from '../ContentBoxHeader';
 import Button from 'buttons/Button';
 import Breadcrumbs from 'breadcrumbs/Breadcrumb';
 import Avatar, {SIZE as AVATAR_SIZE} from 'avatar/Avatar';
-import Label, {ICON_COLOR, ICON_TYPE} from 'labels/Label';
+import LabelDeprecated, {ICON_COLOR, ICON_TYPE} from 'labels-deprecated/LabelDeprecated';
 import Rating from 'rating/Rating';
 import Text from 'text/Text';
 import Link, {LINK_COLOR} from 'text/Link';
@@ -320,7 +320,7 @@ const ContentBoxes = () => (
         <ContentBoxActions>
           <Breadcrumbs elements={breadcrumbsSpaced2} />
           <Button type="primary-inverted">
-            <Label
+            <LabelDeprecated
               text="Thank you"
               number={21}
               iconType={ICON_TYPE.HEART}
@@ -353,7 +353,7 @@ const ContentBoxes = () => (
         <ContentBoxActions>
           <Breadcrumbs elements={breadcrumbsSpaced2} />
           <Button type="primary-inverted">
-            <Label
+            <LabelDeprecated
               text="Thank you"
               number={21}
               iconType={ICON_TYPE.HEART}
@@ -433,7 +433,7 @@ const ContentBoxes = () => (
             ]}
           />
           <Button type="primary-inverted">
-            <Label
+            <LabelDeprecated
               text="Thank you"
               number={21}
               iconType={ICON_TYPE.HEART}
@@ -451,7 +451,7 @@ const ContentBoxes = () => (
         <ContentBoxActions align={ALIGNMENT.RIGHT}>
           <Breadcrumbs elements={breadcrumbsSpaced2} />
           <Button type="primary-inverted">
-            <Label
+            <LabelDeprecated
               text="Thank you"
               number={21}
               iconType={ICON_TYPE.HEART}

--- a/src/components/form-elements/pages/checkbox.jsx
+++ b/src/components/form-elements/pages/checkbox.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Checkbox from '../Checkbox';
 import DocsBlock from 'components/DocsBlock';
-import Label from 'labels/Label';
+import LabelDeprecated from 'labels-deprecated/LabelDeprecated';
 
 const dumpProps = {onChange: () => undefined};
 
@@ -11,13 +11,13 @@ const checkboxes = () => (
       <Checkbox />
       <Checkbox checked {...dumpProps} />
       <br />
-      <Label
+      <LabelDeprecated
         secondary
         text="Check me!"
         htmlFor="checkbox-1"
         iconContent={<Checkbox id="checkbox-1" />}
       />
-      <Label
+      <LabelDeprecated
         secondary
         text="Check me!"
         htmlFor="checkbox-2"

--- a/src/components/form-elements/pages/radio.jsx
+++ b/src/components/form-elements/pages/radio.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import DocsBlock from 'components/DocsBlock';
-import Label from 'labels/Label';
+import LabelDeprecated from 'labels-deprecated/LabelDeprecated';
 import Radio, {RADIO_SIZE} from '../Radio';
 
 const dumpProps = {onChange: () => undefined};
@@ -11,13 +11,13 @@ const radios = () => (
       <Radio name="group1" />
       <Radio name="group1" checked {...dumpProps} />
       <br />
-      <Label
+      <LabelDeprecated
         secondary
         htmlFor="radio-3"
         text="Check me!"
         iconContent={<Radio name="group2" />}
       />
-      <Label
+      <LabelDeprecated
         secondary
         htmlFor="radio-4"
         text="Check me!"

--- a/src/components/labels-deprecated/LabelDeprecated.jsx
+++ b/src/components/labels-deprecated/LabelDeprecated.jsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import type {Node} from 'react';
 import classNames from 'classnames';
-import LabelIcon from './subcomponents/LabelIcon';
+import LabelDeprecatedIcon from './subcomponents/LabelDeprecatedIcon';
 import * as IconModule from '../icons/Icon';
 
 const {ICON_COLOR, TYPE: ICON_TYPE} = IconModule;
@@ -39,7 +39,7 @@ type PropsType = {
   ...
 };
 
-const Label = (props: PropsType) => {
+const LabelDeprecated = (props: PropsType) => {
   const {
     size = SIZE.NORMAL,
     text,
@@ -58,13 +58,13 @@ const Label = (props: PropsType) => {
   } = props;
 
   const labelClass = classNames(
-    'sg-label',
+    'sg-label-deprecated',
     {
-      [`sg-label--${size}`]: size !== SIZE.NORMAL,
-      'sg-label--secondary': secondary,
-      'sg-label--unstyled': unstyled,
-      'sg-label--emphasised': emphasised,
-      'sg-label--elements-to-the-top': elementsToTop,
+      [`sg-label-deprecated--${size}`]: size !== SIZE.NORMAL,
+      'sg-label-deprecated--secondary': secondary,
+      'sg-label-deprecated--unstyled': unstyled,
+      'sg-label-deprecated--emphasised': emphasised,
+      'sg-label-deprecated--elements-to-the-top': elementsToTop,
     },
     className
   );
@@ -74,18 +74,18 @@ const Label = (props: PropsType) => {
 
   if (text !== undefined && text !== '') {
     textElement = (
-      <label className="sg-label__text" htmlFor={htmlFor}>
+      <label className="sg-label-deprecated__text" htmlFor={htmlFor}>
         {text}
       </label>
     );
   }
   if (number !== undefined) {
-    numberElement = <div className="sg-label__number">{number}</div>;
+    numberElement = <div className="sg-label-deprecated__number">{number}</div>;
   }
 
   return (
     <div {...restProps} className={labelClass}>
-      <LabelIcon
+      <LabelDeprecatedIcon
         iconContent={iconContent}
         iconType={iconType}
         iconColor={iconColor}
@@ -98,5 +98,5 @@ const Label = (props: PropsType) => {
   );
 };
 
-export default Label;
-export {ICON_TYPE, ICON_COLOR, LabelIcon};
+export default LabelDeprecated;
+export {ICON_TYPE, ICON_COLOR, LabelDeprecatedIcon};

--- a/src/components/labels-deprecated/LabelDeprecated.spec.jsx
+++ b/src/components/labels-deprecated/LabelDeprecated.spec.jsx
@@ -1,22 +1,22 @@
 import React from 'react';
-import Label, {
+import LabelDeprecated, {
   SIZE,
   ICON_COLOR,
   ICON_TYPE,
   ICON_SIZE,
   LabelIcon,
-} from './Label';
+} from './LabelDeprecated';
 import Icon from 'icons/Icon';
 import {shallow} from 'enzyme';
 
-describe('Label', () => {
+describe('LabelDeprecated', () => {
   test('render', () => {
     const iconType = ICON_TYPE.STAR;
-    const label = shallow(<Label iconType={iconType} text="test" />);
+    const label = shallow(<LabelDeprecated iconType={iconType} text="test" />);
     const icon = label.find(LabelIcon);
-    const textLabel = label.find('label.sg-label__text');
+    const textLabel = label.find('label.sg-label-deprecated__text');
 
-    expect(label.hasClass('sg-label')).toEqual(true);
+    expect(label.hasClass('sg-label-deprecated')).toEqual(true);
     expect(textLabel).toHaveLength(1);
     expect(icon).toHaveLength(1);
     expect(icon.props().iconType).toEqual(iconType);
@@ -26,7 +26,7 @@ describe('Label', () => {
     const iconType = ICON_TYPE.HEART;
     const iconColor = ICON_COLOR.LAVENDER;
     const label = shallow(
-      <Label iconType={iconType} iconColor={iconColor} text="test" />
+      <LabelDeprecated iconType={iconType} iconColor={iconColor} text="test" />
     );
     const icon = label.find(LabelIcon);
 
@@ -37,11 +37,11 @@ describe('Label', () => {
     const size = SIZE.SMALL;
     const iconType = ICON_TYPE.HEART;
     const label = shallow(
-      <Label iconType={iconType} size={size} text="test" />
+      <LabelDeprecated iconType={iconType} size={size} text="test" />
     );
     const icon = label.find(LabelIcon);
 
-    expect(label.hasClass('sg-label--small')).toEqual(true);
+    expect(label.hasClass('sg-label-deprecated--small')).toEqual(true);
     expect(icon.props().iconSize).toEqual(ICON_SIZE[size]);
   });
 
@@ -49,52 +49,52 @@ describe('Label', () => {
     const size = SIZE.NORMAL;
     const iconType = ICON_TYPE.HEART;
     const label = shallow(
-      <Label iconType={iconType} size={size} text="test" />
+      <LabelDeprecated iconType={iconType} size={size} text="test" />
     );
     const icon = label.find(LabelIcon);
 
-    expect(label.hasClass('sg-label--small')).toEqual(false);
-    expect(label.hasClass('sg-label--large')).toEqual(false);
+    expect(label.hasClass('sg-label-deprecated--small')).toEqual(false);
+    expect(label.hasClass('sg-label-deprecated--large')).toEqual(false);
     expect(icon.props().iconSize).toEqual(ICON_SIZE[size]);
   });
 
   test('secondary label', () => {
-    const label = shallow(<Label secondary text="test" />);
+    const label = shallow(<LabelDeprecated secondary text="test" />);
 
-    expect(label.hasClass('sg-label--secondary')).toEqual(true);
+    expect(label.hasClass('sg-label-deprecated--secondary')).toEqual(true);
   });
 
   test('emphasised', () => {
-    const label = shallow(<Label emphasised text="test" />);
+    const label = shallow(<LabelDeprecated emphasised text="test" />);
 
-    expect(label.hasClass('sg-label--emphasised')).toEqual(true);
+    expect(label.hasClass('sg-label-deprecated--emphasised')).toEqual(true);
   });
 
   test('elements to top', () => {
     const iconType = ICON_TYPE.HEART;
     const label = shallow(
-      <Label iconType={iconType} elementsToTop text="test" />
+      <LabelDeprecated iconType={iconType} elementsToTop text="test" />
     );
 
-    expect(label.hasClass('sg-label--elements-to-the-top')).toEqual(true);
+    expect(label.hasClass('sg-label-deprecated--elements-to-the-top')).toEqual(true);
   });
 
   test('label with no text', () => {
     const iconType = ICON_TYPE.HEART;
-    const label = shallow(<Label iconType={iconType} />);
-    const textLabel = label.find('div.sg-label__text');
+    const label = shallow(<LabelDeprecated iconType={iconType} />);
+    const textLabel = label.find('div.sg-label-deprecated__text');
 
     expect(textLabel).toHaveLength(0);
   });
 
   test('label with a number', () => {
-    const label = shallow(<Label secondary text="test" number={23} />);
-    const numberLabel = label.find('div.sg-label__number');
+    const label = shallow(<LabelDeprecated secondary text="test" number={23} />);
+    const numberLabel = label.find('div.sg-label-deprecated__number');
 
     expect(numberLabel).toHaveLength(1);
 
-    const label2 = shallow(<Label secondary text="test" number={0} />);
-    const numberLabel2 = label2.find('div.sg-label__number');
+    const label2 = shallow(<LabelDeprecated secondary text="test" number={0} />);
+    const numberLabel2 = label2.find('div.sg-label-deprecated__number');
 
     expect(numberLabel2).toHaveLength(1);
   });

--- a/src/components/labels-deprecated/LabelDeprecated.spec.jsx
+++ b/src/components/labels-deprecated/LabelDeprecated.spec.jsx
@@ -4,7 +4,7 @@ import LabelDeprecated, {
   ICON_COLOR,
   ICON_TYPE,
   ICON_SIZE,
-  LabelIcon,
+  LabelDeprecatedIcon,
 } from './LabelDeprecated';
 import Icon from 'icons/Icon';
 import {shallow} from 'enzyme';
@@ -13,7 +13,7 @@ describe('LabelDeprecated', () => {
   test('render', () => {
     const iconType = ICON_TYPE.STAR;
     const label = shallow(<LabelDeprecated iconType={iconType} text="test" />);
-    const icon = label.find(LabelIcon);
+    const icon = label.find(LabelDeprecatedIcon);
     const textLabel = label.find('label.sg-label-deprecated__text');
 
     expect(label.hasClass('sg-label-deprecated')).toEqual(true);
@@ -28,7 +28,7 @@ describe('LabelDeprecated', () => {
     const label = shallow(
       <LabelDeprecated iconType={iconType} iconColor={iconColor} text="test" />
     );
-    const icon = label.find(LabelIcon);
+    const icon = label.find(LabelDeprecatedIcon);
 
     expect(icon.props().iconColor).toEqual(iconColor);
   });
@@ -39,7 +39,7 @@ describe('LabelDeprecated', () => {
     const label = shallow(
       <LabelDeprecated iconType={iconType} size={size} text="test" />
     );
-    const icon = label.find(LabelIcon);
+    const icon = label.find(LabelDeprecatedIcon);
 
     expect(label.hasClass('sg-label-deprecated--small')).toEqual(true);
     expect(icon.props().iconSize).toEqual(ICON_SIZE[size]);
@@ -51,7 +51,7 @@ describe('LabelDeprecated', () => {
     const label = shallow(
       <LabelDeprecated iconType={iconType} size={size} text="test" />
     );
-    const icon = label.find(LabelIcon);
+    const icon = label.find(LabelDeprecatedIcon);
 
     expect(label.hasClass('sg-label-deprecated--small')).toEqual(false);
     expect(label.hasClass('sg-label-deprecated--large')).toEqual(false);
@@ -76,7 +76,9 @@ describe('LabelDeprecated', () => {
       <LabelDeprecated iconType={iconType} elementsToTop text="test" />
     );
 
-    expect(label.hasClass('sg-label-deprecated--elements-to-the-top')).toEqual(true);
+    expect(label.hasClass('sg-label-deprecated--elements-to-the-top')).toEqual(
+      true
+    );
   });
 
   test('label with no text', () => {
@@ -88,12 +90,16 @@ describe('LabelDeprecated', () => {
   });
 
   test('label with a number', () => {
-    const label = shallow(<LabelDeprecated secondary text="test" number={23} />);
+    const label = shallow(
+      <LabelDeprecated secondary text="test" number={23} />
+    );
     const numberLabel = label.find('div.sg-label-deprecated__number');
 
     expect(numberLabel).toHaveLength(1);
 
-    const label2 = shallow(<LabelDeprecated secondary text="test" number={0} />);
+    const label2 = shallow(
+      <LabelDeprecated secondary text="test" number={0} />
+    );
     const numberLabel2 = label2.find('div.sg-label-deprecated__number');
 
     expect(numberLabel2).toHaveLength(1);
@@ -101,19 +107,19 @@ describe('LabelDeprecated', () => {
 
   test('passing children', () => {
     const element = <div className="smth123">xyz</div>;
-    const label = shallow(<Label>{element}</Label>);
+    const label = shallow(<LabelDeprecated>{element}</LabelDeprecated>);
 
     expect(label.find('div.smth123')).toHaveLength(1);
   });
 });
 
-describe('LabelIcon', () => {
+describe('LabelDeprecatedIcon', () => {
   test('render icon and pass props', () => {
     const iconType = ICON_TYPE.STAR;
     const iconColor = ICON_COLOR.BLUE;
     const iconSize = 10;
     const label = shallow(
-      <LabelIcon
+      <LabelDeprecatedIcon
         iconType={iconType}
         iconColor={iconColor}
         iconSize={iconSize}
@@ -129,7 +135,7 @@ describe('LabelIcon', () => {
 
   test('render content', () => {
     const content = <div className="xyz">xyz123</div>;
-    const label = shallow(<LabelIcon iconContent={content} />);
+    const label = shallow(<LabelDeprecatedIcon iconContent={content} />);
     const icon = label.find(Icon);
 
     expect(icon).toHaveLength(0);
@@ -137,7 +143,7 @@ describe('LabelIcon', () => {
   });
 
   test('render null', () => {
-    const label = shallow(<LabelIcon />);
+    const label = shallow(<LabelDeprecatedIcon />);
     const icon = label.find(Icon);
 
     expect(icon).toHaveLength(0);

--- a/src/components/labels-deprecated/_labels-deprecated.scss
+++ b/src/components/labels-deprecated/_labels-deprecated.scss
@@ -12,7 +12,7 @@ $includeHtml: false !default;
 
 @if ($includeHtml) {
 
-  .sg-label {
+  .sg-label-deprecated {
     @include component();
     overflow: visible;
     display: flex;
@@ -55,8 +55,8 @@ $includeHtml: false !default;
     }
 
     &--secondary {
-      .sg-label__text,
-      .sg-label__number {
+      .sg-label-deprecated__text,
+      .sg-label-deprecated__number {
         color: $labelSecondaryColor;
       }
     }
@@ -64,8 +64,8 @@ $includeHtml: false !default;
     &--small {
       min-height: 0;
 
-      .sg-label__text,
-      .sg-label__number {
+      .sg-label-deprecated__text,
+      .sg-label-deprecated__number {
         @include fixText($labelFontSizeSecondary);
         @include fixOperaMiniLabelText();
 
@@ -76,7 +76,7 @@ $includeHtml: false !default;
         }
       }
 
-      .sg-label__icon {
+      .sg-label-deprecated__icon {
         margin-right: $labelScaleFactor * gutter(0.25);
         width: $labelIconSizeSecondary;
         height: $labelIconSizeSecondary;
@@ -84,8 +84,8 @@ $includeHtml: false !default;
     }
 
     &--large {
-      .sg-label__text,
-      .sg-label__number {
+      .sg-label-deprecated__text,
+      .sg-label-deprecated__number {
         @include fixText($labelFontSizeLarge);
         @include fixOperaMiniLabelText();
 
@@ -94,7 +94,7 @@ $includeHtml: false !default;
         }
       }
 
-      .sg-label__icon {
+      .sg-label-deprecated__icon {
         margin-right: gutter(0.5);
         width: $labelIconSizeLarge;
         height: $labelIconSizeLarge;
@@ -103,8 +103,8 @@ $includeHtml: false !default;
     }
 
     &--unstyled {
-      .sg-label__text,
-      .sg-label__number {
+      .sg-label-deprecated__text,
+      .sg-label-deprecated__number {
         color: inherit;
       }
     }

--- a/src/components/labels-deprecated/pages/labels-deprecated-interactive.jsx
+++ b/src/components/labels-deprecated/pages/labels-deprecated-interactive.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Label, {SIZE, ICON_TYPE, ICON_COLOR} from '../Label';
+import LabelDeprecated, {SIZE, ICON_TYPE, ICON_COLOR} from '../LabelDeprecated';
 import Checkbox from 'form-elements/Checkbox';
 import DocsActiveBlock from 'components/DocsActiveBlock';
 
-const Labels = () => {
+const LabelsDeprecated = () => {
   const settings = [
     {
       name: 'size',
@@ -46,14 +46,14 @@ const Labels = () => {
   return (
     <div>
       <DocsActiveBlock settings={settings}>
-        <Label
+        <LabelDeprecated
           text="Search"
           iconType={ICON_TYPE.SEARCH}
           iconColor={ICON_COLOR.GRAY}
         />
       </DocsActiveBlock>
       <DocsActiveBlock settings={settings}>
-        <Label
+        <LabelDeprecated
           text="Edit"
           size={SIZE.LARGE}
           iconType={ICON_TYPE.PENCIL}
@@ -63,7 +63,7 @@ const Labels = () => {
         />
       </DocsActiveBlock>
       <DocsActiveBlock settings={settings}>
-        <Label
+        <LabelDeprecated
           size={SIZE.LARGE}
           text="Check me!"
           htmlFor="checkbox-1"
@@ -74,4 +74,4 @@ const Labels = () => {
   );
 };
 
-export default Labels;
+export default LabelsDeprecated;

--- a/src/components/labels-deprecated/pages/labels-deprecated.jsx
+++ b/src/components/labels-deprecated/pages/labels-deprecated.jsx
@@ -1,33 +1,33 @@
 import React from 'react';
 import DocsBlock from 'components/DocsBlock';
-import Label, {ICON_COLOR, ICON_TYPE, SIZE} from '../Label';
+import LabelDeprecated, {ICON_COLOR, ICON_TYPE, SIZE} from '../LabelDeprecated';
 
 const longText =
   'Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.';
 const multilineExample1 = `This is a multiline example with icon in the middle (default behaviur). ${longText}`;
 const multilineExample2 = `This is a multiline example with icon aligned to top. ${longText}`;
 
-const Labels = () => (
+const LabelsDeprecated = () => (
   <div>
     <DocsBlock info="Default">
-      <Label
+      <LabelDeprecated
         text="Default label"
         iconType={ICON_TYPE.SEARCH}
         iconColor={ICON_COLOR.GRAY}
       />
-      <Label
+      <LabelDeprecated
         text="Unstyled label"
         iconType={ICON_TYPE.PENCIL}
         iconColor={ICON_COLOR.LAVENDER}
         unstyled
       />
-      <Label
+      <LabelDeprecated
         text="Mark as brainliest"
         iconType={ICON_TYPE.EXCELLENT}
         iconColor={ICON_COLOR.MUSTARD}
         emphasised
       />
-      <Label
+      <LabelDeprecated
         text="Thank you"
         number={21}
         iconType={ICON_TYPE.HEART}
@@ -36,13 +36,13 @@ const Labels = () => (
         secondary
       />
       <div style={{maxWidth: `${250}px`}}>
-        <Label
+        <LabelDeprecated
           text={multilineExample1}
           iconType={ICON_TYPE.SEARCH}
           iconColor={ICON_COLOR.GRAY}
         />
         <br />
-        <Label
+        <LabelDeprecated
           text={multilineExample2}
           iconType={ICON_TYPE.SEARCH}
           iconColor={ICON_COLOR.GRAY}
@@ -51,14 +51,14 @@ const Labels = () => (
       </div>
     </DocsBlock>
     <DocsBlock info="Small">
-      <Label
+      <LabelDeprecated
         text="Mark as brainliest"
         size={SIZE.SMALL}
         iconType={ICON_TYPE.EXCELLENT}
         iconColor={ICON_COLOR.MUSTARD}
         emphasised
       />
-      <Label
+      <LabelDeprecated
         text="Thank you"
         number={21}
         size={SIZE.SMALL}
@@ -69,13 +69,13 @@ const Labels = () => (
       />
     </DocsBlock>
     <DocsBlock info="Large">
-      <Label
+      <LabelDeprecated
         text="Mark as brainliest"
         size={SIZE.LARGE}
         iconType={ICON_TYPE.EXCELLENT}
         iconColor={ICON_COLOR.MUSTARD}
       />
-      <Label
+      <LabelDeprecated
         text="Thank you"
         number={21}
         size={SIZE.LARGE}
@@ -87,4 +87,4 @@ const Labels = () => (
   </div>
 );
 
-export default Labels;
+export default LabelsDeprecated;

--- a/src/components/labels-deprecated/subcomponents/LabelDeprecatedIcon.jsx
+++ b/src/components/labels-deprecated/subcomponents/LabelDeprecatedIcon.jsx
@@ -13,7 +13,12 @@ type PropsType = {
   ...
 };
 
-const LabelDeprecatedIcon = ({iconType, iconColor, iconContent, iconSize}: PropsType) => {
+const LabelDeprecatedIcon = ({
+  iconType,
+  iconColor,
+  iconContent,
+  iconSize,
+}: PropsType) => {
   if (iconContent) {
     return <div className="sg-label-deprecated__icon">{iconContent}</div>;
   }

--- a/src/components/labels-deprecated/subcomponents/LabelDeprecatedIcon.jsx
+++ b/src/components/labels-deprecated/subcomponents/LabelDeprecatedIcon.jsx
@@ -13,13 +13,13 @@ type PropsType = {
   ...
 };
 
-const LabelIcon = ({iconType, iconColor, iconContent, iconSize}: PropsType) => {
+const LabelDeprecatedIcon = ({iconType, iconColor, iconContent, iconSize}: PropsType) => {
   if (iconContent) {
-    return <div className="sg-label__icon">{iconContent}</div>;
+    return <div className="sg-label-deprecated__icon">{iconContent}</div>;
   }
   if (iconType) {
     return (
-      <div className="sg-label__icon">
+      <div className="sg-label-deprecated__icon">
         <Icon type={iconType} color={iconColor} size={iconSize} />
       </div>
     );
@@ -27,4 +27,4 @@ const LabelIcon = ({iconType, iconColor, iconContent, iconSize}: PropsType) => {
   return null;
 };
 
-export default LabelIcon;
+export default LabelDeprecatedIcon;

--- a/src/docs/navigation.js
+++ b/src/docs/navigation.js
@@ -6,7 +6,7 @@ import select from '../components/form-elements/pages/select';
 import textInput from '../components/form-elements/pages/input';
 import textarea from '../components/form-elements/pages/textarea';
 import formElements from '../components/form-elements/pages/formElements';
-import labels from '../components/labels/pages/labels';
+import labelsDeprecated from '../components/labels-deprecated/pages/labels-deprecated';
 import overlay from '../components/overlay/pages/overlay';
 import overlayedBox from '../components/overlayed-box/pages/overlayed-box';
 import avatar from '../components/avatar/pages/avatar';
@@ -119,8 +119,8 @@ const navigation = [
         component: avatar,
       },
       {
-        name: 'Labels',
-        component: labels,
+        name: 'Labels Deprecated',
+        component: labelsDeprecated,
       },
       {
         name: 'Rating',

--- a/src/docs/page-components.jsx
+++ b/src/docs/page-components.jsx
@@ -17,7 +17,7 @@ import Cards from 'card/pages/card-interactive';
 import ActionLists from 'action-list/pages/action-list-interactive';
 import Ratings from 'rating/pages/rating-interactive';
 import Icons from 'icons/pages/icons-interactive';
-import Labels from 'labels/pages/labels-interactive';
+import LabelsDeprecated from 'labels/pages/labels-deprecated-interactive';
 import Dropdowns from 'dropdowns/pages/dropdowns-interactive';
 import Separators from 'separators/pages/separators-interactive';
 import Texts from 'text/pages/text-interactive';
@@ -62,7 +62,7 @@ const demos = {
   'Action List': <ActionLists />,
   Rating: <Ratings />,
   Icons: <Icons />,
-  Labels: <Labels />,
+  LabelsDeprecated: <LabelsDeprecated />,
   Dropdowns: <Dropdowns />,
   Separators: <Separators />,
   Text: <Texts />,

--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,9 @@ export {
   default as IconAsButton,
 } from './components/icon-as-button/IconAsButton';
 export {default as Icon} from './components/icons/Icon';
-export {default as Label} from './components/labels/Label';
+export {
+  default as LabelDeprecated,
+} from './components/labels-deprecated/LabelDeprecated';
 export {default as Layout} from './components/layout/Layout';
 export {
   default as LayoutAsideContent,

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -42,7 +42,7 @@ $sgFontsPath: 'fonts/' !default;
 @import '../components/separators/horizontal-separator';
 @import '../components/footer/footer';
 @import '../components/content-box/content-box';
-@import '../components/labels/labels';
+@import '../components/labels-deprecated/labels-deprecated';
 @import '../components/rating/rating';
 @import '../components/toplayer/toplayer';
 @import '../components/overlay/overlay';


### PR DESCRIPTION
### Why?

- it's a breaking change
- ultimately `LabelDeprecated` will be removed and components replaced by other ones.
- we wanted to make `Label` namespace free
- as a next step we want to replace current `Badge` namespace with `Label` one

usage:
- `import LabelDepraceted` in React
- `<div class="sg-label-deprecated">` in html

<img width="1171" alt="Screenshot 2019-12-20 at 14 33 21" src="https://user-images.githubusercontent.com/1231144/71258420-6a7cee80-2336-11ea-9bb7-da68e9ac7e86.png">
