### PR TITLE
Adjust sizes of mobile icons

### DIFF
--- a/src/components/mobile-icons/MobileIcon.jsx
+++ b/src/components/mobile-icons/MobileIcon.jsx
@@ -27,7 +27,24 @@ export type IconTypeType =
   | 'text'
   | 'textbook';
 
-export type SizeType = 'small' | 'medium' | 'normal';
+export type SizeType =
+  | 104
+  | 102
+  | 80
+  | 78
+  | 56
+  | 54
+  | 40
+  | 32
+  | 30
+  | 26
+  | 24
+  | 22
+  | 20
+  | 18
+  | 16
+  | 14
+  | 10;
 
 export const TYPE: {[name: string]: IconTypeType, ...} = {
   ANSWER_BUBBLE: 'answer-bubble',
@@ -63,7 +80,7 @@ type PropsType = $ReadOnly<{
 
 const MobileIcon = ({
   type,
-  size = 'normal',
+  size = 24,
   color = 'light',
   className,
   ...props
@@ -71,7 +88,7 @@ const MobileIcon = ({
   const iconClass = classNames(
     'sg-mobile-icon',
     {
-      [`sg-mobile-icon--${size}`]: size !== 'normal',
+      [`sg-mobile-icon--x${size}`]: size,
       [`sg-mobile-icon--${String(color)}`]: color !== 'light',
     },
     className

--- a/src/components/mobile-icons/MobileIcon.spec.jsx
+++ b/src/components/mobile-icons/MobileIcon.spec.jsx
@@ -30,7 +30,7 @@ test('size', () => {
   const type = TYPE.ANSWER_BUBBLE;
   const icon = shallow(<MobileIcon type={type} size={size} />);
 
-  expect(icon.hasClass(`sg-mobile-icon--${size}`)).toEqual(true);
+  expect(icon.hasClass(`sg-mobile-icon--x${size}`)).toEqual(true);
 });
 
 test('other props', () => {

--- a/src/components/mobile-icons/_mobile-icon.scss
+++ b/src/components/mobile-icons/_mobile-icon.scss
@@ -7,6 +7,8 @@ $iconSizes: 104, 102, 80, 78, 56, 54, 40, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10
   width: 24px;
   fill: $white;
 
+  @include iconColor();
+
   @each $size in $iconSizes {
     &--x#{$size} {
       max-width: #{$size}px;
@@ -15,6 +17,4 @@ $iconSizes: 104, 102, 80, 78, 56, 54, 40, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10
       width: #{$size}px;
     }
   }
-
-  @include iconColor();
 }

--- a/src/components/mobile-icons/_mobile-icon.scss
+++ b/src/components/mobile-icons/_mobile-icon.scss
@@ -1,22 +1,19 @@
 @import '../icons/icons-mixin';
 
-$sizeSmall: 24px;
-$sizeMedium: 32px;
-$sizeNormal: 64px;
+$iconSizes: 104, 102, 80, 78, 56, 54, 40, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10;
 
 .sg-mobile-icon {
-  height: $sizeNormal;
-  width: $sizeNormal;
+  height: 24px;
+  width: 24px;
   fill: $white;
 
-  &--medium {
-    height: $sizeMedium;
-    width: $sizeMedium;
-  }
-
-  &--small {
-    height: $sizeSmall;
-    width: $sizeSmall;
+  @each $size in $iconSizes {
+    &--x#{$size} {
+      max-width: #{$size}px;
+      max-height: #{$size}px;
+      height: #{$size}px;
+      width: #{$size}px;
+    }
   }
 
   @include iconColor();

--- a/src/components/mobile-icons/_mobile-icon.scss
+++ b/src/components/mobile-icons/_mobile-icon.scss
@@ -3,11 +3,10 @@
 $iconSizes: 104, 102, 80, 78, 56, 54, 40, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10;
 
 .sg-mobile-icon {
+  @include iconColor();
   height: 24px;
   width: 24px;
   fill: $white;
-
-  @include iconColor();
 
   @each $size in $iconSizes {
     &--x#{$size} {


### PR DESCRIPTION
requested by Design System team:

<img width="705" alt="Screenshot 2020-06-08 at 09 35 38" src="https://user-images.githubusercontent.com/1231144/84004197-7bb0ca80-a96b-11ea-9a4d-1b2bd61977dd.png">

to keep the same sizes as basic icons
