### PR TITLE
Enable multiple interactive pages in docs

### DIFF
--- a/src/docs/layouts/ItemsInteractivePage.jsx
+++ b/src/docs/layouts/ItemsInteractivePage.jsx
@@ -12,16 +12,22 @@ const version = packageJSON.version;
 type PropsType = {
   navigationIdx?: number,
   rootNodeToBeRemovedAfterFullWebpackMigration?: React.Node,
-  pageBundleName?: string,
+  pageBundleName: string,
   ...
 };
 
 const ItemsInteractivePage = ({
   navigationIdx,
   rootNodeToBeRemovedAfterFullWebpackMigration,
-  pageBundleName = 'components',
+  pageBundleName,
 }: PropsType) => {
   const pageConfig = navigation[navigationIdx];
+
+  if (!pageBundleName) {
+    throw new Error(
+      `<ItemsInteractivePage/> requires pageBundleName to be specified. Current value is "${pageBundleName}".`
+    );
+  }
 
   return (
     <html>

--- a/src/docs/layouts/ItemsInteractivePage.jsx
+++ b/src/docs/layouts/ItemsInteractivePage.jsx
@@ -12,12 +12,14 @@ const version = packageJSON.version;
 type PropsType = {
   navigationIdx?: number,
   rootNodeToBeRemovedAfterFullWebpackMigration?: React.Node,
+  pageBundleName?: string,
   ...
 };
 
 const ItemsInteractivePage = ({
   navigationIdx,
   rootNodeToBeRemovedAfterFullWebpackMigration,
+  pageBundleName = 'components',
 }: PropsType) => {
   const pageConfig = navigation[navigationIdx];
 
@@ -36,7 +38,7 @@ const ItemsInteractivePage = ({
           defer
         />
 
-        <script src="js/page-components.jsx.bundle.js" defer />
+        <script src={`js/page-${pageBundleName}.jsx.bundle.js`} defer />
 
         <Navigation navigation={navigation} version={version} />
 

--- a/src/docs/page-utilities.jsx
+++ b/src/docs/page-utilities.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import slugify from './slugify';
+import navigation from './navigation';
+
+const blocks = navigation[3].elements;
+
+export const sections = blocks.map(block => {
+  const Component = block.component;
+
+  return (
+    <article key={block.name}>
+      <h2 className="article-header" id={slugify(block.name)}>
+        {block.name}
+        <a href={`#${slugify(block.name)}`} className="permalink">
+          #
+        </a>
+      </h2>
+      <Component />
+    </article>
+  );
+});
+
+const root = document.getElementById('root');
+
+if (root) {
+  ReactDOM.render(<div>{sections}</div>, root);
+}

--- a/src/docs/pages/interactive.jsx
+++ b/src/docs/pages/interactive.jsx
@@ -2,7 +2,11 @@ import React from 'react';
 import ItemsInteractivePage from '../layouts/ItemsInteractivePage';
 
 const interactive = props => (
-  <ItemsInteractivePage {...props} navigationIdx={4} />
+  <ItemsInteractivePage
+    {...props}
+    navigationIdx={4}
+    pageBundleName="components"
+  />
 );
 
 export default interactive;

--- a/src/docs/pages/utilities.jsx
+++ b/src/docs/pages/utilities.jsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import ItemsInteractivePage from '../layouts/ItemsInteractivePage';
 
-const utilities = () => <ItemsInteractivePage navigationIdx={3} />;
+const utilities = props => (
+  <ItemsInteractivePage
+    navigationIdx={3}
+    pageBundleName="utilities"
+    {...props}
+  />
+);
 
 export default utilities;

--- a/src/docs/pages/utilities.jsx
+++ b/src/docs/pages/utilities.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import ItemsInteractivePage from '../layouts/ItemsInteractivePage';
 
-const utilties = () => <ItemsInteractivePage navigationIdx={3} />;
+const utilities = () => <ItemsInteractivePage navigationIdx={3} />;
 
-export default utilties;
+export default utilities;

--- a/src/docs/pages/utilities.jsx
+++ b/src/docs/pages/utilities.jsx
@@ -3,9 +3,9 @@ import ItemsInteractivePage from '../layouts/ItemsInteractivePage';
 
 const utilities = props => (
   <ItemsInteractivePage
+    {...props}
     navigationIdx={3}
     pageBundleName="utilities"
-    {...props}
   />
 );
 

--- a/src/sass/pages/utils/space-between.jsx
+++ b/src/sass/pages/utils/space-between.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import DocsBlock from 'components/DocsBlock';
 import DocsActiveBlock from 'components/DocsActiveBlock';
-import CodeBlock from 'components/CodeBlock';
 
 const horizontalSettings = [
   {
@@ -68,9 +67,9 @@ const SpaceBetween = () => (
   <div>
     <DocsBlock info="General">
       Control the space between child elements.
-      <CodeBlock type="css">
+      {/* <CodeBlock type="css">
         {'.sg-space-{x, y}-{xxs, xs, s, m, l, xl, xxl, xxxl, xxxxl}'}
-      </CodeBlock>
+      </CodeBlock> */}
     </DocsBlock>
     <DocsBlock info="Horizontal">
       Control the horizontal space between children.

--- a/src/sass/pages/utils/space-between.jsx
+++ b/src/sass/pages/utils/space-between.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import CodeBlock from 'components/CodeBlock';
 import DocsBlock from 'components/DocsBlock';
 import DocsActiveBlock from 'components/DocsActiveBlock';
 
@@ -67,9 +68,9 @@ const SpaceBetween = () => (
   <div>
     <DocsBlock info="General">
       Control the space between child elements.
-      {/* <CodeBlock type="css">
+      <CodeBlock type="css">
         {'.sg-space-{x, y}-{xxs, xs, s, m, l, xl, xxl, xxxl, xxxxl}'}
-      </CodeBlock> */}
+      </CodeBlock>
     </DocsBlock>
     <DocsBlock info="Horizontal">
       Control the horizontal space between children.


### PR DESCRIPTION
Build setup is pretty rigid at the moment and interactive page templates are needed to make active item blocks to work. Previous docs are broken and interactive pages always point to the same bundle.