### PR TITLE
Move background color to outer element (html-sketchapp compat)

### DIFF
--- a/src/components/avatar/Avatar.jsx
+++ b/src/components/avatar/Avatar.jsx
@@ -68,7 +68,7 @@ const Avatar = ({
     );
   } else {
     avatarContent = (
-      <div className="sg-avatar__image" title={title}>
+      <div className="sg-avatar__image sg-avatar__image--icon" title={title}>
         <Icon
           className="sg-avatar__icon"
           type="profile"

--- a/src/components/avatar/Avatar.spec.jsx
+++ b/src/components/avatar/Avatar.spec.jsx
@@ -10,6 +10,7 @@ test('render default', () => {
   expect(avatar.find('.sg-avatar__image')).toHaveLength(1);
   expect(avatar.find('img')).toHaveLength(0);
 
+  expect(avatar.find('.sg-avatar__image--icon')).toHaveLength(1);
   expect(avatar.find(Icon)).toHaveLength(1);
   expect(avatar.find(Icon).hasClass('sg-avatar__icon')).toEqual(true);
 });

--- a/src/components/avatar/_avatar.scss
+++ b/src/components/avatar/_avatar.scss
@@ -28,10 +28,13 @@ $includeHtml: false !default;
       position: relative;
       height: 100%;
       width: 100%;
+
+      &--icon {
+        background-color: $avatarDefaultBackgroundColor;
+      }
     }
 
     &__icon {
-      background-color: $avatarDefaultBackgroundColor;
       width: 100%;
       height: 100%;
     }


### PR DESCRIPTION
Unfortunately html-sketchapp is not able to properly clip background on so many nested elements with svg. I need to move bg color to outer element.

![image](https://user-images.githubusercontent.com/8572321/95210156-7bc2b900-07eb-11eb-8d3a-407142237d99.png)

 Third time lucky 🍀 