### PR TITLE
Update hover color of outline and transparent buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "161.1.0",
+  "version": "161.2.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -30,6 +30,7 @@
   transition-timing-function: ease-in-out;
   cursor: pointer;
   box-sizing: border-box;
+  fill: $white;
 
   &__text {
     position: relative;
@@ -38,7 +39,6 @@
   }
 
   &__icon {
-    fill: $white;
     display: inline-flex;
     margin-right: spacing(xs);
     margin-left: -4px;
@@ -98,6 +98,7 @@
     @include buttonHover($graySecondaryUltraLight, $white, 80%);
     background-color: $white;
     color: $black;
+    fill: $black;
   }
 
   &--solid-blue {
@@ -114,25 +115,29 @@
     @include buttonHover($graySecondaryLight, $graySecondaryLightest, 20%);
     background-color: $graySecondaryLightest;
     color: $black;
+    fill: $black;
   }
 
   &--outline {
-    @include buttonHover($black, $transparent, 12%);
+    @include buttonHover($graySecondary, $transparent, 12%);
     background-color: $transparent;
     border: 2px solid $black;
     color: $black;
+    fill: $black;
   }
 
   &--transparent {
-    @include buttonHover($black, $transparent, 12%);
+    @include buttonHover($graySecondary, $transparent, 12%);
     background-color: $transparent;
     color: $black;
+    fill: $black;
   }
 
   &--transparent-light {
-    @include buttonHover($black, $transparent, 12%);
+    @include buttonHover($graySecondary, $transparent, 12%);
     background-color: $transparent;
     color: $graySecondary;
+    fill: $graySecondary;
   }
 
   &--transparent-inverted {
@@ -145,12 +150,14 @@
     @include buttonHover($peachPrimary, $transparent, 12%);
     background-color: $transparent;
     color: $peachPrimary;
+    fill: $peachPrimary;
   }
 
   &--transparent-mustard {
     @include buttonHover($mustardPrimary, $transparent, 12%);
     background-color: $transparent;
     color: $mustardPrimary;
+    fill: $mustardPrimary;
   }
 
   &--transparent,

--- a/src/components/buttons/pages/buttons.jsx
+++ b/src/components/buttons/pages/buttons.jsx
@@ -12,32 +12,11 @@ function getValues(object, addUndefined = true) {
     : Object.values(object);
 }
 
-const getIconColor = type => {
-  if (
-    type === 'solid-inverted' ||
-    type === 'solid-light' ||
-    type === 'outline' ||
-    type === 'transparent'
-  ) {
-    return 'dark';
-  } else if (type === 'transparent-peach') {
-    return 'peach';
-  } else if (type === 'transparent-mustard') {
-    return 'mustard';
-  } else if (type === 'transparent-light') {
-    return 'gray-secondary';
-  } else {
-    return 'light';
-  }
-};
-
 const Buttons = () => {
   const buttonsVariants = [];
   const buttonsText = 'Button';
 
   getValues(BUTTON_TYPE, false).forEach(type => {
-    const iconColor = getIconColor(type);
-
     buttonsVariants.push(
       <DocsBlock key="type" centered fullWidth>
         <Flex
@@ -67,9 +46,7 @@ const Buttons = () => {
           <DocsBlock evenColumns justified>
             <Button
               type={type}
-              icon={
-                <Icon type={iconTypes.ANSWER} color={iconColor} size={24} />
-              }
+              icon={<Icon type={iconTypes.ANSWER} color="adaptive" size={24} />}
             >
               {buttonsText}
             </Button>

--- a/src/docs/_sass/_docs-buttons.scss
+++ b/src/docs/_sass/_docs-buttons.scss
@@ -20,15 +20,15 @@
   }
 
   &--outline {
-    @include sgButtonHoverMix($black, $transparent, 12%);
+    @include sgButtonHoverMix($graySecondary, $transparent, 12%);
   }
 
   &--transparent {
-    @include sgButtonHoverMix($black, $transparent, 12%);
+    @include sgButtonHoverMix($graySecondary, $transparent, 12%);
   }
 
   &--transparent-light {
-    @include sgButtonHoverMix($black, $transparent, 12%);
+    @include sgButtonHoverMix($graySecondary, $transparent, 12%);
   }
 
   &--transparent-inverted {


### PR DESCRIPTION
## before

<img width="604" alt="Screenshot 2020-04-10 at 09 56 45" src="https://user-images.githubusercontent.com/1231144/78976202-fd27e000-7b15-11ea-8275-3925c4be2b19.png">

## after

<img width="621" alt="Screenshot 2020-04-10 at 10 03 15" src="https://user-images.githubusercontent.com/1231144/78976206-ff8a3a00-7b15-11ea-91c6-35387d3da094.png">

additional change (no visual change in doc): make icon color (when `color="adaptive"`) to be taken from button component