### PR TITLE
Define line-height in Select

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "159.0.1",
+  "version": "159.0.2",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -16,6 +16,7 @@ $includeHtml: false !default;
       font-size: $formElementDefaultFontSize;
       color: $formElementPlacholderTextColor;
       height: $formElementNormalHeight;
+      line-height: $formElementNormalHeight - 4px; // subtraction due to top and bottom border
       background: $formElementDefaultBackgroundColor;
       border-radius: $formElementStandardBorderRadius;
 
@@ -96,6 +97,7 @@ $includeHtml: false !default;
 
       .sg-select__element {
         height: $formElementLargeHeight;
+        line-height: $formElementLargeHeight - 4px; // subtraction due to top and bottom border
         font-size: $formElementLargeFontSize;
         border-radius: $formElementLargeBorderRadius;
         padding: 0 50px 0 spacing(m);


### PR DESCRIPTION
fixes: https://github.com/brainly/style-guide/issues/1748

It was an issues when `<Select />` was wrapped into `<ActionList />` (line-height: 0 😢 )

no visual changes