### PR TITLE
Rename text sizes from normal to medium

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "172.2.2",
+  "version": "173.0.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/text/Headline.jsx
+++ b/src/components/text/Headline.jsx
@@ -9,7 +9,7 @@ export type HeadlineTypeType = 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 export type HeadlineSizeType =
   | 'xsmall'
   | 'small'
-  | 'normal'
+  | 'medium'
   | 'large'
   | 'xlarge'
   | 'xxlarge';
@@ -57,7 +57,7 @@ export type HeadlinePropsType = {
 const Headline = ({
   children,
   type = HEADLINE_TYPE.H1,
-  size = HEADLINE_SIZE.NORMAL,
+  size = HEADLINE_SIZE.MEDIUM,
   extraBold,
   transform,
   align,
@@ -69,7 +69,7 @@ const Headline = ({
   const headlineClass = classNames(
     'sg-headline',
     {
-      [`sg-headline--${size}`]: size !== HEADLINE_SIZE.NORMAL,
+      [`sg-headline--${size}`]: size !== HEADLINE_SIZE.MEDIUM,
       [`sg-headline--${String(color)}`]: color,
       [`sg-headline--${String(transform)}`]: transform,
       [`sg-headline--${align || ''}`]: align,

--- a/src/components/text/Headline.spec.jsx
+++ b/src/components/text/Headline.spec.jsx
@@ -36,10 +36,10 @@ test('light', () => {
 
 test('default size', () => {
   const headline = shallow(
-    <Headline size={HEADLINE_SIZE.NORMAL}>Test</Headline>
+    <Headline size={HEADLINE_SIZE.MEDIUM}>Test</Headline>
   );
 
-  expect(headline.hasClass('sg-headline--normal')).toBeFalsy();
+  expect(headline.hasClass('sg-headline--medium')).toBeFalsy();
 });
 
 test('transform uppercase', () => {

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -28,7 +28,7 @@ type TextTypeType =
 type TextSizeType =
   | 'xsmall'
   | 'small'
-  | 'normal'
+  | 'medium'
   | 'large'
   | 'xlarge'
   | 'xxlarge';

--- a/src/components/text/Text.jsx
+++ b/src/components/text/Text.jsx
@@ -25,7 +25,7 @@ export type TextTypeType =
 export type TextSizeType =
   | 'xsmall'
   | 'small'
-  | 'normal'
+  | 'medium'
   | 'large'
   | 'xlarge'
   | 'xxlarge';
@@ -83,7 +83,7 @@ export type TextPropsType = {
 const Text = ({
   children,
   type = TEXT_TYPE.DIV,
-  size = TEXT_SIZE.NORMAL,
+  size = TEXT_SIZE.MEDIUM,
   weight = TEXT_WEIGHT.REGULAR,
   color,
   transform,
@@ -100,7 +100,7 @@ const Text = ({
   const textClass = classNames(
     'sg-text',
     {
-      [`sg-text--${String(size)}`]: size !== TEXT_SIZE.NORMAL,
+      [`sg-text--${String(size)}`]: size !== TEXT_SIZE.MEDIUM,
       [`sg-text--${String(color)}`]: color,
       [`sg-text--${String(weight)}`]: weight !== TEXT_WEIGHT.REGULAR,
       [`sg-text--${transform || ''}`]: transform,

--- a/src/components/text/TextBit.jsx
+++ b/src/components/text/TextBit.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 type TextBitTypeType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'div';
 
-type TextBitSizeType = 'small' | 'normal' | 'large' | 'xlarge';
+type TextBitSizeType = 'small' | 'medium' | 'large' | 'xlarge';
 
 type TextBitColorType =
   | 'blue-primary'
@@ -35,7 +35,7 @@ export const TEXT_BIT_TYPE = Object.freeze({
 
 export const TEXT_BIT_SIZE = Object.freeze({
   SMALL: 'small',
-  NORMAL: 'normal',
+  MEDIUM: 'medium',
   LARGE: 'large',
   XLARGE: 'xlarge',
 });
@@ -69,7 +69,7 @@ type TextBitPropsType = {
 const TextBit = ({
   children,
   type = TEXT_BIT_TYPE.H1,
-  size = TEXT_BIT_SIZE.NORMAL,
+  size = TEXT_BIT_SIZE.MEDIUM,
   color,
   className,
   ...props
@@ -78,7 +78,7 @@ const TextBit = ({
   const textClass = classNames(
     'sg-text-bit',
     {
-      [`sg-text-bit--${size}`]: size && size !== TEXT_BIT_SIZE.NORMAL,
+      [`sg-text-bit--${size}`]: size && size !== TEXT_BIT_SIZE.MEDIUM,
       [`sg-text-bit--${color || ''}`]: color,
     },
     className

--- a/src/components/text/TextBit.spec.jsx
+++ b/src/components/text/TextBit.spec.jsx
@@ -15,9 +15,9 @@ test('size', () => {
 });
 
 test('should not pass size when default passed', () => {
-  const textBit = shallow(<TextBit size={TEXT_BIT_SIZE.NORMAL}>Test</TextBit>);
+  const textBit = shallow(<TextBit size={TEXT_BIT_SIZE.MEDIUM}>Test</TextBit>);
 
-  expect(textBit.hasClass('sg-text-bit--normal')).toBeFalsy();
+  expect(textBit.hasClass('sg-text-bit--medium')).toBeFalsy();
 });
 
 test('type', () => {

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -13,7 +13,7 @@ $headlineSizes: (
     fontSize: 28px,
     lineHeight: 32px
   ),
-  normal: (
+  medium: (
     fontSize: 21px,
     lineHeight: 24px
   ),
@@ -42,7 +42,7 @@ $headlineSizes: (
 @if ($includeHtml) {
 
   .sg-headline {
-    @include headlineTypeSizeVariant(normal);
+    @include headlineTypeSizeVariant(medium);
     display: block;
     color: $black;
     font-weight: $fontWeightBold;

--- a/src/components/text/_text-bits.scss
+++ b/src/components/text/_text-bits.scss
@@ -3,7 +3,7 @@ $includeHtml: false !default;
 $bitSizes: (
   xlarge: 80px,
   large: 56px,
-  normal: 40px,
+  medium: 40px,
   small: 24px,
 );
 
@@ -15,8 +15,8 @@ $bitSizes: (
 
   .sg-text-bit {
     @include uppercaseText(-0.0625rem);
-    font-size: getBitSize(normal);
-    line-height: getBitSize(normal);
+    font-size: getBitSize(medium);
+    line-height: getBitSize(medium);
     color: $mintSecondary;
     font-weight: $fontWeightBlack;
     margin: 0;

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -13,7 +13,7 @@ $bodyTextSizes: (
     fontSize: 24px,
     lineHeight: 32px
   ),
-  normal: (
+  medium: (
     fontSize: 18px,
     lineHeight: 24px
   ),
@@ -42,7 +42,7 @@ $bodyTextSizes: (
 @if ($includeHtml) {
 
   .sg-text {
-    @include bodyTextTypeSizeVariant(normal);
+    @include bodyTextTypeSizeVariant(medium);
     font-family: $fontFamilyPrimary;
     font-weight: $fontWeightNormal;
     color: $black;

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -13,7 +13,7 @@ export const HEADLINE_TYPE = Object.freeze({
 export const HEADLINE_SIZE = Object.freeze({
   XSMALL: 'xsmall',
   SMALL: 'small',
-  NORMAL: 'normal',
+  MEDIUM: 'medium',
   LARGE: 'large',
   XLARGE: 'xlarge',
   XXLARGE: 'xxlarge',

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -21,7 +21,7 @@ const headlineSizesMap = [
     fontSize: '18px',
   },
   {
-    type: 'normal',
+    type: 'medium',
     fontSize: '21px',
   },
   {
@@ -75,7 +75,7 @@ const Headlines = () => {
         <Headline
           key={color}
           type={HEADLINE_TYPE.H2}
-          size={HEADLINE_SIZE.NORMAL}
+          size={HEADLINE_SIZE.MEDIUM}
           color={color}
         >
           {text} - {color}
@@ -86,7 +86,7 @@ const Headlines = () => {
         <ContrastBox key={color}>
           <Headline
             type={HEADLINE_TYPE.H2}
-            size={HEADLINE_SIZE.NORMAL}
+            size={HEADLINE_SIZE.MEDIUM}
             color={color}
           >
             {text} - {color}
@@ -103,21 +103,21 @@ const Headlines = () => {
       <DocsBlock info="Examples">
         <Headline
           type={HEADLINE_TYPE.H2}
-          size={HEADLINE_SIZE.NORMAL}
+          size={HEADLINE_SIZE.MEDIUM}
           transform={HEADLINE_TRANSFORM.CAPITALIZE}
         >
           {text} - capitalize
         </Headline>
         <Headline
           type={HEADLINE_TYPE.H2}
-          size={HEADLINE_SIZE.NORMAL}
+          size={HEADLINE_SIZE.MEDIUM}
           transform={HEADLINE_TRANSFORM.LOWERCASE}
         >
           {text} - lowercase
         </Headline>
         <Headline
           type={HEADLINE_TYPE.H2}
-          size={HEADLINE_SIZE.NORMAL}
+          size={HEADLINE_SIZE.MEDIUM}
           transform={HEADLINE_TRANSFORM.UPPERCASE}
         >
           {text} - uppercase
@@ -125,21 +125,21 @@ const Headlines = () => {
         <br />
         <Headline
           type={HEADLINE_TYPE.H2}
-          size={HEADLINE_SIZE.NORMAL}
+          size={HEADLINE_SIZE.MEDIUM}
           align={HEADLINE_ALIGN.LEFT}
         >
           {text} - align left
         </Headline>
         <Headline
           type={HEADLINE_TYPE.H2}
-          size={HEADLINE_SIZE.NORMAL}
+          size={HEADLINE_SIZE.MEDIUM}
           align={HEADLINE_ALIGN.CENTER}
         >
           {text} - align center
         </Headline>
         <Headline
           type={HEADLINE_TYPE.H2}
-          size={HEADLINE_SIZE.NORMAL}
+          size={HEADLINE_SIZE.MEDIUM}
           align={HEADLINE_ALIGN.RIGHT}
         >
           {text} - align right

--- a/src/components/text/pages/text-bit.jsx
+++ b/src/components/text/pages/text-bit.jsx
@@ -10,7 +10,7 @@ const textBitSizesMap = [
     fontSize: '24px',
   },
   {
-    type: 'normal',
+    type: 'medium',
     fontSize: '40px',
   },
   {
@@ -49,7 +49,7 @@ const TextBitExamples = () => {
 
   getValues(TEXT_BIT_COLOR, false).forEach(color => {
     colorsVariants.push(
-      <TextBit key="color" size={TEXT_BIT_SIZE.NORMAL} color={color}>
+      <TextBit key="color" size={TEXT_BIT_SIZE.MEDIUM} color={color}>
         {text} - {color}
       </TextBit>
     );

--- a/src/components/text/pages/text.jsx
+++ b/src/components/text/pages/text.jsx
@@ -25,7 +25,7 @@ const textSizesMap = [
     fontSize: '15px',
   },
   {
-    type: 'normal',
+    type: 'medium',
     fontSize: '18px',
   },
   {

--- a/src/components/text/textConsts.js
+++ b/src/components/text/textConsts.js
@@ -19,7 +19,7 @@ export const TYPE = TEXT_TYPE; // backward compatibility
 export const TEXT_SIZE = Object.freeze({
   XSMALL: 'xsmall',
   SMALL: 'small',
-  NORMAL: 'normal',
+  MEDIUM: 'medium',
   LARGE: 'large',
   XLARGE: 'xlarge',
   XXLARGE: 'xxlarge',


### PR DESCRIPTION
no visual changes

this change applies to `Text`, `Link`, `TextBit` and `Headline` components