### PR TITLE
Remove outline none property and fix hover in IconAsButton on touch devices

### DIFF
--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -37,10 +37,6 @@ $buttonPrimaryFbHoverColor: #4367a9;
     width: 100%;
   }
 
-  &:focus {
-    outline: none;
-  }
-
   &:hover,
   &:focus,
   &:active,

--- a/src/components/form-elements/_text-input.scss
+++ b/src/components/form-elements/_text-input.scss
@@ -18,7 +18,6 @@ $includeHtml: false !default;
     &:active,
     &:focus:hover,
     &:active:hover {
-      outline: none;
       background-color: $white;
       border: 2px solid $graySecondaryLight;
 

--- a/src/components/form-elements/_textarea.scss
+++ b/src/components/form-elements/_textarea.scss
@@ -30,7 +30,6 @@ $includeHtml: false !default;
     &:active,
     &:focus:hover,
     &:active:hover {
-      outline: none;
       background-color: $white;
       border: 2px solid $formElementActiveBorderColor;
 

--- a/src/components/icon-as-button/_icon-as-button.scss
+++ b/src/components/icon-as-button/_icon-as-button.scss
@@ -61,7 +61,6 @@ $includeHtml: false !default;
     display: inline-flex;
     background: none;
     border: none;
-    outline: none;
     padding: 0;
     cursor: pointer;
     overflow: visible;

--- a/src/components/icon-as-button/_icon-as-button.scss
+++ b/src/components/icon-as-button/_icon-as-button.scss
@@ -45,12 +45,10 @@ $includeHtml: false !default;
   }
 
   &.sg-icon-as-button--action {
-    @media (hover: none) {
-      &:active {
-        &.sg-icon-as-button--#{$modifierName} {
-          fill: $actionForegroundColor;
-          background: $color;
-        }
+    &:active {
+      &.sg-icon-as-button--#{$modifierName} {
+        fill: $actionForegroundColor;
+        background: $color;
       }
     }
 
@@ -161,11 +159,9 @@ $includeHtml: false !default;
       transition: background 0.3s ease-out, fill 0.3s ease-out;
       border-radius: 50%;
 
-      @media (hover: none) {
         &:active {
           background: $iconAsButtonTransparentColor;
         }
-      }
 
       @media (hover: hover) {
         &:hover {

--- a/src/components/icon-as-button/_icon-as-button.scss
+++ b/src/components/icon-as-button/_icon-as-button.scss
@@ -29,7 +29,12 @@ $includeHtml: false !default;
   &.sg-icon-as-button--#{$modifierName} {
     fill: $color;
 
-    &:hover,
+    @media (hover: hover) {
+      &:hover {
+        fill: $colorActive;
+      }
+    }
+
     &:active {
       fill: $colorActive;
     }
@@ -40,10 +45,21 @@ $includeHtml: false !default;
   }
 
   &.sg-icon-as-button--action {
-    &:hover {
-      &.sg-icon-as-button--#{$modifierName} {
-        fill: $actionForegroundColor;
-        background: $color;
+    @media (hover: none) {
+      &:active {
+        &.sg-icon-as-button--#{$modifierName} {
+          fill: $actionForegroundColor;
+          background: $color;
+        }
+      }
+    }
+
+    @media (hover: hover) {
+      &:hover {
+        &.sg-icon-as-button--#{$modifierName} {
+          fill: $actionForegroundColor;
+          background: $color;
+        }
       }
     }
   }
@@ -66,9 +82,14 @@ $includeHtml: false !default;
     overflow: visible;
     fill: $iconAsButtonColor;
 
-    &:hover,
     &:active {
       fill: $iconAsButtonActiveColor;
+    }
+
+    @media (hover: hover) {
+      &:hover {
+        fill: $iconAsButtonActiveColor;
+      }
     }
 
     &__hole {
@@ -140,8 +161,16 @@ $includeHtml: false !default;
       transition: background 0.3s ease-out, fill 0.3s ease-out;
       border-radius: 50%;
 
-      &:hover {
-        background: $iconAsButtonTransparentColor;
+      @media (hover: none) {
+        &:active {
+          background: $iconAsButtonTransparentColor;
+        }
+      }
+
+      @media (hover: hover) {
+        &:hover {
+          background: $iconAsButtonTransparentColor;
+        }
       }
     }
 
@@ -149,10 +178,6 @@ $includeHtml: false !default;
       background: $iconAsButtonColor;
       fill: $iconAsButtonActionColor;
       border-radius: 50%;
-
-      &:hover {
-        fill: $iconAsButtonActionColor;
-      }
 
       &.sg-icon-as-button--adaptive {
         fill: inherit;

--- a/src/components/icon-as-button/_icon-as-button.scss
+++ b/src/components/icon-as-button/_icon-as-button.scss
@@ -159,9 +159,9 @@ $includeHtml: false !default;
       transition: background 0.3s ease-out, fill 0.3s ease-out;
       border-radius: 50%;
 
-        &:active {
-          background: $iconAsButtonTransparentColor;
-        }
+      &:active {
+        background: $iconAsButtonTransparentColor;
+      }
 
       @media (hover: hover) {
         &:hover {

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -24,7 +24,6 @@
     border: none;
     padding: 0;
     margin-left: 6px;
-    outline: none;
   }
 
   &--black {

--- a/src/components/round-buttons/_round-buttons.scss
+++ b/src/components/round-buttons/_round-buttons.scss
@@ -40,7 +40,6 @@ $colorSetup: (
   align-items: center;
   background: none;
   border: none;
-  outline: none;
   padding: 0;
   cursor: pointer;
   overflow: visible;


### PR DESCRIPTION
- remove ```outline: none``` property
- fix hover in IconAsButton on touch devices: change css on `active` instead of `hover` -> hover state stays after mouse click on mobile and it should be visible only during click

Before:
![old](https://user-images.githubusercontent.com/39903772/73360889-23263e00-42a4-11ea-979f-73ac8d2759df.gif)

After:
![new](https://user-images.githubusercontent.com/39903772/73360903-27525b80-42a4-11ea-89ce-c042dbb4c5e3.gif)
