### PR TITLE
Add whiteSpace prop to Text

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "161.3.0",
+  "version": "161.4.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/text/Text.jsx
+++ b/src/components/text/Text.jsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import {TEXT_TYPE, TEXT_SIZE, TEXT_WEIGHT} from './textConsts';
+import {TEXT_TYPE, TEXT_SIZE, TEXT_WEIGHT, TEXT_WHITE_SPACE} from './textConsts';
 
 export type TextTypeType =
   | 'span'
@@ -42,6 +42,7 @@ export type TextWeightType = 'regular' | 'bold';
 export type TextTransformType = 'uppercase' | 'lowercase' | 'capitalize';
 
 export type TextAlignType = 'to-left' | 'to-center' | 'to-right' | 'justify';
+export type TextWhiteSpaceType = 'pre-wrap' | 'pre-line';
 
 export {
   TYPE, // backward compatibility
@@ -54,6 +55,7 @@ export {
   TEXT_WEIGHT,
   TEXT_TRANSFORM,
   TEXT_ALIGN,
+  TEXT_WHITE_SPACE,
 } from './textConsts';
 
 export type TextPropsType = {
@@ -68,7 +70,7 @@ export type TextPropsType = {
   asContainer?: ?boolean,
   full?: ?boolean,
   breakWords?: ?boolean,
-  breakLines?: ?boolean,
+  whiteSpace?: TextWhiteSpaceType, 
   className?: ?string,
   ...
 };
@@ -85,7 +87,7 @@ const Text = ({
   asContainer,
   full,
   breakWords,
-  breakLines,
+  whiteSpace,
   className,
   ...props
 }: TextPropsType) => {
@@ -102,7 +104,8 @@ const Text = ({
       'sg-text--full': full,
       'sg-text--no-wrap': noWrap,
       'sg-text--break-words': breakWords,
-      'sg-text--break-lines': breakLines,
+      'sg-text--pre-wrap': whiteSpace === TEXT_WHITE_SPACE.PRE_WRAP,
+      'sg-text--pre-line': whiteSpace === TEXT_WHITE_SPACE.PRE_LINE,
     },
     className
   );

--- a/src/components/text/Text.jsx
+++ b/src/components/text/Text.jsx
@@ -2,7 +2,12 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import {TEXT_TYPE, TEXT_SIZE, TEXT_WEIGHT, TEXT_WHITE_SPACE} from './textConsts';
+import {
+  TEXT_TYPE,
+  TEXT_SIZE,
+  TEXT_WEIGHT,
+  TEXT_WHITE_SPACE,
+} from './textConsts';
 
 export type TextTypeType =
   | 'span'
@@ -70,7 +75,7 @@ export type TextPropsType = {
   asContainer?: ?boolean,
   full?: ?boolean,
   breakWords?: ?boolean,
-  whiteSpace?: TextWhiteSpaceType, 
+  whiteSpace?: TextWhiteSpaceType,
   className?: ?string,
   ...
 };

--- a/src/components/text/Text.jsx
+++ b/src/components/text/Text.jsx
@@ -68,6 +68,7 @@ export type TextPropsType = {
   asContainer?: ?boolean,
   full?: ?boolean,
   breakWords?: ?boolean,
+  breakLines?: ?boolean,
   className?: ?string,
   ...
 };
@@ -84,6 +85,7 @@ const Text = ({
   asContainer,
   full,
   breakWords,
+  breakLines,
   className,
   ...props
 }: TextPropsType) => {
@@ -100,6 +102,7 @@ const Text = ({
       'sg-text--full': full,
       'sg-text--no-wrap': noWrap,
       'sg-text--break-words': breakWords,
+      'sg-text--break-lines': breakLines,
     },
     className
   );

--- a/src/components/text/Text.spec.jsx
+++ b/src/components/text/Text.spec.jsx
@@ -102,3 +102,9 @@ test('asContainer', () => {
 
   expect(text.hasClass('sg-text--container')).toBeTruthy();
 });
+
+test('breakLines', () => {
+  const text = shallow(<Text breakLines>Test</Text>);
+
+  expect(text.hasClass('sg-text--break-lines')).toBeTruthy();
+});

--- a/src/components/text/Text.spec.jsx
+++ b/src/components/text/Text.spec.jsx
@@ -103,8 +103,10 @@ test('asContainer', () => {
   expect(text.hasClass('sg-text--container')).toBeTruthy();
 });
 
-test('breakLines', () => {
-  const text = shallow(<Text breakLines>Test</Text>);
+test('whiteSpace', () => {
+  const text1 = shallow(<Text whiteSpace="pre-wrap">Test</Text>);
+  const text2 = shallow(<Text whiteSpace="pre-line">Test</Text>);
 
-  expect(text.hasClass('sg-text--break-lines')).toBeTruthy();
+  expect(text1.hasClass('sg-text--pre-wrap')).toBeTruthy();
+  expect(text2.hasClass('sg-text--pre-line')).toBeTruthy();
 });

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -118,12 +118,12 @@ $bodyTextSizes: (
       word-break: break-word;
     }
 
-    &--pre-wrap {
-      white-space: pre-wrap;
-    }
-
     &--pre-line {
       white-space: pre-line;
+    }
+
+    &--pre-wrap {
+      white-space: pre-wrap;
     }
 
     &--uppercase {

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -118,6 +118,10 @@ $bodyTextSizes: (
       word-break: break-word;
     }
 
+    &--break-lines {
+      white-space: pre-line;
+    }
+
     &--uppercase {
       text-transform: uppercase;
     }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -118,7 +118,11 @@ $bodyTextSizes: (
       word-break: break-word;
     }
 
-    &--break-lines {
+    &--pre-wrap {
+      white-space: pre-wrap;
+    }
+
+    &--pre-line {
       white-space: pre-line;
     }
 

--- a/src/components/text/pages/text-interactive.jsx
+++ b/src/components/text/pages/text-interactive.jsx
@@ -49,12 +49,18 @@ const Texts = () => {
       name: 'breakWords',
       values: Boolean,
     },
+    {
+      name: 'breakLines',
+      values: Boolean,
+    },
   ];
+
+  const text = 'Lorem Ipsum \ndolor sit amet';
 
   return (
     <div>
       <DocsActiveBlock settings={settings}>
-        <Text>Lorem Ipsum</Text>
+        <Text>{text}</Text>
       </DocsActiveBlock>
     </div>
   );

--- a/src/components/text/pages/text-interactive.jsx
+++ b/src/components/text/pages/text-interactive.jsx
@@ -7,6 +7,7 @@ import {
   TEXT_TYPE,
   TEXT_TRANSFORM,
   TEXT_ALIGN,
+  TEXT_WHITE_SPACE,
 } from 'text/textConsts';
 
 import DocsActiveBlock from 'components/DocsActiveBlock';
@@ -50,8 +51,8 @@ const Texts = () => {
       values: Boolean,
     },
     {
-      name: 'breakLines',
-      values: Boolean,
+      name: 'whiteSpace',
+      values: TEXT_WHITE_SPACE,
     },
   ];
 

--- a/src/components/text/textConsts.js
+++ b/src/components/text/textConsts.js
@@ -71,3 +71,8 @@ export const TEXT_ALIGN = Object.freeze({
   RIGHT: 'to-right',
   JUSTIFY: 'justify',
 });
+
+export const TEXT_WHITE_SPACE = Object.freeze({
+  PRE_WRAP: 'pre-wrap',
+  PRE_LINE: 'pre-line',
+});


### PR DESCRIPTION
closes: https://github.com/brainly/style-guide/issues/1775

2 options added:
- `pre-wrap`
- `pre-line`

<img width="778" alt="Screenshot 2020-04-28 at 08 51 34" src="https://user-images.githubusercontent.com/1231144/80456211-7f454080-892d-11ea-8d9e-2679acd897e2.png">
ref: https://css-tricks.com/almanac/properties/w/whitespace/

<img width="1009" alt="Screenshot 2020-04-28 at 08 51 04" src="https://user-images.githubusercontent.com/1231144/80456234-8a986c00-892d-11ea-8434-4bf25ce45b09.png">
<img width="991" alt="Screenshot 2020-04-28 at 08 51 09" src="https://user-images.githubusercontent.com/1231144/80456246-8e2bf300-892d-11ea-80e9-03a7802bd34c.png">
<img width="1001" alt="Screenshot 2020-04-28 at 08 51 14" src="https://user-images.githubusercontent.com/1231144/80456247-8ec48980-892d-11ea-9d81-9257a8f5002d.png">

