### PR TITLE
Fix default Radio size

### DIFF
--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -24,7 +24,7 @@ const Radio = (props: RadioPropsType) => {
   const {
     checked,
     name,
-    size = 'xs',
+    size = 'xxs',
     className,
     id = generateRandomString(),
     ...additionalProps


### PR DESCRIPTION
closes https://github.com/brainly/style-guide/issues/1828

thank you @seahindeniz