### PR TITLE
Add default cursor to Counter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "158.1.0",
+  "version": "158.1.1",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/counters/_counters.scss
+++ b/src/components/counters/_counters.scss
@@ -11,6 +11,7 @@ $includeHtml: false !default;
     justify-content: center;
     align-content: center;
     background-color: $peachPrimary;
+    cursor: default;
 
     &__text {
       position: relative;


### PR DESCRIPTION
fixing the same issue that we had with `Label`: https://github.com/brainly/style-guide/pull/1740 

no visual changes:
<img width="493" alt="Screenshot 2020-03-12 at 10 52 47" src="https://user-images.githubusercontent.com/1231144/76509102-c5167a00-644f-11ea-816f-d4155035ed71.png">
