### PR TITLE
Add componentSize mixin and rename sizes of Radio

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "163.0.0",
+  "version": "164.0.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -4,11 +4,11 @@ import React from 'react';
 import classNames from 'classnames';
 import generateRandomString from '../../js/generateRandomString';
 
-type RadioSizeType = 'normal' | 'large';
+type RadioSizeType = 'xs' | 's';
 
 export const RADIO_SIZE = {
-  NORMAL: 'normal',
-  LARGE: 'large',
+  xs: 'xs',
+  s: 's',
 };
 
 export type RadioPropsType = {
@@ -24,7 +24,7 @@ const Radio = (props: RadioPropsType) => {
   const {
     checked,
     name,
-    size = RADIO_SIZE.NORMAL,
+    size = 'xs',
     className,
     id = generateRandomString(),
     ...additionalProps
@@ -33,7 +33,7 @@ const Radio = (props: RadioPropsType) => {
   const radioClass = classNames(
     'sg-radio',
     {
-      [`sg-radio--${String(size)}`]: size !== RADIO_SIZE.NORMAL,
+      [`sg-radio--${String(size)}`]: size,
     },
     className
   );

--- a/src/components/form-elements/_checkbox-radio.scss
+++ b/src/components/form-elements/_checkbox-radio.scss
@@ -1,11 +1,12 @@
-$crInputSize: 16px;
+$radioSizeXS: componentSize(xs);
+$radioSizeS: componentSize(s);
 $crInputColor: $white;
 $crInputBorderColor: $graySecondaryLight;
 $crInputActiveBorderColor: $bluePrimary;
 $crInputCheckedColor: $bluePrimary;
 $crRadioCheckedColor: $white;
 $crInputActiveColor: rgba($crInputColor, 0.7);
-$radioLargeSize: 32px;
+
 $includeHtml: false !default;
 
 @if ($includeHtml) {
@@ -14,16 +15,16 @@ $includeHtml: false !default;
   .sg-radio {
     @include component();
     overflow: visible;
-    width: $crInputSize;
-    height: $crInputSize;
-    min-height: $crInputSize;
+    width: $radioSizeXS;
+    height: $radioSizeXS;
+    min-height: $radioSizeXS;
 
     &__element {
       opacity: 0;
       position: absolute;
       margin: 0;
-      width: $crInputSize;
-      height: $crInputSize;
+      width: $radioSizeXS;
+      height: $radioSizeXS;
       z-index: 1;
     }
 
@@ -33,8 +34,8 @@ $includeHtml: false !default;
 
     &__ghost {
       background: $crInputColor;
-      width: $crInputSize;
-      height: $crInputSize;
+      width: $radioSizeXS;
+      height: $radioSizeXS;
       border: 2px solid $crInputBorderColor;
       fill: $crInputColor;
       display: flex;
@@ -70,8 +71,8 @@ $includeHtml: false !default;
         content: '';
         border-radius: 50%;
         background-color: $crInputColor;
-        width: $crInputSize / 2;
-        height: $crInputSize / 2;
+        width: $radioSizeXS / 2;
+        height: $radioSizeXS / 2;
       }
     }
 
@@ -86,25 +87,25 @@ $includeHtml: false !default;
       }
     }
 
-    &--large {
-      width: $radioLargeSize;
-      height: $radioLargeSize;
-      min-height: $radioLargeSize;
-      line-height: $radioLargeSize;
+    &--s {
+      width: $radioSizeS;
+      height: $radioSizeS;
+      min-height: $radioSizeS;
+      line-height: $radioSizeS;
 
       .sg-radio__element {
         left: 0;
-        width: $radioLargeSize;
-        height: $radioLargeSize;
+        width: $radioSizeS;
+        height: $radioSizeS;
       }
 
       .sg-radio__ghost {
-        width: $radioLargeSize;
-        height: $radioLargeSize;
+        width: $radioSizeS;
+        height: $radioSizeS;
 
         &::before {
-          width: $radioLargeSize / 2;
-          height: $radioLargeSize / 2;
+          width: $radioSizeS / 2;
+          height: $radioSizeS / 2;
         }
       }
     }

--- a/src/components/form-elements/pages/radio.jsx
+++ b/src/components/form-elements/pages/radio.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import DocsBlock from 'components/DocsBlock';
 import LabelDeprecated from 'labels-deprecated/LabelDeprecated';
-import Radio, {RADIO_SIZE} from '../Radio';
+import Radio from '../Radio';
 
 const dumpProps = {onChange: () => undefined};
 
@@ -24,9 +24,9 @@ const radios = () => (
         iconContent={<Radio name="group3" />}
       />
     </DocsBlock>
-    <DocsBlock info="Large">
-      <Radio size={RADIO_SIZE.LARGE} name="group4" />
-      <Radio size={RADIO_SIZE.LARGE} name="group4" checked {...dumpProps} />
+    <DocsBlock info="size S">
+      <Radio size="s" name="group4" />
+      <Radio size="s" name="group4" checked {...dumpProps} />
     </DocsBlock>
   </div>
 );

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -101,6 +101,17 @@ $sizesSetup: (
   xxxxl: 272px,
 );
 
+// component sizes
+$componentSizesSetup: (
+  xxs: 16px,
+  xs: 24px,
+  s: 32px,
+  m: 40px,
+  l: 56px,
+  xl: 80px,
+  xxl: 104px,
+);
+
 // Border radius
 $borderRadiusDefault: 8px;
 $borderRadiusLarge: $borderRadiusDefault * 1.5;

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -108,6 +108,15 @@
   }
 }
 
+// componentSize function that returns proper size based on namespace
+@function componentSize($size) {
+  @each $key, $value in $componentSizesSetup {
+    @if($key == $size) {
+      @return $value;
+    }
+  }
+}
+
 // https://css-tricks.com/snippets/sass/strip-unit-function/
 // Remove the unit of a length
 // @param {Number} $number - Number to remove unit from


### PR DESCRIPTION
according to: https://brainly.atlassian.net/wiki/spaces/DesignSystem/pages/33523275/FNC#RADIO-BUTTON (internal brainly doc)

it's a breaking change: renaming of sizes

no visual changes of component:

<img width="411" alt="Screenshot 2020-06-08 at 14 25 02" src="https://user-images.githubusercontent.com/1231144/84030718-c8f56200-a994-11ea-9a28-b7b117cc9de3.png">
<img width="1103" alt="Screenshot 2020-06-08 at 14 25 18" src="https://user-images.githubusercontent.com/1231144/84030724-cb57bc00-a994-11ea-9617-1fd6af076206.png">
