### PR TITLE
Fix iconType of RoundButtons on Interactive page

### DIFF
--- a/src/components/round-buttons/pages/round-buttons-interactive.jsx
+++ b/src/components/round-buttons/pages/round-buttons-interactive.jsx
@@ -21,7 +21,7 @@ const RoundButtons = () => {
       values: ROUND_BUTTON_COLOR,
     },
     {
-      name: 'icon',
+      name: 'iconType',
       values: ROUND_BUTTON_ICON_TYPE,
       required: true,
     },

--- a/src/docs/page-components.jsx
+++ b/src/docs/page-components.jsx
@@ -48,7 +48,7 @@ const demos = {
   Avatars: <Avatars />,
   Bubbles: <Bubbles />,
   Buttons: <Buttons />,
-  RoundButtons: <RoundButtons />,
+  'Round Buttons': <RoundButtons />,
   Counters: <Counters />,
   'Icon as a button': <IconsAsButtons />,
   'Subject icons': <SubjectIcons />,


### PR DESCRIPTION
there was no way to change an icon of RoundButton due to wrong prop name in settings.

## after

<img width="1011" alt="Screenshot 2020-03-24 at 08 10 35" src="https://user-images.githubusercontent.com/1231144/77398121-2ff87700-6da7-11ea-842b-fe674eb23f87.png">
<img width="1003" alt="Screenshot 2020-03-24 at 08 11 08" src="https://user-images.githubusercontent.com/1231144/77398130-338bfe00-6da7-11ea-85f7-9b54c9c49a0e.png">

## before

<img width="1009" alt="Screenshot 2020-03-24 at 08 10 48" src="https://user-images.githubusercontent.com/1231144/77398127-325ad100-6da7-11ea-82ec-235b443344e9.png">
<img width="1000" alt="Screenshot 2020-03-24 at 08 10 54" src="https://user-images.githubusercontent.com/1231144/77398129-32f36780-6da7-11ea-97e0-f636d5b0c1b7.png">
