### PR TITLE
Add toggle buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "161.2.1",
+  "version": "161.3.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/buttons/Button.jsx
+++ b/src/components/buttons/Button.jsx
@@ -30,20 +30,6 @@ export const BUTTON_TOGGLE = Object.freeze({
   MUSTARD: 'mustard',
 });
 
-type ButtonTypeType =
-  | 'solid'
-  | 'solid-inverted'
-  | 'solid-blue'
-  | 'solid-mint'
-  | 'solid-light'
-  | 'outline'
-  | 'transparent'
-  | 'transparent-light'
-  | 'transparent-inverted'
-  | 'transparent-peach'
-  | 'transparent-mustard'
-  | 'facebook';
-
 type ButtonSizeType = 'large' | 'medium' | 'small';
 
 type ButtonColorType =
@@ -203,6 +189,10 @@ const Button = ({
       <span className="sg-button__text">{children}</span>
     </TypeToRender>
   );
+};
+
+export const Lol = () => {
+  return <Button type="solid-light" toggle="peach" />;
 };
 
 export default Button;

--- a/src/components/buttons/Button.jsx
+++ b/src/components/buttons/Button.jsx
@@ -25,6 +25,11 @@ export const BUTTON_TYPE = Object.freeze({
   FACEBOOK: 'facebook',
 });
 
+export const BUTTON_TOGGLE = Object.freeze({
+  PEACH: 'peach',
+  MUSTARD: 'mustard',
+});
+
 type ButtonTypeType =
   | 'solid'
   | 'solid-inverted'
@@ -40,6 +45,7 @@ type ButtonTypeType =
   | 'facebook';
 
 type ButtonSizeType = 'large' | 'medium' | 'small';
+type ButtonToggleType = 'peach' | 'mustard' | null;
 
 export type ButtonPropsType = {
   /**
@@ -110,6 +116,10 @@ export type ButtonPropsType = {
    *          </Button>
    */
   fullWidth?: boolean,
+   /**
+   * UPDATE ME
+   */
+  toggle?: ButtonToggleType,
   /**
    * Additional class names
    */
@@ -124,6 +134,7 @@ const Button = ({
   href,
   fullWidth,
   disabled,
+  toggle,
   children,
   className,
   ...props
@@ -135,6 +146,7 @@ const Button = ({
       [`sg-button--${String(type)}`]: type,
       'sg-button--disabled': disabled,
       'sg-button--full-width': fullWidth,
+      [`sg-button--${String(type)}-toggle-${String(toggle)}`]: toggle,
     },
     className
   );

--- a/src/components/buttons/Button.jsx
+++ b/src/components/buttons/Button.jsx
@@ -45,9 +45,57 @@ type ButtonTypeType =
   | 'facebook';
 
 type ButtonSizeType = 'large' | 'medium' | 'small';
-type ButtonToggleType = 'peach' | 'mustard' | null;
+
+type ButtonColorType =
+  | {
+      type:
+        | 'solid'
+        | 'solid-inverted'
+        | 'solid-blue'
+        | 'solid-mint'
+        | 'transparent-inverted'
+        | 'facebook',
+      toggle?: null,
+    }
+  | {
+      type: 'solid-light' | 'outline' | 'transparent' | 'transparent-light',
+      toggle?: 'peach' | 'mustard' | null,
+    }
+  | {
+      type: 'transparent-peach',
+      toggle?: 'peach' | null,
+    }
+  | {
+      type: 'transparent-mustard',
+      toggle?: 'mustard' | null,
+    };
 
 export type ButtonPropsType = {
+  /**
+   * type: Specify type of the button that you want to use
+   * @example <Button type="solid">
+   *            button
+   *          </Button>
+   * @see type="solid" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid"#buttons
+   * @see type="solid-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-inverted"#buttons
+   * @see type="solid-blue" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-blue"#buttons
+   * @see type="solid-mint" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-mint"#buttons
+   * @see type="solid-light" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-light"#buttons
+   * @see type="outline" https://styleguide.brainly.com/latest/docs/interactive.html?type="outline"#buttons
+   * @see type="transparent" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent"#buttons
+   * @see type="transparent-light" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-light"#buttons
+   * @see type="transparent-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-inverted"#buttons
+   * @see type="transparent-peach" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-peach"#buttons
+   * @see type="transparent-mustard" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-mustard"#buttons
+   * @see type="facebook" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-inverted"#buttons
+   *
+   * toggle: optional union available just for selected type of buttons
+   *
+   * @example <Button type="solid-light" toggle="peach">
+   *            button
+   *          </Button>
+   */
+  ...ButtonColorType,
   /**
    * Children to be rendered inside Button
    * @example <Button
@@ -58,23 +106,6 @@ export type ButtonPropsType = {
    *          </Button>
    */
   children?: Node,
-  /**
-   * Specify type of the button that you want to use
-   * @example <Button type="solid">
-   *            button
-   *          </Button>
-   * @see type="solid" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid"#buttons
-   * @see type="solid-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-inverted"#buttons
-   * @see type="solid-blue" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-blue"#buttons
-   * @see type="solid-mint" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-mint"#buttons
-   * @see type="outline" https://styleguide.brainly.com/latest/docs/interactive.html?type="outline"#buttons
-   * @see type="transparent" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent"#buttons
-   * @see type="transparent-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-inverted"#buttons
-   * @see type="transparent-peach" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-peach"#buttons
-   * @see type="transparent-mustard" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-mustard"#buttons
-   * @see type="facebook" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-inverted"#buttons
-   */
-  type: ButtonTypeType,
   /**
    * You can render icon inside each type of button on the left side
    * @example <Button
@@ -116,10 +147,6 @@ export type ButtonPropsType = {
    *          </Button>
    */
   fullWidth?: boolean,
-   /**
-   * UPDATE ME
-   */
-  toggle?: ButtonToggleType,
   /**
    * Additional class names
    */

--- a/src/components/buttons/Button.jsx
+++ b/src/components/buttons/Button.jsx
@@ -19,9 +19,9 @@ export const BUTTON_TYPE = Object.freeze({
   OUTLINE: 'outline',
   TRANSPARENT: 'transparent',
   TRANSPARENT_LIGHT: 'transparent-light',
-  TRANSPARENT_INVERTED: 'transparent-inverted',
   TRANSPARENT_PEACH: 'transparent-peach',
   TRANSPARENT_MUSTRAD: 'transparent-mustard',
+  TRANSPARENT_INVERTED: 'transparent-inverted',
   FACEBOOK: 'facebook',
 });
 
@@ -178,13 +178,9 @@ const Button = ({
     className
   );
 
-  const iconClass = cx(
-    'sg-button__icon',
-    {
-      [`sg-button__icon--${size || ''}`]: size,
-    },
-    className
-  );
+  const iconClass = cx('sg-button__icon', {
+    [`sg-button__icon--${size || ''}`]: size,
+  });
 
   let ico;
 

--- a/src/components/buttons/Button.spec.jsx
+++ b/src/components/buttons/Button.spec.jsx
@@ -59,3 +59,13 @@ test('no icon', () => {
 
   expect(button.find('.sg-button__icon')).toHaveLength(0);
 });
+
+test('toggle', () => {
+  const button = shallow(
+    <Button type="solid-light" toggle="peach">
+      Some text
+    </Button>
+  );
+
+  expect(button.hasClass('sg-button--solid-light-toggle-peach')).toEqual(true);
+});

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -116,6 +116,16 @@
     background-color: $graySecondaryLightest;
     color: $black;
     fill: $black;
+
+    &-toggle-peach {
+      background-color: $peachSecondaryLight;
+      fill: $peachPrimary;
+    }
+
+    &-toggle-mustard {
+      background-color: $mustardSecondaryLight;
+      fill: $mustardPrimary;
+    }
   }
 
   &--outline {
@@ -124,6 +134,16 @@
     border: 2px solid $black;
     color: $black;
     fill: $black;
+
+    &-toggle-peach {
+      border-color: $peachPrimary;
+      fill: $peachPrimary;
+    }
+
+    &-toggle-mustard {
+      border-color: $mustardPrimary;
+      fill: $mustardPrimary;
+    }
   }
 
   &--transparent {
@@ -131,6 +151,14 @@
     background-color: $transparent;
     color: $black;
     fill: $black;
+
+    &-toggle-peach {
+      fill: $peachPrimary;
+    }
+
+    &-toggle-mustard {
+      fill: $mustardPrimary;
+    }
   }
 
   &--transparent-light {
@@ -138,12 +166,21 @@
     background-color: $transparent;
     color: $graySecondary;
     fill: $graySecondary;
+
+    &-toggle-peach {
+      fill: $peachPrimary;
+    }
+
+    &-toggle-mustard {
+      fill: $mustardPrimary;
+    }
   }
 
   &--transparent-inverted {
     @include buttonHover($white, $transparent, 12%);
     background-color: $transparent;
     color: $white;
+    fill: $white;
   }
 
   &--transparent-peach {
@@ -151,6 +188,10 @@
     background-color: $transparent;
     color: $peachPrimary;
     fill: $peachPrimary;
+
+    &-toggle-peach {
+      background-color: mix($peachPrimary, $transparent, 12%);
+    }
   }
 
   &--transparent-mustard {
@@ -158,6 +199,10 @@
     background-color: $transparent;
     color: $mustardPrimary;
     fill: $mustardPrimary;
+
+    &-toggle-mustard {
+      background-color: mix($mustardPrimary, $transparent, 12%);
+    }
   }
 
   &--transparent,

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -118,13 +118,13 @@
     fill: $black;
 
     &-toggle-peach {
-      @include buttonHover($peachSecondary, $peachSecondaryLight, 12%);
+      @include buttonHover($peachPrimary, $peachSecondaryLight, 12%);
       background-color: $peachSecondaryLight;
       fill: $peachPrimary;
     }
 
     &-toggle-mustard {
-      @include buttonHover($mustardSecondary, $mustardSecondaryLight, 12%);
+      @include buttonHover($mustardPrimary, $mustardSecondaryLight, 12%);
       background-color: $mustardSecondaryLight;
       fill: $mustardPrimary;
     }

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -112,17 +112,19 @@
   }
 
   &--solid-light {
-    @include buttonHover($graySecondaryLight, $graySecondaryLightest, 20%);
+    @include buttonHover($graySecondaryLight, $graySecondaryLightest, 12%);
     background-color: $graySecondaryLightest;
     color: $black;
     fill: $black;
 
     &-toggle-peach {
+      @include buttonHover($peachSecondary, $peachSecondaryLight, 12%);
       background-color: $peachSecondaryLight;
       fill: $peachPrimary;
     }
 
     &-toggle-mustard {
+      @include buttonHover($mustardSecondary, $mustardSecondaryLight, 12%);
       background-color: $mustardSecondaryLight;
       fill: $mustardPrimary;
     }
@@ -136,11 +138,13 @@
     fill: $black;
 
     &-toggle-peach {
+      @include buttonHover($peachPrimary, $transparent, 12%);
       border-color: $peachPrimary;
       fill: $peachPrimary;
     }
 
     &-toggle-mustard {
+      @include buttonHover($mustardPrimary, $transparent, 12%);
       border-color: $mustardPrimary;
       fill: $mustardPrimary;
     }
@@ -153,10 +157,12 @@
     fill: $black;
 
     &-toggle-peach {
+      @include buttonHover($peachPrimary, $transparent, 12%);
       fill: $peachPrimary;
     }
 
     &-toggle-mustard {
+      @include buttonHover($mustardPrimary, $transparent, 12%);
       fill: $mustardPrimary;
     }
   }
@@ -168,10 +174,12 @@
     fill: $graySecondary;
 
     &-toggle-peach {
+      @include buttonHover($peachPrimary, $transparent, 12%);
       fill: $peachPrimary;
     }
 
     &-toggle-mustard {
+      @include buttonHover($mustardPrimary, $transparent, 12%);
       fill: $mustardPrimary;
     }
   }
@@ -190,7 +198,7 @@
     fill: $peachPrimary;
 
     &-toggle-peach {
-      background-color: mix($peachPrimary, $transparent, 12%);
+      @include buttonHover($peachPrimary, $transparent, 12%);
     }
   }
 
@@ -201,7 +209,7 @@
     fill: $mustardPrimary;
 
     &-toggle-mustard {
-      background-color: mix($mustardPrimary, $transparent, 12%);
+      @include buttonHover($mustardPrimary, $transparent, 12%);
     }
   }
 

--- a/src/components/buttons/pages/buttons-interactive.jsx
+++ b/src/components/buttons/pages/buttons-interactive.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import Button, {BUTTON_TYPE, BUTTON_SIZE} from '../Button';
+import Button, {BUTTON_TYPE, BUTTON_SIZE, BUTTON_TOGGLE} from '../Button';
 import ButtonRound from '../ButtonRound';
 import Icon, {TYPE as ICON_TYPES, ICON_COLOR} from 'icons/Icon';
 import DocsActiveBlock from 'components/DocsActiveBlock';
@@ -44,6 +44,10 @@ const Buttons = () => {
     {
       name: 'icon',
       values: allIcons,
+    },
+    {
+      name: 'toggle',
+      values: BUTTON_TOGGLE,
     },
     {
       name: 'href',

--- a/src/components/buttons/pages/buttons.jsx
+++ b/src/components/buttons/pages/buttons.jsx
@@ -21,7 +21,7 @@ const Buttons = () => {
     'transparent',
     'transparent-light',
   ];
-
+  // eslint-disable-next-line react/prop-types
   const getToggleButtons = ({type, hover = false} = {}) => (
     <>
       {[...someButtonsWithToggle, 'transparent-peach'].includes(type) && (

--- a/src/components/buttons/pages/buttons.jsx
+++ b/src/components/buttons/pages/buttons.jsx
@@ -51,6 +51,54 @@ const Buttons = () => {
               {buttonsText}
             </Button>
           </DocsBlock>
+          <DocsBlock evenColumns justified>
+            <Flex direction="column">
+              {[
+                'solid-light',
+                'outline',
+                'transparent',
+                'transparent-light',
+                'transparent-peach',
+              ].includes(type) && (
+                <Button
+                  type={type}
+                  toggle="peach"
+                  icon={
+                    <Icon type={iconTypes.ANSWER} color="adaptive" size={24} />
+                  }
+                  style={{marginBottom: '12px'}}
+                >
+                  {buttonsText}
+                </Button>
+              )}
+
+              {[
+                'solid-light',
+                'outline',
+                'transparent',
+                'transparent-light',
+                'transparent-mustard',
+              ].includes(type) && (
+                <Button
+                  type={type}
+                  toggle="mustard"
+                  icon={
+                    <Icon type={iconTypes.ANSWER} color="adaptive" size={24} />
+                  }
+                >
+                  {buttonsText}
+                </Button>
+              )}
+              {![
+                'solid-light',
+                'outline',
+                'transparent',
+                'transparent-light',
+                'transparent-peach',
+                'transparent-mustard',
+              ].includes(type) && '-'}
+            </Flex>
+          </DocsBlock>
         </Flex>
       </DocsBlock>
     );
@@ -73,6 +121,9 @@ const Buttons = () => {
         </DocsBlock>
         <DocsBlock evenColumns justified>
           <Text>with icon</Text>
+        </DocsBlock>
+        <DocsBlock evenColumns justified>
+          <Text>toggle</Text>
         </DocsBlock>
       </DocsBlock>
       {buttonsVariants}

--- a/src/components/buttons/pages/buttons.jsx
+++ b/src/components/buttons/pages/buttons.jsx
@@ -3,7 +3,7 @@ import hex from '../../colors/hex';
 import Button, {BUTTON_TYPE} from '../Button';
 import DocsBlock from 'components/DocsBlock';
 import Flex from '../../flex/Flex';
-import Icon, {TYPE as iconTypes} from 'icons/Icon';
+import Icon from 'icons/Icon';
 import Text from '../../text/Text';
 
 function getValues(object, addUndefined = true) {
@@ -22,6 +22,35 @@ const Buttons = () => {
     'transparent-light',
   ];
 
+  const getToggleButtons = ({type, hover = false} = {}) => (
+    <>
+      {[...someButtonsWithToggle, 'transparent-peach'].includes(type) && (
+        <Button
+          type={type}
+          toggle="peach"
+          icon={<Icon type="heart" color="adaptive" size={24} />}
+          style={{marginBottom: '12px'}}
+          className={hover ? `docs-button-hovered--${type}-toggle-peach` : null}
+        >
+          {buttonsText}
+        </Button>
+      )}
+
+      {[...someButtonsWithToggle, 'transparent-mustard'].includes(type) && (
+        <Button
+          type={type}
+          toggle="mustard"
+          icon={<Icon type="heart" color="adaptive" size={24} />}
+          className={
+            hover ? `docs-button-hovered--${type}-toggle-mustard` : null
+          }
+        >
+          {buttonsText}
+        </Button>
+      )}
+    </>
+  );
+
   getValues(BUTTON_TYPE, false).forEach(type => {
     buttonsVariants.push(
       <DocsBlock key="type" centered fullWidth>
@@ -30,7 +59,8 @@ const Buttons = () => {
           style={{
             backgroundColor:
               type === 'transparent-inverted' ? hex.graySecondary : null,
-            paddingTop: type === 'transparent-inverted' ? '10px' : null,
+            paddingTop: type === 'transparent-inverted' ? '8px' : null,
+            paddingLeft: type === 'transparent-inverted' ? '4px' : null,
           }}
         >
           <DocsBlock evenColumns justified>
@@ -52,41 +82,17 @@ const Buttons = () => {
           <DocsBlock evenColumns justified>
             <Button
               type={type}
-              icon={<Icon type={iconTypes.ANSWER} color="adaptive" size={24} />}
+              icon={<Icon type="heart_outlined" color="adaptive" size={24} />}
             >
               {buttonsText}
             </Button>
           </DocsBlock>
           <DocsBlock evenColumns justified>
+            <Flex direction="column">{getToggleButtons({type})}</Flex>
+          </DocsBlock>
+          <DocsBlock evenColumns justified>
             <Flex direction="column">
-              {[...someButtonsWithToggle, 'transparent-peach'].includes(
-                type
-              ) && (
-                <Button
-                  type={type}
-                  toggle="peach"
-                  icon={
-                    <Icon type={iconTypes.ANSWER} color="adaptive" size={24} />
-                  }
-                  style={{marginBottom: '12px'}}
-                >
-                  {buttonsText}
-                </Button>
-              )}
-
-              {[...someButtonsWithToggle, 'transparent-mustard'].includes(
-                type
-              ) && (
-                <Button
-                  type={type}
-                  toggle="mustard"
-                  icon={
-                    <Icon type={iconTypes.ANSWER} color="adaptive" size={24} />
-                  }
-                >
-                  {buttonsText}
-                </Button>
-              )}
+              {getToggleButtons({type, hover: true})}
             </Flex>
           </DocsBlock>
         </Flex>
@@ -115,20 +121,23 @@ const Buttons = () => {
         <DocsBlock evenColumns justified>
           <Text>toggle</Text>
         </DocsBlock>
+        <DocsBlock evenColumns justified>
+          <Text>toggle hover</Text>
+        </DocsBlock>
       </DocsBlock>
       {buttonsVariants}
       <DocsBlock info="Buttons sizes">
         <Button
           size="large"
           type="facebook"
-          icon={<Icon type={iconTypes.FACEBOOK} color="light" size={32} />}
+          icon={<Icon type="facebook" color="light" size={32} />}
         >
           {buttonsText}
         </Button>
         &nbsp;
         <Button
           type="facebook"
-          icon={<Icon type={iconTypes.FACEBOOK} color="light" size={24} />}
+          icon={<Icon type="facebook" color="light" size={24} />}
         >
           {buttonsText}
         </Button>
@@ -136,7 +145,7 @@ const Buttons = () => {
         <Button
           size="small"
           type="facebook"
-          icon={<Icon type={iconTypes.FACEBOOK} color="light" size={16} />}
+          icon={<Icon type="facebook" color="light" size={16} />}
         >
           {buttonsText}
         </Button>

--- a/src/components/buttons/pages/buttons.jsx
+++ b/src/components/buttons/pages/buttons.jsx
@@ -15,6 +15,12 @@ function getValues(object, addUndefined = true) {
 const Buttons = () => {
   const buttonsVariants = [];
   const buttonsText = 'Button';
+  const someButtonsWithToggle = [
+    'solid-light',
+    'outline',
+    'transparent',
+    'transparent-light',
+  ];
 
   getValues(BUTTON_TYPE, false).forEach(type => {
     buttonsVariants.push(
@@ -53,13 +59,9 @@ const Buttons = () => {
           </DocsBlock>
           <DocsBlock evenColumns justified>
             <Flex direction="column">
-              {[
-                'solid-light',
-                'outline',
-                'transparent',
-                'transparent-light',
-                'transparent-peach',
-              ].includes(type) && (
+              {[...someButtonsWithToggle, 'transparent-peach'].includes(
+                type
+              ) && (
                 <Button
                   type={type}
                   toggle="peach"
@@ -72,13 +74,9 @@ const Buttons = () => {
                 </Button>
               )}
 
-              {[
-                'solid-light',
-                'outline',
-                'transparent',
-                'transparent-light',
-                'transparent-mustard',
-              ].includes(type) && (
+              {[...someButtonsWithToggle, 'transparent-mustard'].includes(
+                type
+              ) && (
                 <Button
                   type={type}
                   toggle="mustard"
@@ -89,14 +87,6 @@ const Buttons = () => {
                   {buttonsText}
                 </Button>
               )}
-              {![
-                'solid-light',
-                'outline',
-                'transparent',
-                'transparent-light',
-                'transparent-peach',
-                'transparent-mustard',
-              ].includes(type) && '-'}
             </Flex>
           </DocsBlock>
         </Flex>

--- a/src/docs/_sass/_docs-buttons.scss
+++ b/src/docs/_sass/_docs-buttons.scss
@@ -17,18 +17,50 @@
 
   &--solid-light {
     @include sgButtonHoverMix($graySecondaryLight, $graySecondaryLightest, 20%);
+
+    &-toggle-peach {
+      @include sgButtonHoverMix($peachPrimary, $peachSecondaryLight, 12%);
+    }
+
+    &-toggle-mustard {
+      @include sgButtonHoverMix($mustardPrimary, $mustardSecondaryLight, 12%);
+    }
   }
 
   &--outline {
     @include sgButtonHoverMix($graySecondary, $transparent, 12%);
+
+    &-toggle-peach {
+      @include sgButtonHoverMix($peachPrimary, $transparent, 12%);
+    }
+
+    &-toggle-mustard {
+      @include sgButtonHoverMix($mustardPrimary, $transparent, 12%);
+    }
   }
 
   &--transparent {
     @include sgButtonHoverMix($graySecondary, $transparent, 12%);
+
+    &-toggle-peach {
+      @include sgButtonHoverMix($peachPrimary, $transparent, 12%);
+    }
+
+    &-toggle-mustard {
+      @include sgButtonHoverMix($mustardPrimary, $transparent, 12%);
+    }
   }
 
   &--transparent-light {
     @include sgButtonHoverMix($graySecondary, $transparent, 12%);
+
+    &-toggle-peach {
+      @include sgButtonHoverMix($peachPrimary, $transparent, 12%);
+    }
+
+    &-toggle-mustard {
+      @include sgButtonHoverMix($mustardPrimary, $transparent, 12%);
+    }
   }
 
   &--transparent-inverted {
@@ -37,10 +69,19 @@
 
   &--transparent-peach {
     @include sgButtonHoverMix($peachPrimary, $transparent, 12%);
+
+    &-toggle-peach {
+      @include sgButtonHoverMix($peachPrimary, $transparent, 12%);
+    }
   }
 
   &--transparent-mustard {
     @include sgButtonHoverMix($mustardPrimary, $transparent, 12%);
+
+
+    &-toggle-mustard {
+      @include sgButtonHoverMix($mustardPrimary, $transparent, 12%);
+    }
   }
 
   &--facebook {


### PR DESCRIPTION
According to "[System of colors for States and Variants of buttons](https://brainly.atlassian.net/wiki/spaces/DesignSystem/pages/25198593/System%2Bof%2Bcolors%2Bfor%2BStates%2Band%2BVariants%2Bof%2Bbuttons)":

**Toggle button:**
- we use toggles only for Transparent, Outline and Solid Light.
- the color variant includes: (...) icon color + additional attributes like background / outline.
- the color of text is never changed.

**Toggle button hover:**
- we use toggles only for Transparent, Outline and Solid Light so the same logic for hovers applies


<img width="1011" alt="Screenshot 2020-04-16 at 11 55 18" src="https://user-images.githubusercontent.com/1231144/79442858-6063b780-7fd9-11ea-8760-8d474ae6c850.png">
<img width="1033" alt="Screenshot 2020-04-16 at 11 55 26" src="https://user-images.githubusercontent.com/1231144/79442873-65286b80-7fd9-11ea-9c41-f128c458b124.png">
<img width="1007" alt="Screenshot 2020-04-16 at 12 13 45" src="https://user-images.githubusercontent.com/1231144/79444647-be919a00-7fdb-11ea-9a6c-349061941125.png">
