### PR TITLE
Fixes for breadcrumb elements

### DIFF
--- a/src/components/breadcrumbs/Breadcrumb.jsx
+++ b/src/components/breadcrumbs/Breadcrumb.jsx
@@ -8,6 +8,7 @@ type PropsType = {
   className?: ?string,
   adaptive?: ?boolean,
   short?: ?boolean,
+  inlineItems?: ?boolean,
   elements: $ReadOnlyArray<Node>,
   ...
 };
@@ -16,6 +17,7 @@ const Breadcrumb = ({
   className,
   short,
   adaptive,
+  inlineItems,
   elements = [],
   ...props
 }: PropsType) => {
@@ -24,6 +26,7 @@ const Breadcrumb = ({
     {
       'sg-breadcrumb-list--short': short,
       'sg-breadcrumb-list--adaptive': adaptive,
+      'sg-breadcrumb-list--inline-items': inlineItems,
     },
     className
   );

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -12,7 +12,7 @@ $includeHtml: false !default;
       display: inline-block;
 
       &::after {
-        content: "\00B7";
+        content: '\00B7';
         display: inline-block;
         color: $breadcrumbListSeparatorColor;
         padding: 0 2px;

--- a/src/components/breadcrumbs/_breadcrumbs.scss
+++ b/src/components/breadcrumbs/_breadcrumbs.scss
@@ -12,7 +12,7 @@ $includeHtml: false !default;
       display: inline-block;
 
       &::after {
-        content: '·';
+        content: "\00B7";
         display: inline-block;
         color: $breadcrumbListSeparatorColor;
         padding: 0 2px;
@@ -35,6 +35,12 @@ $includeHtml: false !default;
         &::after {
           color: inherit;
         }
+      }
+    }
+
+    &--inline-items {
+      .sg-breadcrumb-list__element {
+        display: inline;
       }
     }
   }

--- a/src/components/breadcrumbs/pages/breadcrumbs-interactive.jsx
+++ b/src/components/breadcrumbs/pages/breadcrumbs-interactive.jsx
@@ -15,6 +15,10 @@ const Breadcrumbs = () => {
       name: 'adaptive',
       values: Boolean,
     },
+    {
+      name: 'inlineItems',
+      values: Boolean,
+    },
   ];
 
   return (

--- a/src/components/breadcrumbs/pages/breadcrumbs.jsx
+++ b/src/components/breadcrumbs/pages/breadcrumbs.jsx
@@ -4,6 +4,11 @@ import Breadcrumb from '../Breadcrumb';
 import Text, {TEXT_COLOR} from 'text/Text';
 
 const elements = ['Comments (9)', 'Report', 'Follow'];
+const longElements = [
+  "I'm so long and there is so little space there",
+  'The second element is also very talkative',
+  'Lorem ipsum has many many words',
+];
 
 const breadcrumbs = () => (
   <div>
@@ -19,6 +24,11 @@ const breadcrumbs = () => (
       <Text color={TEXT_COLOR.MINT}>
         <Breadcrumb elements={elements} adaptive />
       </Text>
+    </DocsBlock>
+    <DocsBlock info="Inline items">
+      <div style={{maxWidth: 300}}>
+        <Breadcrumb elements={longElements} inlineItems />
+      </div>
     </DocsBlock>
   </div>
 );


### PR DESCRIPTION
Includes:
* display: inline for breadcrumb elements
https://github.com/brainly/style-guide/issues/1796
* possibly fixing Â shown when rendering breadcrumb elements (I say possibly because this error is hard to reproduce. The solution I used brings no visible changes, this is the same `·` character, but it may prevent it from happening again).
https://github.com/brainly/style-guide/issues/1787

Tested on all browsers / devices we usually test on.

<img width="610" alt="Screenshot 2020-05-26 at 14 46 52" src="https://user-images.githubusercontent.com/9083292/82902521-dad01180-9f5f-11ea-9424-4bc1ecbf7c36.png">
