### PR TITLE
Fix modifiers in Label

### DIFF
--- a/src/components/labels/Label.jsx
+++ b/src/components/labels/Label.jsx
@@ -14,7 +14,8 @@ export type LabelColorType =
   | 'lavender'
   | 'peach'
   | 'mustard'
-  | 'gray';
+  | 'gray'
+  | 'default';
 
 export type LabelType =
   | 'default'
@@ -166,8 +167,7 @@ const Label = ({
     'sg-label',
     {
       [`sg-label--${String(backgroundColor)}`]:
-        type === 'solid' || type === 'default',
-      [`sg-label--${type}`]: type,
+        backgroundColor && (type === 'solid' || type === 'default'),
       'sg-label--closable': onClose,
     },
     className


### PR DESCRIPTION
Changes:
-  unnecessary `type`-based `className` removed

## before

![91890919-da4ec180-ec98-11ea-9666-ca39f13e7a22](https://user-images.githubusercontent.com/1231144/94446188-9623e380-01a8-11eb-9f89-304876e7575a.png)


## after

<img width="1050" alt="Screenshot 2020-09-28 at 16 32 20" src="https://user-images.githubusercontent.com/1231144/94445949-5230de80-01a8-11eb-9151-0eec215c9534.png">


closes: https://github.com/brainly/style-guide/issues/1898