### PR TITLE
Add default cursor to Label

### DIFF
--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -5,6 +5,7 @@
   height: 24px;
   border-radius: 6px;
   padding: spacing(xs);
+  cursor: default;
 
   &__icon {
     margin-right: spacing(xs);


### PR DESCRIPTION
fixes: https://github.com/brainly/style-guide/issues/1738

## after
![labels-cursor-default mov](https://user-images.githubusercontent.com/1231144/76502566-7dd6bc00-6444-11ea-9418-a7c4b2b9804d.gif)


## before
![labels-current mov](https://user-images.githubusercontent.com/1231144/76502552-7adbcb80-6444-11ea-9cdc-2587707a5698.gif)