### PR TITLE
Remove image offset in avatar

### DIFF
--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -61,11 +61,6 @@ $includeHtml: false !default;
 
     &--with-border {
       border: solid $avatarBorderColor $avatarBorderWidth;
-
-      .sg-avatar__image {
-        margin-top: -$avatarBorderWidth;
-        margin-left: -$avatarBorderWidth;
-      }
     }
 
     &--spaced {


### PR DESCRIPTION
Removing offset from avatar image. Not sure why it was introduced but we cannot move element by border size here. Normally nested element should be moved by `border` to the right if they were absolutely positioned with `border box` sizing on wrapper.

Please let me know if you are aware what use case was meant to be fixed by that :)

![image](https://user-images.githubusercontent.com/8572321/95190663-f8479e80-07cf-11eb-8c5e-2c48ad6b40e6.png)

