### PR TITLE
Add solid-light and transparent-light buttons

### DIFF
--- a/src/components/buttons/Button.jsx
+++ b/src/components/buttons/Button.jsx
@@ -15,8 +15,10 @@ export const BUTTON_TYPE = Object.freeze({
   SOLID_INVERTED: 'solid-inverted',
   SOLID_BLUE: 'solid-blue',
   SOLID_MINT: 'solid-mint',
+  SOLID_LIGHT: 'solid-light',
   OUTLINE: 'outline',
   TRANSPARENT: 'transparent',
+  TRANSPARENT_LIGHT: 'transparent-light',
   TRANSPARENT_INVERTED: 'transparent-inverted',
   TRANSPARENT_PEACH: 'transparent-peach',
   TRANSPARENT_MUSTRAD: 'transparent-mustard',
@@ -28,8 +30,10 @@ type ButtonTypeType =
   | 'solid-inverted'
   | 'solid-blue'
   | 'solid-mint'
+  | 'solid-light'
   | 'outline'
   | 'transparent'
+  | 'transparent-light'
   | 'transparent-inverted'
   | 'transparent-peach'
   | 'transparent-mustard'

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -106,8 +106,14 @@
   }
 
   &--solid-mint {
-    @include buttonHover($mintPrimaryDark, $mintPrimary, 80%);
+    @include buttonHover($graySecondaryLight, $mintPrimary, 80%);
     background-color: $mintPrimary;
+  }
+
+  &--solid-light {
+    @include buttonHover($graySecondaryLight, $graySecondaryLightest, 20%);
+    background-color: $graySecondaryLightest;
+    color: $black;
   }
 
   &--outline {
@@ -121,6 +127,12 @@
     @include buttonHover($black, $transparent, 12%);
     background-color: $transparent;
     color: $black;
+  }
+
+  &--transparent-light {
+    @include buttonHover($black, $transparent, 12%);
+    background-color: $transparent;
+    color: $graySecondary;
   }
 
   &--transparent-inverted {
@@ -142,6 +154,7 @@
   }
 
   &--transparent,
+  &--transparent-light,
   &--transparent-inverted,
   &--transparent-peach,
   &--transparent-mustard {

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -106,7 +106,7 @@
   }
 
   &--solid-mint {
-    @include buttonHover($graySecondaryLight, $mintPrimary, 80%);
+    @include buttonHover($mintPrimaryDark, $mintPrimary, 80%);
     background-color: $mintPrimary;
   }
 

--- a/src/components/buttons/pages/buttons.jsx
+++ b/src/components/buttons/pages/buttons.jsx
@@ -15,6 +15,7 @@ function getValues(object, addUndefined = true) {
 const getIconColor = type => {
   if (
     type === 'solid-inverted' ||
+    type === 'solid-light' ||
     type === 'outline' ||
     type === 'transparent'
   ) {
@@ -23,6 +24,8 @@ const getIconColor = type => {
     return 'peach';
   } else if (type === 'transparent-mustard') {
     return 'mustard';
+  } else if (type === 'transparent-light') {
+    return 'gray-secondary';
   } else {
     return 'light';
   }

--- a/src/docs/_sass/_docs-buttons.scss
+++ b/src/docs/_sass/_docs-buttons.scss
@@ -15,11 +15,19 @@
     @include sgButtonHoverMix($mintPrimaryDark, $mintPrimary, 80%);
   }
 
+  &--solid-light {
+    @include sgButtonHoverMix($graySecondaryLight, $graySecondaryLightest, 20%);
+  }
+
   &--outline {
     @include sgButtonHoverMix($black, $transparent, 12%);
   }
 
   &--transparent {
+    @include sgButtonHoverMix($black, $transparent, 12%);
+  }
+
+  &--transparent-light {
     @include sgButtonHoverMix($black, $transparent, 12%);
   }
 


### PR DESCRIPTION
Two new types of buttons are introduced here:
- `solid-light`
- `transparent-light`

<img width="1012" alt="Screenshot 2020-04-08 at 10 03 43" src="https://user-images.githubusercontent.com/1231144/78759775-7097e900-7980-11ea-8505-fed8947bab7e.png">

design handoff: https://app.abstract.com/share/080a3c15-fcf8-4321-9435-a3af0a6d5719?collectionLayerId=b1a1b979-1408-4105-97e5-38858f5008e3&mode=build&selected=root-0952A77D-837A-4003-B99B-27C29F492040&sha=6674e6d6c3b6e9f1da9e6803cfc88f90a6631ac6 (non-public access)