### PR TITLE
Add xxsmall size to Texts and Headlines

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "174.1.0",
+  "version": "174.2.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/text/Headline.jsx
+++ b/src/components/text/Headline.jsx
@@ -7,6 +7,7 @@ import {HEADLINE_SIZE, HEADLINE_TYPE} from './headlineConsts';
 export type HeadlineTypeType = 'span' | 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
 
 export type HeadlineSizeType =
+  | 'xxsmall'
   | 'xsmall'
   | 'small'
   | 'medium'

--- a/src/components/text/Text.jsx
+++ b/src/components/text/Text.jsx
@@ -23,6 +23,7 @@ export type TextTypeType =
   | 'a';
 
 export type TextSizeType =
+  | 'xxsmall'
   | 'xsmall'
   | 'small'
   | 'medium'

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -24,6 +24,10 @@ $headlineSizes: (
   xsmall: (
     fontSize: 14px,
     lineHeight: 16px
+  ),
+  xxsmall: (
+    fontSize: 10px,
+    lineHeight: 12px
   )
 );
 
@@ -47,6 +51,10 @@ $headlineSizes: (
     color: $black;
     font-weight: $fontWeightBold;
     max-width: 100%;
+
+    &--xxsmall {
+      @include headlineTypeSizeVariant(xxsmall);
+    }
 
     &--xsmall {
       @include headlineTypeSizeVariant(xsmall);

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -24,6 +24,10 @@ $bodyTextSizes: (
   xsmall: (
     fontSize: 12px,
     lineHeight: 16px
+  ),
+  xxsmall: (
+    fontSize: 9px,
+    lineHeight: 12px
   )
 );
 
@@ -69,6 +73,10 @@ $bodyTextSizes: (
 
     &--xsmall {
       @include bodyTextTypeSizeVariant(xsmall);
+    }
+
+    &--xxsmall {
+      @include bodyTextTypeSizeVariant(xxsmall);
     }
 
     &--link {

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -11,6 +11,7 @@ export const HEADLINE_TYPE = Object.freeze({
 });
 
 export const HEADLINE_SIZE = Object.freeze({
+  XXSMALL: 'xxsmall',
   XSMALL: 'xsmall',
   SMALL: 'small',
   MEDIUM: 'medium',

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -13,6 +13,10 @@ const text = "We've got your back!";
 
 const headlineSizesMap = [
   {
+    type: 'xxsmall',
+    fontSize: '10px',
+  },
+  {
     type: 'xsmall',
     fontSize: '14px',
   },

--- a/src/components/text/pages/text.jsx
+++ b/src/components/text/pages/text.jsx
@@ -17,6 +17,10 @@ const text = "We've got your back!";
 
 const textSizesMap = [
   {
+    type: 'xxsmall',
+    fontSize: '9px',
+  },
+  {
     type: 'xsmall',
     fontSize: '12px',
   },

--- a/src/components/text/textConsts.js
+++ b/src/components/text/textConsts.js
@@ -17,6 +17,7 @@ export const TEXT_TYPE = Object.freeze({
 export const TYPE = TEXT_TYPE; // backward compatibility
 
 export const TEXT_SIZE = Object.freeze({
+  XXSMALL: 'xxsmall',
   XSMALL: 'xsmall',
   SMALL: 'small',
   MEDIUM: 'medium',


### PR DESCRIPTION
<img width="578" alt="Screenshot 2020-07-08 at 10 12 26" src="https://user-images.githubusercontent.com/1231144/86894669-aecdb180-c103-11ea-9f7c-ddd22562f665.png">
<img width="455" alt="Screenshot 2020-07-08 at 10 12 31" src="https://user-images.githubusercontent.com/1231144/86894677-b0977500-c103-11ea-81ce-7be2cc49f77c.png">
