### PR TITLE
Add xxxlarge size to the headline

### DIFF
--- a/src/components/text/Headline.jsx
+++ b/src/components/text/Headline.jsx
@@ -13,7 +13,8 @@ export type HeadlineSizeType =
   | 'medium'
   | 'large'
   | 'xlarge'
-  | 'xxlarge';
+  | 'xxlarge'
+  | 'xxxlarge';
 
 export type HeadlineColorType =
   | 'default'

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -1,34 +1,38 @@
 $includeHtml: false !default;
 
 $headlineSizes: (
+  xxxlarge: (
+    fontSize: 78px,
+    lineHeight: 88px,
+  ),
   xxlarge: (
     fontSize: 53px,
-    lineHeight: 60px
+    lineHeight: 60px,
   ),
   xlarge: (
     fontSize: 39px,
-    lineHeight: 44px
+    lineHeight: 44px,
   ),
   large: (
     fontSize: 28px,
-    lineHeight: 32px
+    lineHeight: 32px,
   ),
   medium: (
     fontSize: 21px,
-    lineHeight: 24px
+    lineHeight: 24px,
   ),
   small: (
     fontSize: 18px,
-    lineHeight: 20px
+    lineHeight: 20px,
   ),
   xsmall: (
     fontSize: 14px,
-    lineHeight: 16px
+    lineHeight: 16px,
   ),
   xxsmall: (
     fontSize: 10px,
-    lineHeight: 12px
-  )
+    lineHeight: 12px,
+  ),
 );
 
 @function getHeadLineSizeFromMap($map, $keys...) {
@@ -44,7 +48,6 @@ $headlineSizes: (
 }
 
 @if ($includeHtml) {
-
   .sg-headline {
     @include headlineTypeSizeVariant(medium);
     display: block;
@@ -74,6 +77,10 @@ $headlineSizes: (
 
     &--xxlarge {
       @include headlineTypeSizeVariant(xxlarge);
+    }
+
+    &--xxxlarge {
+      @include headlineTypeSizeVariant(xxxlarge);
     }
 
     &--extra-bold {

--- a/src/components/text/headlineConsts.js
+++ b/src/components/text/headlineConsts.js
@@ -18,6 +18,7 @@ export const HEADLINE_SIZE = Object.freeze({
   LARGE: 'large',
   XLARGE: 'xlarge',
   XXLARGE: 'xxlarge',
+  XXXLARGE: 'xxxlarge',
 });
 
 export const HEADLINE_COLOR = Object.freeze({

--- a/src/components/text/pages/headlines.jsx
+++ b/src/components/text/pages/headlines.jsx
@@ -40,6 +40,10 @@ const headlineSizesMap = [
     type: 'xxlarge',
     fontSize: '53px',
   },
+  {
+    type: 'xxxlarge',
+    fontSize: '78px',
+  },
 ];
 
 function getValues(object, addUndefined = true) {


### PR DESCRIPTION
This is to enable biggest size for `headlines` which are otherwise overridden in few places in the application.

![image](https://user-images.githubusercontent.com/8572321/92530763-48612e80-f22d-11ea-82e0-211f3627a283.png)
