### PR TITLE
Turn off side effects flag for the package

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,5 +130,5 @@
       ".*": "babel-jest"
     }
   },
-  "sideEffects": true
+  "sideEffects": false
 }


### PR DESCRIPTION
Side effect flag may have impact on consumers package size after build and we need to have it set to `false`. Style guide itself doesn't have side effect other than css file which is being loaded separately from the package.