### PR TITLE
Fix flex spacing doc

### DIFF
--- a/src/components/flex/README.md
+++ b/src/components/flex/README.md
@@ -28,7 +28,7 @@ Variable | Value
 ------------ | -------------
 xxs | 4px
 xs | 8px
-x | 16px
+s | 16px
 m | 24px
 l | 40px
 xl | 64px


### PR DESCRIPTION
Change `x` to `s` for 16px spacing size in doc