### PR TITLE
Remove horizontal padding for transparent labels

### DIFF
--- a/src/components/labels/Label.jsx
+++ b/src/components/labels/Label.jsx
@@ -171,6 +171,8 @@ const Label = ({
       [`sg-label--${String(backgroundColor)}`]:
         backgroundColor && (type === 'solid' || type === 'default'),
       'sg-label--closable': onClose,
+      'sg-label--transparent':
+        type === 'transparent' || type === 'transparent-color',
     },
     className
   );

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -27,6 +27,11 @@
     margin-left: 6px;
   }
 
+  &--transparent {
+    padding-left: 0;
+    padding-right: 0;
+  }
+
   &--black {
     background-color: $black;
   }


### PR DESCRIPTION
Change dictated by the needs of the designers. Transparent labels do not have an element that would indicate a visible margin. Therefore, it is a problem when aligning elements on designs.

We remove horizontal padding in transparent labels and let manage the spacing between elements by the parent container.

![image](https://user-images.githubusercontent.com/8572321/95729781-a6928e80-0c7d-11eb-8e68-396f1061f9ee.png)
