### PR TITLE
add onKeyDown prop, role and tabIndex to close Icon in TopLayer

### DIFF
--- a/src/components/toplayer/TopLayer.jsx
+++ b/src/components/toplayer/TopLayer.jsx
@@ -16,7 +16,9 @@ export const SIZE = {
 export type PropsType = {
   children: Node,
   onClose?: (SyntheticMouseEvent<HTMLDivElement>) => mixed,
-  onKeyDown?: (SyntheticMouseEvent<HTMLDivElement>) => mixed,
+  onCloseButtonKeyDown?: (
+    event: SyntheticKeyboardEvent<HTMLInputElement>
+  ) => mixed,
   lead?: boolean,
   fill?: boolean,
   modal?: boolean,
@@ -48,7 +50,7 @@ const TopLayer = (props: PropsType) => {
     noPadding,
     transparent,
     className,
-    onKeyDown,
+    onCloseButtonKeyDown,
     ...additionalProps
   } = props;
 
@@ -79,7 +81,7 @@ const TopLayer = (props: PropsType) => {
         <div
           className="sg-toplayer__close"
           onClick={onClose}
-          onKeyDown={onKeyDown}
+          onKeyDown={onCloseButtonKeyDown}
           role="button"
           tabIndex="0"
         >

--- a/src/components/toplayer/TopLayer.jsx
+++ b/src/components/toplayer/TopLayer.jsx
@@ -16,6 +16,7 @@ export const SIZE = {
 export type PropsType = {
   children: Node,
   onClose?: (SyntheticMouseEvent<HTMLDivElement>) => mixed,
+  onKeyDown?: (SyntheticMouseEvent<HTMLDivElement>) => mixed,
   lead?: boolean,
   fill?: boolean,
   modal?: boolean,
@@ -47,6 +48,7 @@ const TopLayer = (props: PropsType) => {
     noPadding,
     transparent,
     className,
+    onKeyDown,
     ...additionalProps
   } = props;
 
@@ -74,7 +76,13 @@ const TopLayer = (props: PropsType) => {
   return (
     <div {...additionalProps} className={topLayerClassName}>
       {onClose ? (
-        <div className="sg-toplayer__close" onClick={onClose}>
+        <div
+          className="sg-toplayer__close"
+          onClick={onClose}
+          onKeyDown={onKeyDown}
+          role="button"
+          tabIndex="0"
+        >
           <Icon type="close" color="gray-secondary" size={24} />
         </div>
       ) : null}

--- a/src/components/toplayer/TopLayer.spec.jsx
+++ b/src/components/toplayer/TopLayer.spec.jsx
@@ -38,6 +38,17 @@ test('click action', () => {
   expect(mockCallback.mock.calls).toHaveLength(1);
 });
 
+test('key down action', () => {
+  const mockCallback = jest.fn();
+  const topLayer = mount(
+    <TopLayer onClose={mockCallback} onKeyDown={mockCallback} />
+  );
+  const button = topLayer.find('.sg-toplayer__close');
+
+  button.simulate('keyDown');
+  expect(mockCallback.mock.calls).toHaveLength(1);
+});
+
 test('size', () => {
   const size = SIZE.SMALL;
   const topLayer = shallow(<TopLayer size={size}>some text</TopLayer>);

--- a/src/components/toplayer/TopLayer.spec.jsx
+++ b/src/components/toplayer/TopLayer.spec.jsx
@@ -41,7 +41,7 @@ test('click action', () => {
 test('key down action', () => {
   const mockCallback = jest.fn();
   const topLayer = mount(
-    <TopLayer onClose={mockCallback} onKeyDown={mockCallback} />
+    <TopLayer onClose={mockCallback} onCloseButtonKeyDown={mockCallback} />
   );
   const button = topLayer.find('.sg-toplayer__close');
 


### PR DESCRIPTION
add onKeyDown prop, role and tabIndex to close Icon in TopLayer for accessibility reasons