### PR TITLE
Fix search icon spacing

### DIFF
--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -17,7 +17,7 @@ $includeHtml: false !default;
       fill: $white;
       background: none;
       border: none;
-      right: spacing(xxs);
+      right: 5px;
     }
 
     &__input {


### PR DESCRIPTION
Closes #1903
Top and bottom spacing of icon is (40px (input height) - 18px(icon)) / 2 = 11px
.sg-search__icon has internal 6px padding + 5px = 11px
