### PR TITLE
Add space between util

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,1 @@
+module.exports = require('eslint-config-brainly/prettier.config');

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,1 +1,0 @@
-module.exports = require('eslint-config-brainly/prettier.config');

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -70,31 +70,19 @@ $baseline: 1.5rem;
 
 // Typo
 $fontSizes: (
-  default: 1rem,
-  // 16px
-    xsmall: 0.625rem,
-  // 10px
-    small: 0.875rem,
-  // 14px
-    medium: 0.9375rem,
-  // 15px
-    large: 3.625rem,
-  // 58px
-    xlarge: 4.5rem,
-  // 72px
-    xxlarge: 5rem,
-  // 80px
-    obscure: 0.75rem,
-  // 12px
-    standout: 1.125rem,
-  // 18px
-    subheadline: 1.25rem,
-  // 20px
-    headline: 1.5rem,
-  // 24px
-    subheader: 2.75rem,
-  // 44px
-    header: 3rem,
+  default: 1rem,      // 16px
+  xsmall: 0.625rem,     // 10px
+  small: 0.875rem,   // 14px
+  medium: 0.9375rem,  // 15px
+  large: 3.625rem,    // 58px
+  xlarge: 4.5rem,     // 72px
+  xxlarge: 5rem,      // 80px
+  obscure: 0.75rem,   // 12px
+  standout: 1.125rem, // 18px
+  subheadline: 1.25rem, // 20px
+  headline: 1.5rem,  // 24px
+  subheader: 2.75rem, // 44px
+  header: 3rem
 );
 
 // Layout
@@ -103,9 +91,8 @@ $layoutDefaultPadding: 24px;
 
 // Spacings
 $sizesSetup: (
-  xxs: 4px,
-  // additional for very small components, like icons
-    xs: 8px,
+  xxs: 4px, // additional for very small components, like icons
+  xs: 8px,
   s: 16px,
   m: 24px,
   l: 40px,
@@ -142,8 +129,7 @@ $breakpointLarge: 1024px !default;
 
 $breakpointsMap: (
   'small-only': '(max-width: #{$breakpointMedium - 1px})',
-  'medium-only':
-    '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
+  'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
   'medium-down': '(max-width: #{$breakpointLarge - 1px})',
   'medium-up': '(min-width: #{$breakpointMedium})',
   'large-only': '(min-width: #{$breakpointLarge})',

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -48,7 +48,7 @@ $buttonPrimaryFbHoverColor: #4367a9;
 
 // this comment exists to suppress errors about these unused variables:
 // $mintPrimaryDark $bluePrimaryDark $lavenderPrimaryDark $peachPrimaryDark $mustardPrimaryDark
-// $blueSecondaryUltraLight $lavenderSecondaryUltraLight $mintSecondaryUltraLight 
+// $blueSecondaryUltraLight $lavenderSecondaryUltraLight $mintSecondaryUltraLight
 // $mustardSecondaryUltraLight $peachSecondaryUltraLight $peachSecondary $graySecondaryLighter
 
 // Shadows
@@ -70,19 +70,31 @@ $baseline: 1.5rem;
 
 // Typo
 $fontSizes: (
-  default: 1rem,      // 16px
-  xsmall: 0.625rem,     // 10px
-  small: 0.875rem,   // 14px
-  medium: 0.9375rem,  // 15px
-  large: 3.625rem,    // 58px
-  xlarge: 4.5rem,     // 72px
-  xxlarge: 5rem,      // 80px
-  obscure: 0.75rem,   // 12px
-  standout: 1.125rem, // 18px
-  subheadline: 1.25rem, // 20px
-  headline: 1.5rem,  // 24px
-  subheader: 2.75rem, // 44px
-  header: 3rem
+  default: 1rem,
+  // 16px
+    xsmall: 0.625rem,
+  // 10px
+    small: 0.875rem,
+  // 14px
+    medium: 0.9375rem,
+  // 15px
+    large: 3.625rem,
+  // 58px
+    xlarge: 4.5rem,
+  // 72px
+    xxlarge: 5rem,
+  // 80px
+    obscure: 0.75rem,
+  // 12px
+    standout: 1.125rem,
+  // 18px
+    subheadline: 1.25rem,
+  // 20px
+    headline: 1.5rem,
+  // 24px
+    subheader: 2.75rem,
+  // 44px
+    header: 3rem,
 );
 
 // Layout
@@ -91,8 +103,9 @@ $layoutDefaultPadding: 24px;
 
 // Spacings
 $sizesSetup: (
-  xxs: 4px, // additional for very small components, like icons
-  xs: 8px,
+  xxs: 4px,
+  // additional for very small components, like icons
+    xs: 8px,
   s: 16px,
   m: 24px,
   l: 40px,
@@ -118,7 +131,6 @@ $borderRadiusDefault: 8px;
 $borderRadiusLarge: $borderRadiusDefault * 1.5;
 $borderRadiusSmall: $borderRadiusDefault / 2;
 
-
 // Vertical stack
 $sgHeaderZIndex: 101;
 $overlayZIndex: 999;
@@ -130,10 +142,24 @@ $breakpointLarge: 1024px !default;
 
 $breakpointsMap: (
   'small-only': '(max-width: #{$breakpointMedium - 1px})',
-  'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
+  'medium-only':
+    '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
   'medium-down': '(max-width: #{$breakpointLarge - 1px})',
   'medium-up': '(min-width: #{$breakpointMedium})',
-  'large-only': '(min-width: #{$breakpointLarge})'
+  'large-only': '(min-width: #{$breakpointLarge})',
+);
+
+// Breakpoints map for mobile first approach usage
+$responsiveBreakpointsMap: (
+  'md': '(min-width: #{$breakpointMedium})',
+  'lg': '(min-width: #{$breakpointLarge})',
+);
+
+// Breakpoints variants for generating reposnive utility classes
+$responsiveVariants: (
+  '': '',
+  md: 'md\\:',
+  lg: 'lg\\:',
 );
 
 // Form elements configuration

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -132,7 +132,7 @@ $breakpointsMap: (
   'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
   'medium-down': '(max-width: #{$breakpointLarge - 1px})',
   'medium-up': '(min-width: #{$breakpointMedium})',
-  'large-only': '(min-width: #{$breakpointLarge})',
+  'large-only': '(min-width: #{$breakpointLarge})'
 );
 
 // Breakpoints map for mobile first approach usage

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -95,7 +95,7 @@
         @content;
       }
     } @else {
-      @error 'Breakpoint "#{$name}" does not exist';
+      @error 'Responsive breakpoint "#{$name}" does not exist';
     }
   }
 }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -56,7 +56,6 @@
 // fontsizeName - string
 // lineHeight - int, number of baselines
 @mixin typeVariant($fontsizeName, $lineHeight: null) {
-
   $remFontsize: fontSize($fontsizeName);
 
   @if $remFontsize != null {
@@ -74,14 +73,22 @@
   @return $baselines * $baseline;
 }
 
-@mixin sgBreakpoint($name) {
-  $media: map-get($breakpointsMap, $name);
-  @if($media) {
+@mixin sgBreakpoint($name, $map: $breakpointsMap) {
+  $media: map-get($map, $name);
+  @if ($media) {
     @media #{$media} {
       @content;
     }
   } @else {
     @error 'Breakpoint "#{$name}" does not exist';
+  }
+}
+
+@mixin sgResponsive($name) {
+  @if $name == '' {
+    @content;
+  } @else {
+    @include sgBreakpoint($name, $responsiveBreakpointsMap);
   }
 }
 
@@ -102,7 +109,7 @@
 // spacing function that returns proper size based on namespace
 @function spacing($size) {
   @each $key, $value in $sizesSetup {
-    @if($key == $size) {
+    @if ($key == $size) {
       @return $value;
     }
   }
@@ -111,7 +118,7 @@
 // componentSize function that returns proper size based on namespace
 @function componentSize($size) {
   @each $key, $value in $componentSizesSetup {
-    @if($key == $size) {
+    @if ($key == $size) {
       @return $value;
     }
   }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -76,7 +76,7 @@
 
 @mixin sgBreakpoint($name, $map: $breakpointsMap) {
   $media: map-get($map, $name);
-  @if ($media) {
+  @if($media) {
     @media #{$media} {
       @content;
     }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -56,6 +56,7 @@
 // fontsizeName - string
 // lineHeight - int, number of baselines
 @mixin typeVariant($fontsizeName, $lineHeight: null) {
+
   $remFontsize: fontSize($fontsizeName);
 
   @if $remFontsize != null {
@@ -109,7 +110,7 @@
 // spacing function that returns proper size based on namespace
 @function spacing($size) {
   @each $key, $value in $sizesSetup {
-    @if ($key == $size) {
+    @if($key == $size) {
       @return $value;
     }
   }
@@ -118,7 +119,7 @@
 // componentSize function that returns proper size based on namespace
 @function componentSize($size) {
   @each $key, $value in $componentSizesSetup {
-    @if ($key == $size) {
+    @if($key == $size) {
       @return $value;
     }
   }

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -74,8 +74,8 @@
   @return $baselines * $baseline;
 }
 
-@mixin sgBreakpoint($name, $map: $breakpointsMap) {
-  $media: map-get($map, $name);
+@mixin sgBreakpoint($name) {
+  $media: map-get($breakpointsMap, $name);
   @if($media) {
     @media #{$media} {
       @content;
@@ -89,7 +89,14 @@
   @if $name == '' {
     @content;
   } @else {
-    @include sgBreakpoint($name, $responsiveBreakpointsMap);
+    $media: map-get($responsiveBreakpointsMap, $name);
+    @if($media) {
+      @media #{$media} {
+        @content;
+      }
+    } @else {
+      @error 'Breakpoint "#{$name}" does not exist';
+    }
   }
 }
 

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -3,7 +3,7 @@
 
 // Space between (Lobotomized owl) util for controlling the space between child elements.
 // You can take the child out of the layout area by giving the child a .sg-space-ignore class.
-// To automaticaly ignore empty children use "empty" class variant e.g. empty:sg-spacey-m
+// To automaticaly ignore empty children use "empty" class variant e.g. empty:sg-space-y-m
 @each $breakpoint, $variant in $responsiveVariants {
   @include sgResponsive($breakpoint) {
     @each $sizeName, $size in $sizesSetup {

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -6,7 +6,7 @@
 // To automaticaly ignore empty children use "empty" class variant e.g. empty:sg-space-y-m
 @each $breakpoint, $variant in $responsiveVariants {
   @include sgResponsive($breakpoint) {
-    @each $pseudo, $name in ('': '', ':not(empty)': 'empty\\:')
+    @each $pseudo, $name in ('': '', ':not(:empty)': 'empty\\:')
     {
       .#{$variant}#{$name}sg-space-y-0 > * + *:not(.sg-space-ignore)#{$pseudo} {
         margin-top: 0 !important;

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -11,17 +11,21 @@
       .#{$variant}sg-space-y-0 > * + *:not(.sg-space-ignore) {
         margin-top: 0 !important;
       }
+
       .#{$variant}sg-space-y-#{$sizeName} > * + *:not(.sg-space-ignore) {
         margin-top: $size !important;
       }
+
       .#{$variant}sg-space-x-0 > * + * :not(.sg-space-ignore) {
         margin-left: 0 !important;
       }
+
       .#{$variant}sg-space-x-#{$sizeName} > * + *:not(.sg-space-ignore) {
         margin-left: $size !important;
       }
-
+      
       // Automatically ignore empty elements in the same way as sg-space-ignore would be applied
+
       .#{$variant}empty\\:sg-space-y-0
         > *
         + *:not(.sg-space-ignore):not(:empty) {

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -1,17 +1,49 @@
+// sass-lint:disable no-important
 // Utils are meant to override other styles (See 7-1 or ITCSS for reference)
 
 // Space between (Lobotomized owl) util for controlling the space between child elements.
-@each $sizeName, $size in $sizesSetup {
-  .sg-space-y-0 > * + * {
-    margin-top: 0 !important;
-  }
-  .sg-space-y-#{$sizeName} > * + * {
-    margin-top: $size !important;
-  }
-  .sg-space-x-0 > * + * {
-    margin-left: 0 !important;
-  }
-  .sg-space-x-#{$sizeName} > * + * {
-    margin-left: $size !important;
+// You can take the child out of the layout area by giving the child a .sg-space-ignore class.
+// To automaticaly ignore empty children use "empty" class variant e.g. empty:sg-spacey-m
+@each $breakpoint, $variant in $responsiveVariants {
+  @include sgResponsive($breakpoint) {
+    @each $sizeName, $size in $sizesSetup {
+      // Basic version
+      .#{$variant}sg-space-y-0 > * + *:not(.sg-space-ignore) {
+        margin-top: 0 !important;
+      }
+      .#{$variant}sg-space-y-#{$sizeName} > * + *:not(.sg-space-ignore) {
+        margin-top: $size !important;
+      }
+      .#{$variant}sg-space-x-0 > * + * :not(.sg-space-ignore) {
+        margin-left: 0 !important;
+      }
+      .#{$variant}sg-space-x-#{$sizeName} > * + *:not(.sg-space-ignore) {
+        margin-left: $size !important;
+      }
+
+      // Automatically ignore empty elements in the same way as sg-space-ignore would be applied
+      .#{$variant}empty\\:sg-space-y-0
+        > *
+        + *:not(.sg-space-ignore):not(:empty) {
+        margin-top: 0 !important;
+      }
+      .#{$variant}empty\\:sg-space-y-#{$sizeName}
+        > *
+        + *:not(.sg-space-ignore):not(:empty) {
+        margin-top: $size !important;
+      }
+      .#{$variant}empty\\:sg-space-x-0
+        > *
+        + *:not(.sg-space-ignore):not(:empty) {
+        margin-left: 0 !important;
+      }
+      .#{$variant}empty\\:sg-space-x-#{$sizeName}
+        > *
+        + *:not(.sg-space-ignore):not(:empty) {
+        margin-left: $size !important;
+      }
+    }
   }
 }
+
+// sass-lint:enable no-important

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -8,7 +8,6 @@
   @include sgResponsive($breakpoint) {
     @each $pseudo, $name in ('': '', ':not(empty)': 'empty\\:')
     {
-      // Basic
       .#{$variant}#{$name}sg-space-y-0 > * + *:not(.sg-space-ignore)#{$pseudo} {
         margin-top: 0 !important;
       }
@@ -18,7 +17,6 @@
       }
 
       @each $sizeName, $size in $sizesSetup {
-        // Basic
         .#{$variant}#{$name}sg-space-y-#{$sizeName} > * + *:not(.sg-space-ignore)#{$pseudo} {
           margin-top: $size !important;
         }

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -23,27 +23,21 @@
       .#{$variant}sg-space-x-#{$sizeName} > * + *:not(.sg-space-ignore) {
         margin-left: $size !important;
       }
-      
-      // Automatically ignore empty elements in the same way as sg-space-ignore would be applied
 
-      .#{$variant}empty\\:sg-space-y-0
-        > *
-        + *:not(.sg-space-ignore):not(:empty) {
+      // Automatically ignore empty elements in the same way as sg-space-ignore would be applied
+      .#{$variant}empty\\:sg-space-y-0 > * + *:not(.sg-space-ignore):not(:empty) {
         margin-top: 0 !important;
       }
-      .#{$variant}empty\\:sg-space-y-#{$sizeName}
-        > *
-        + *:not(.sg-space-ignore):not(:empty) {
+
+      .#{$variant}empty\\:sg-space-y-#{$sizeName} > * + *:not(.sg-space-ignore):not(:empty) {
         margin-top: $size !important;
       }
-      .#{$variant}empty\\:sg-space-x-0
-        > *
-        + *:not(.sg-space-ignore):not(:empty) {
+
+      .#{$variant}empty\\:sg-space-x-0 > * + *:not(.sg-space-ignore):not(:empty) {
         margin-left: 0 !important;
       }
-      .#{$variant}empty\\:sg-space-x-#{$sizeName}
-        > *
-        + *:not(.sg-space-ignore):not(:empty) {
+
+      .#{$variant}empty\\:sg-space-x-#{$sizeName} > * + *:not(.sg-space-ignore):not(:empty) {
         margin-left: $size !important;
       }
     }

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -1,0 +1,17 @@
+// Utils are meant to override other styles (See 7-1 or ITCSS for reference)
+
+// Space between (Lobotomized owl) util for controlling the space between child elements.
+@each $sizeName, $size in $sizesSetup {
+  .sg-space-y-0 > * + * {
+    margin-top: 0 !important;
+  }
+  .sg-space-y-#{$sizeName} > * + * {
+    margin-top: $size !important;
+  }
+  .sg-space-x-0 > * + * {
+    margin-left: 0 !important;
+  }
+  .sg-space-x-#{$sizeName} > * + * {
+    margin-left: $size !important;
+  }
+}

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -1,5 +1,5 @@
-// sass-lint:disable no-important
 // Utils are meant to override other styles (See 7-1 or ITCSS for reference)
+// sass-lint:disable no-important
 
 // Space between (Lobotomized owl) util for controlling the space between child elements.
 // You can take the child out of the layout area by giving the child a .sg-space-ignore class.

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -6,39 +6,27 @@
 // To automaticaly ignore empty children use "empty" class variant e.g. empty:sg-space-y-m
 @each $breakpoint, $variant in $responsiveVariants {
   @include sgResponsive($breakpoint) {
-    @each $sizeName, $size in $sizesSetup {
-      // Basic version
-      .#{$variant}sg-space-y-0 > * + *:not(.sg-space-ignore) {
+    @each $pseudo, $name in ('': '', ':not(empty)': 'empty\\:')
+    {
+      // Basic
+      .#{$variant}#{$name}sg-space-y-0 > * + *:not(.sg-space-ignore)#{$pseudo} {
         margin-top: 0 !important;
       }
 
-      .#{$variant}sg-space-y-#{$sizeName} > * + *:not(.sg-space-ignore) {
-        margin-top: $size !important;
-      }
-
-      .#{$variant}sg-space-x-0 > * + * :not(.sg-space-ignore) {
+      .#{$variant}#{$name}sg-space-x-0 > * + * :not(.sg-space-ignore)#{$pseudo} {
         margin-left: 0 !important;
       }
 
-      .#{$variant}sg-space-x-#{$sizeName} > * + *:not(.sg-space-ignore) {
-        margin-left: $size !important;
-      }
+      @each $sizeName, $size in $sizesSetup {
+        // Basic
+        .#{$variant}#{$name}sg-space-y-#{$sizeName} > * + *:not(.sg-space-ignore)#{$pseudo} {
+          margin-top: $size !important;
+        }
 
-      // Automatically ignore empty elements in the same way as sg-space-ignore would be applied
-      .#{$variant}empty\\:sg-space-y-0 > * + *:not(.sg-space-ignore):not(:empty) {
-        margin-top: 0 !important;
-      }
+        .#{$variant}#{$name}sg-space-x-#{$sizeName} > * + *:not(.sg-space-ignore)#{$pseudo} {
+          margin-left: $size !important;
+        }
 
-      .#{$variant}empty\\:sg-space-y-#{$sizeName} > * + *:not(.sg-space-ignore):not(:empty) {
-        margin-top: $size !important;
-      }
-
-      .#{$variant}empty\\:sg-space-x-0 > * + *:not(.sg-space-ignore):not(:empty) {
-        margin-left: 0 !important;
-      }
-
-      .#{$variant}empty\\:sg-space-x-#{$sizeName} > * + *:not(.sg-space-ignore):not(:empty) {
-        margin-left: $size !important;
       }
     }
   }

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -9,6 +9,7 @@ $sgFontsPath: 'fonts/' !default;
 @import 'fonts';
 @import 'basics';
 @import 'reset';
+@import 'utils';
 @import '../components/icons/icons';
 @import '../components/subject-icons/subject-icon';
 @import '../components/subject-icons/subject-icon-box';


### PR DESCRIPTION
## What?

Add **space between** util for controlling the space between child elements (Lobotomized Owls).

## Usage

### Basic
Creates space between children. Ignoring children with `.sg-space-ignore` class
```html
<ul class="sg-space-y-xxl">
  <li>1</li>
  <li>2</li>
  <li class="sg-space-ignore">3</li> <!--  Ignored child because of class -->
  <li>4</li>
</ul>
```

### Auto emtpy node remove

```html
<ul class="emtpy:sg-space-y-xxl">
  <li>1</li>
  <li>2</li>
  <li class="sg-space-ignore">3</li> <!--  Ignored child because of class -->
  <li>4</li>
  <li></li> <!--  Ignored child because empty node -->
</ul>
```

### Responsive variants

`md:sg-space-y-xs`, `lg:sg-space-y-xs`

```html
<!--  XS margin by default, xl margin on medium screen, xxl margin on large -->
<ul class="sg-space-y-xs md:sg-space-y-xl lg:sg-space-y-xxl"> 
  // ...
</ul>
```

It works in similar way for `empty` variant

```html
<!--  XS margin by default, xl margin on medium screen, xxl margin on large -->
<ul class="empty:sg-space-y-xs md:empty:sg-space-y-xl lg:empty:sg-space-y-xxl"> 
  // ...
</ul>
```

### Easily applicable and testable from dev tools (leverages autocomplete)

![image](https://user-images.githubusercontent.com/8572321/94121315-7bbcd380-fe51-11ea-89c9-f76ada530054.png)

## Bundle size

This approach generates quite a lot of classes. Normally it is easily mitigated by using purge css againt the website. Since we don't have it yet we need to be careful here.

Let's discuss if result below is acceptable. If not we can easily get rid of some variants (eg. large screens, or empty variant becomes default)

**before:**
![image](https://user-images.githubusercontent.com/8572321/94200506-cde60f00-feba-11ea-89e0-7f835b5c3b73.png)

**after**
![image](https://user-images.githubusercontent.com/8572321/94200497-cc1c4b80-feba-11ea-9076-8ceb80ad1788.png)


## Context reference

https://alistapart.com/article/axiomatic-css-and-lobotomized-owls/