### PR TITLE
Fix Textarea Paddings

### DIFF
--- a/src/components/form-elements/_textarea.scss
+++ b/src/components/form-elements/_textarea.scss
@@ -12,7 +12,7 @@ $includeHtml: false !default;
     display: block;
     font-size: $formElementDefaultFontSize;
     line-height: $formElementDefaultLineHeight;
-    padding: spacing(xs) spacing(s);
+    padding: 6px spacing(s);
     resize: none;
     height: $textareaStandardHeight;
     overflow-y: auto;
@@ -104,7 +104,6 @@ $includeHtml: false !default;
 
     &--short {
       height: 40px;
-      padding-top: spacing(xs);
       line-height: 24px;
     }
 


### PR DESCRIPTION
The modifier `short` (with initial `40px` height) and bigger top/bottom paddings result with unwanted inner scroll. Moreover `react-textarea-autosize` has a problem with it.

<img width="238" alt="Screen Shot 2020-01-21 at 15 20 39" src="https://user-images.githubusercontent.com/13873576/72812374-abcc2b00-3c61-11ea-969a-306f06f32d15.png">
