### PR TITLE
Add nowrap to Text white-space

### DIFF
--- a/src/components/text/Text.jsx
+++ b/src/components/text/Text.jsx
@@ -47,7 +47,7 @@ export type TextWeightType = 'regular' | 'bold';
 export type TextTransformType = 'uppercase' | 'lowercase' | 'capitalize';
 
 export type TextAlignType = 'to-left' | 'to-center' | 'to-right' | 'justify';
-export type TextWhiteSpaceType = 'pre-wrap' | 'pre-line';
+export type TextWhiteSpaceType = 'pre-wrap' | 'pre-line' | 'nowrap';
 
 export {
   TYPE, // backward compatibility
@@ -111,6 +111,7 @@ const Text = ({
       'sg-text--break-words': breakWords,
       'sg-text--pre-wrap': whiteSpace === TEXT_WHITE_SPACE.PRE_WRAP,
       'sg-text--pre-line': whiteSpace === TEXT_WHITE_SPACE.PRE_LINE,
+      'sg-text--nowrap': whiteSpace === TEXT_WHITE_SPACE.NOWRAP,
     },
     className
   );

--- a/src/components/text/Text.spec.jsx
+++ b/src/components/text/Text.spec.jsx
@@ -106,7 +106,9 @@ test('asContainer', () => {
 test('whiteSpace', () => {
   const text1 = shallow(<Text whiteSpace="pre-wrap">Test</Text>);
   const text2 = shallow(<Text whiteSpace="pre-line">Test</Text>);
+  const text3 = shallow(<Text whiteSpace="nowrap">Test</Text>);
 
   expect(text1.hasClass('sg-text--pre-wrap')).toBeTruthy();
   expect(text2.hasClass('sg-text--pre-line')).toBeTruthy();
+  expect(text3.hasClass('sg-text--nowrap')).toBeTruthy();
 });

--- a/src/components/text/textConsts.js
+++ b/src/components/text/textConsts.js
@@ -75,4 +75,5 @@ export const TEXT_ALIGN = Object.freeze({
 export const TEXT_WHITE_SPACE = Object.freeze({
   PRE_WRAP: 'pre-wrap',
   PRE_LINE: 'pre-line',
+  NOWRAP: 'nowrap',
 });


### PR DESCRIPTION
Proposal to add 'nowrap' to white-space property of Text component. 
Prop added to Text by css in 4 places in Brainly-frontend:
- brn-answering-onboarding--text-ellipsis
- brn-similar-question__ellipsis
- brn-payment-request-button__text
- brn-price-box-arrow__text