### PR TITLE
Add fullWidth option to SpinnerContainer

### DIFF
--- a/src/components/spinner-container/SpinnerContainer.jsx
+++ b/src/components/spinner-container/SpinnerContainer.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import type {Node} from 'react';
 import * as SpinnerModule from '../spinner/Spinner';
+import classnames from 'classnames';
 
 const {default: Spinner} = SpinnerModule;
 
@@ -11,6 +12,7 @@ export {SPINNER_SIZE} from '../spinner/Spinner';
 type PropsType = {
   loading?: boolean,
   light?: boolean,
+  fullWidth?: boolean,
   size?: SpinnerModule.SpinnerSizeType,
   children?: Node,
   ...
@@ -19,11 +21,16 @@ type PropsType = {
 const SpinnerContainer = ({
   loading,
   light,
+  fullWidth,
   size,
   children,
   ...props
 }: PropsType) => (
-  <div {...props} className="sg-spinner-container">
+  <div
+    {...props}
+    className={classnames("sg-spinner-container", {
+    'sg-spinner-container--full-width': fullWidth,
+  })}>
     {children}
     {loading === true && (
       <div className="sg-spinner-container__overlay">

--- a/src/components/spinner-container/SpinnerContainer.jsx
+++ b/src/components/spinner-container/SpinnerContainer.jsx
@@ -28,9 +28,10 @@ const SpinnerContainer = ({
 }: PropsType) => (
   <div
     {...props}
-    className={classnames("sg-spinner-container", {
-    'sg-spinner-container--full-width': fullWidth,
-  })}>
+    className={classnames('sg-spinner-container', {
+      'sg-spinner-container--full-width': fullWidth,
+    })}
+  >
     {children}
     {loading === true && (
       <div className="sg-spinner-container__overlay">

--- a/src/components/spinner-container/_spinner-container.scss
+++ b/src/components/spinner-container/_spinner-container.scss
@@ -4,7 +4,13 @@ $includeHtml: false !default;
 
   .sg-spinner-container {
     position: relative;
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &--full-width {
+      width: 100%;
+    }
 
     &__overlay {
       position: absolute;

--- a/src/components/spinner-container/pages/spinner-containers-interactive.jsx
+++ b/src/components/spinner-container/pages/spinner-containers-interactive.jsx
@@ -17,6 +17,10 @@ const SpinnerContainers = () => {
       name: 'light',
       values: Boolean,
     },
+    {
+      name: 'fullWidth',
+      values: Boolean,
+    },
   ];
 
   return (

--- a/src/components/spinner-container/pages/spinner-containers.jsx
+++ b/src/components/spinner-container/pages/spinner-containers.jsx
@@ -8,6 +8,7 @@ import ContentBox from 'content-box/ContentBox';
 import ContentBoxHeader from 'content-box/ContentBoxHeader';
 import ContentBoxActions from 'content-box/ContentBoxActions';
 import Headline, {HEADLINE_TYPE} from 'text/Headline';
+import Textarea from 'form-elements/Textarea';
 
 const IS_LOADING = true;
 
@@ -61,6 +62,12 @@ const SpinnerContainers = () => (
             </ContentBoxActions>
           </ContentBox>
         </Box>
+      </SpinnerContainer>
+    </DocsBlock>
+
+    <DocsBlock info="full width">
+      <SpinnerContainer loading fullWidth>
+        <Textarea placeholder="Simple textarea" fullWidth />
       </SpinnerContainer>
     </DocsBlock>
 


### PR DESCRIPTION
fixes: https://github.com/brainly/style-guide/issues/1652

before:
<img width="1092" alt="Screenshot 2020-01-03 at 12 26 01" src="https://user-images.githubusercontent.com/1231144/71721159-5fd95380-2e24-11ea-8ea8-d783a8c74386.png">

after:

<img width="1053" alt="Screenshot 2020-01-03 at 12 25 52" src="https://user-images.githubusercontent.com/1231144/71721158-5fd95380-2e24-11ea-87b1-8a9817ac2f90.png">

