### PR TITLE
Add ability to import sg scss without fonts

### DIFF
--- a/src/sass/_fonts.scss
+++ b/src/sass/_fonts.scss
@@ -1,4 +1,5 @@
 $includeHtml: false !default;
+$includeFonts: true !default;
 $proximaNovaRegularWoff2Path: $sgFontsPath + 'ProximaNova-Regular.woff2';
 $proximaNovaRegularWoffPath: $sgFontsPath + 'ProximaNova-Regular.woff';
 $proximaNovaBoldWoff2Path: $sgFontsPath + 'ProximaNova-Bold.woff2';
@@ -6,7 +7,7 @@ $proximaNovaBoldWoffPath: $sgFontsPath + 'ProximaNova-Bold.woff';
 $proximaNovaBlackWoff2Path: $sgFontsPath + 'ProximaNova-Black.woff2';
 $proximaNovaBlackWoffPath: $sgFontsPath + 'ProximaNova-Black.woff';
 
-@if ($includeHtml) {
+@if ($includeHtml and $includeFonts) {
 
   @font-face {
     font-family: $fontFamilyProximaNova;

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -1,4 +1,5 @@
 $includeHtml: true;
+$includeFonts: true !default;
 $sgImagesPath: 'images/' !default;
 $sgFontsPath: 'fonts/' !default;
 


### PR DESCRIPTION
In the spa application we want to directly import scss from style-guide package instead relying on external url to the built css. We still want to link to external resources which are unlikely to change so there should be a way to not import fonts when scss in being processed.