### PR TITLE
Improve accessibility of selects

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "158.1.1",
+  "version": "158.2.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -80,9 +80,7 @@ $includeHtml: false !default;
           $graySecondaryLight,
           80%
         );
-        border: 2px
-          solid
-          mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
+        border: 2px solid mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
       }
     }
 
@@ -100,7 +98,6 @@ $includeHtml: false !default;
         height: $formElementLargeHeight;
         font-size: $formElementLargeFontSize;
         border-radius: $formElementLargeBorderRadius;
-        font-size: $formElementLargeFontSize;
         height: $formElementLargeHeight;
         padding: 0 50px 0 spacing(m);
 

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -4,28 +4,20 @@ $includeHtml: false !default;
   .sg-select {
     display: inline-block;
     position: relative;
-    overflow: hidden;
     text-overflow: ellipsis;
     margin: 0;
-    font-size: $formElementDefaultFontSize;
-    color: $formElementPlacholderTextColor;
-    border-radius: $formElementStandardBorderRadius;
-    height: $formElementNormalHeight;
-    border: 2px solid $graySecondaryLightest;
 
     &__element {
-      position: relative;
-      top: $borderRelatedVariable;
-      background: $formElementDefaultBackgroundColor;
-      border-radius: $borderRadiusDefault;
-      font-size: inherit;
       display: inline-block;
-      height: $formElementNormalHeight;
       padding: 0 36px 0 spacing(s);
-      outline: 0;
       appearance: none;
       width: 100%;
       border: 2px solid $graySecondaryLightest;
+      font-size: $formElementDefaultFontSize;
+      color: $formElementPlacholderTextColor;
+      height: $formElementNormalHeight;
+      background: $formElementDefaultBackgroundColor;
+      border-radius: $formElementStandardBorderRadius;
 
       &::-ms-expand {
         display: none;
@@ -40,7 +32,7 @@ $includeHtml: false !default;
 
     &__icon {
       position: absolute;
-      top: spacing(xs) + 2px;
+      top: spacing(xs) + 4px;
       right: spacing(xs) + 4px;
       pointer-events: none;
       z-index: 1;
@@ -48,35 +40,32 @@ $includeHtml: false !default;
     }
 
     &--white {
-      background: $white;
-      border: 2px solid $white;
-
       .sg-select__element {
         background: $white;
         border: 2px solid $white;
-
       }
     }
 
     &.sg-select--white {
       &.sg-select--valid {
         &:hover {
-          background-color: mix($white, $graySecondaryUltraLight, 12%);
-          border: 2px solid $formElementValidColor;
+          .sg-select__element {
+            background-color: mix($white, $graySecondaryUltraLight, 12%);
+            border: 2px solid $formElementValidColor;
+          }
         }
       }
 
       &.sg-select--invalid {
         &:hover {
-          background-color: mix($white, $graySecondaryUltraLight, 12%);
-          border: 2px solid $formElementInvalidColor;
+          .sg-select__element {
+            background-color: mix($white, $graySecondaryUltraLight, 12%);
+            border: 2px solid $formElementInvalidColor;
+          }
         }
       }
 
       &:hover {
-        background-color: mix($white, $graySecondaryUltraLight, 12%);
-        border: 2px solid mix($white, $graySecondaryUltraLight, 12%);
-
         .sg-select__element {
           background-color: mix($white, $graySecondaryUltraLight, 12%);
           border: 2px solid mix($white, $graySecondaryUltraLight, 12%);
@@ -85,12 +74,15 @@ $includeHtml: false !default;
     }
 
     &:hover {
-      background-color: mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
-      border: 2px solid mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
-
       .sg-select__element {
-        background-color: mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
-        border: 2px solid mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
+        background-color: mix(
+          $formElementDefaultBackgroundColor,
+          $graySecondaryLight,
+          80%
+        );
+        border: 2px
+          solid
+          mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
       }
     }
 
@@ -99,18 +91,14 @@ $includeHtml: false !default;
     }
 
     &--large {
-      height: $formElementLargeHeight;
-      font-size: $formElementLargeFontSize;
-      border-radius: $formElementLargeBorderRadius;
-
       .sg-select__icon {
-        right: spacing(s);
         top: spacing(s);
+        right: spacing(s);
       }
 
       .sg-select__element {
-        position: relative;
-        top: $borderRelatedVariable;
+        height: $formElementLargeHeight;
+        font-size: $formElementLargeFontSize;
         border-radius: $formElementLargeBorderRadius;
         font-size: $formElementLargeFontSize;
         height: $formElementLargeHeight;
@@ -127,42 +115,40 @@ $includeHtml: false !default;
     }
 
     &--valid {
-      border: 2px solid $formElementValidColor;
-      color: $black;
-      font-weight: normal;
-
-      &:focus,
-      &:active,
-      &:focus:hover,
-      &:active:hover {
-        background-color: $white;
+      .sg-select__element {
+        color: $black;
+        font-weight: normal;
         border: 2px solid $formElementValidColor;
-        box-shadow: none;
       }
 
       &:hover {
-        background-color: mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
-        border: 2px solid $formElementValidColor;
+        .sg-select__element {
+          background-color: mix(
+            $formElementDefaultBackgroundColor,
+            $graySecondaryLight,
+            80%
+          );
+          border: 2px solid $formElementValidColor;
+        }
       }
     }
 
     &--invalid {
-      border: 2px solid $formElementInvalidColor;
-      color: $black;
-      font-weight: normal;
-
-      &:focus,
-      &:active,
-      &:focus:hover,
-      &:active:hover {
-        background-color: $white;
+      .sg-select__element {
+        color: $black;
+        font-weight: normal;
         border: 2px solid $formElementInvalidColor;
-        box-shadow: none;
       }
 
       &:hover {
-        background-color: mix($formElementDefaultBackgroundColor, $graySecondaryLight, 80%);
-        border: 2px solid $formElementInvalidColor;
+        .sg-select__element {
+          background-color: mix(
+            $formElementDefaultBackgroundColor,
+            $graySecondaryLight,
+            80%
+          );
+          border: 2px solid $formElementInvalidColor;
+        }
       }
     }
 

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -98,7 +98,6 @@ $includeHtml: false !default;
         height: $formElementLargeHeight;
         font-size: $formElementLargeFontSize;
         border-radius: $formElementLargeBorderRadius;
-        height: $formElementLargeHeight;
         padding: 0 50px 0 spacing(m);
 
         &::-ms-expand {

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -138,4 +138,3 @@ $formElementValidColor: $mintPrimary;
 $formElementInvalidColor: $peachPrimary;
 $formElementStandardBorderRadius: 20px;
 $formElementLargeBorderRadius: 28px;
-$borderRelatedVariable: -2px;


### PR DESCRIPTION
- native `select` element gets proper focus and outline (it was hidden earlier)
- `sg-select` becomes just a container, no more styling needed
- almost no visual changes (removing border from container makes it 2px more narrow)
- tested on various devices

## after

<img width="1016" alt="Screenshot 2020-03-13 at 09 59 13" src="https://user-images.githubusercontent.com/1231144/76605893-8d700680-6511-11ea-9bad-c11765dc6607.png">
<img width="1027" alt="Screenshot 2020-03-13 at 09 59 21" src="https://user-images.githubusercontent.com/1231144/76605897-906af700-6511-11ea-8edc-4575684e6fca.png">

## before
<img width="1014" alt="Screenshot 2020-03-13 at 09 59 30" src="https://user-images.githubusercontent.com/1231144/76605898-91038d80-6511-11ea-9387-3c51eec1f57b.png">
