### PR TITLE
Add Accordion Component

### DIFF
--- a/src/components/accordion/Accordion.jsx
+++ b/src/components/accordion/Accordion.jsx
@@ -25,7 +25,7 @@ export const AccordionContext = createContext<AccordionContextType>({
   onChange: () => undefined,
 });
 
-const spaceClasses = {
+export const spaceClasses = {
   xxs: 'sg-space-y-xxs',
   xs: 'sg-space-y-xs',
   s: 'sg-space-y-s',
@@ -63,7 +63,7 @@ const Accordion = ({
 
   const classes = cx(
     {
-      [`${spaceClasses[spacing]}`]: !!spacing,
+      [`${spaceClasses[spacing]}`]: spaceClasses[spacing],
     },
     className
   );

--- a/src/components/accordion/Accordion.jsx
+++ b/src/components/accordion/Accordion.jsx
@@ -1,0 +1,77 @@
+//@flow strict
+
+import React, {createContext, useCallback, useState} from 'react';
+import cx from 'classnames';
+
+type PropType = $ReadOnly<{
+  allowMultiple?: boolean,
+  children: React$Node,
+  className?: string,
+  spacing: 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl' | 'xxxxl',
+}>;
+
+type OpenedMapType = {
+  [key: string]: boolean,
+};
+
+type AccordionContextType = {
+  opened: OpenedMapType,
+  onChange: (item: string, value: boolean) => void,
+};
+
+export const AccordionContext = createContext<AccordionContextType>({
+  opened: {},
+  onChange: () => undefined,
+});
+
+const spaceClasses = {
+  xxs: 'sg-space-y-xxs',
+  xs: 'sg-space-y-xs',
+  s: 'sg-space-y-s',
+  m: 'sg-space-y-m',
+  l: 'sg-space-y-l',
+  xl: 'sg-space-y-xl',
+  xxl: 'sg-space-y-xxl',
+  xxxl: 'sg-space-y-xxxl',
+  xxxxl: 'sg-space-y-xxxxl',
+};
+
+const Accordion = ({
+  children,
+  allowMultiple = false,
+  className = '',
+  spacing = 's',
+}: PropType) => {
+  const [opened, setOpened] = useState({});
+
+  const handleChange = useCallback(
+    (item: string, value: boolean) => {
+      if (allowMultiple) {
+        setOpened({...opened, [item]: value});
+      } else {
+        const newOpened = {...opened};
+
+        Object.keys(newOpened).forEach(i => (newOpened[i] = false));
+        setOpened({...newOpened, [item]: value});
+      }
+    },
+    [opened, allowMultiple]
+  );
+
+  const context = {onChange: handleChange, opened};
+
+  const classes = cx(
+    {
+      [`${spaceClasses[spacing]}`]: !!spacing,
+    },
+    className
+  );
+
+  return (
+    <AccordionContext.Provider value={context}>
+      <div className={classes}>{children}</div>
+    </AccordionContext.Provider>
+  );
+};
+
+export default Accordion;

--- a/src/components/accordion/Accordion.jsx
+++ b/src/components/accordion/Accordion.jsx
@@ -12,6 +12,7 @@ type PropType = $ReadOnly<{
 
 type OpenedMapType = {
   [key: string]: boolean,
+  ...,
 };
 
 type AccordionContextType = {

--- a/src/components/accordion/Accordion.jsx
+++ b/src/components/accordion/Accordion.jsx
@@ -7,7 +7,7 @@ type PropType = $ReadOnly<{
   allowMultiple?: boolean,
   children: React$Node,
   className?: string,
-  spacing: 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl' | 'xxxxl',
+  spacing?: 'xxs' | 'xs' | 's' | 'm' | 'l' | 'xl' | 'xxl' | 'xxxl' | 'xxxxl',
 }>;
 
 type OpenedMapType = {

--- a/src/components/accordion/Accordion.spec.jsx
+++ b/src/components/accordion/Accordion.spec.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {mount} from 'enzyme';
+import {act} from 'react-dom/test-utils';
+import Accordion from './Accordion';
+import AccordionItem from './AccordionItem';
+
+describe('<Accordion>', () => {
+  it('renders', () => {
+    const accordion = mount(
+      <Accordion>
+        <AccordionItem title="Item 1">Accordion Item Description</AccordionItem>
+      </Accordion>
+    );
+
+    expect(
+      accordion
+        .find(AccordionItem)
+        .containsMatchingElement('Accordion Item Description')
+    ).toBe(true);
+  });
+
+  it('has collapsed items by default', () => {
+    const accordion = mount(
+      <Accordion>
+        <AccordionItem title="Item 1">Accordion Item Description</AccordionItem>
+      </Accordion>
+    );
+
+    expect(
+      accordion
+        .find(AccordionItem)
+        .getDOMNode()
+        .getAttribute('aria-expanded')
+    ).toBe('false');
+  });
+
+  it('expands items after click', () => {
+    const accordion = mount(
+      <Accordion>
+        <AccordionItem title="Item 1">Accordion Item Description</AccordionItem>
+      </Accordion>
+    );
+
+    const accordionItem = accordion.find(AccordionItem);
+
+    accordionItem.simulate('click');
+
+    expect(accordionItem.getDOMNode().getAttribute('aria-expanded')).toBe(
+      'true'
+    );
+
+    expect(accordion.find('.sg-accordion-item__content--hidden')).toHaveLength(
+      0
+    );
+  });
+});

--- a/src/components/accordion/Accordion.spec.jsx
+++ b/src/components/accordion/Accordion.spec.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {mount} from 'enzyme';
-import {act} from 'react-dom/test-utils';
 import Accordion from './Accordion';
 import AccordionItem from './AccordionItem';
 
@@ -52,5 +51,39 @@ describe('<Accordion>', () => {
     expect(accordion.find('.sg-accordion-item__content--hidden')).toHaveLength(
       0
     );
+  });
+
+  it('expands one item at a time when "allowMultiple" is set to false', () => {
+    const accordion = mount(
+      <Accordion>
+        <AccordionItem title="Item 1">Accordion Item Description</AccordionItem>
+        <AccordionItem title="Item 2">Accordion Item Description</AccordionItem>
+        <AccordionItem title="Item 3">Accordion Item Description</AccordionItem>
+      </Accordion>
+    );
+
+    accordion.find({title: 'Item 1'}).simulate('click');
+    accordion.find({title: 'Item 2'}).simulate('click');
+    accordion.find({title: 'Item 3'}).simulate('click');
+
+    // hostNodes returns html elements and skip react components
+    expect(accordion.find('[aria-expanded=true]').hostNodes()).toHaveLength(1);
+  });
+
+  it('allows expanding multiple items when "allowMultiple" is set to true', () => {
+    const accordion = mount(
+      <Accordion allowMultiple>
+        <AccordionItem title="Item 1">Accordion Item Description</AccordionItem>
+        <AccordionItem title="Item 2">Accordion Item Description</AccordionItem>
+        <AccordionItem title="Item 3">Accordion Item Description</AccordionItem>
+      </Accordion>
+    );
+
+    accordion.find({title: 'Item 1'}).simulate('click');
+    accordion.find({title: 'Item 2'}).simulate('click');
+    accordion.find({title: 'Item 3'}).simulate('click');
+
+    // hostNodes returns html elements and skip react components
+    expect(accordion.find('[aria-expanded=true]').hostNodes()).toHaveLength(3);
   });
 });

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -29,7 +29,7 @@ const copy = {
   url: '#',
 };
 
-export const CallToAction = ({url, cta}: {url: string, cta: string}) => {
+const CallToAction = ({url, cta}: {url: string, cta: string}) => {
   return (
     <Flex marginTop="s">
       <Link href={url}>

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -1,0 +1,45 @@
+//@flow strict
+
+import React from 'react';
+import Accordion from './Accordion';
+import AccordionItem from './AccordionItem';
+import {Flex, Icon, Link} from '../../index';
+
+export default {
+  title: 'Components/Accordion',
+  parameters: {
+    component: Accordion,
+  },
+};
+
+const copy = {
+  title: 'Is this title for accordion?',
+  description:
+    "Now your family member just needs to open the link and hit 'accept'. If they aren't already on Brainly, we'll hook them up with that too. Create your unique family link with a click and share it with your family via email, Messenger, WhatsApp, whatever you like.",
+  cta: 'Learn more',
+  url: '#',
+};
+
+const CallToAction = ({url, cta}) => {
+  return (
+    <Flex marginTop="s">
+      <Link href={url}>
+        <Flex inlineFlex alignItems="center">
+          <span>{cta}</span>
+          <Icon type="arrow_right" color="blue" size={16} />
+        </Flex>
+      </Link>
+    </Flex>
+  );
+};
+
+export const Default = args => (
+  <Accordion {...args}>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+  </Accordion>
+);

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -1,4 +1,4 @@
-//@flow strict
+//@flow
 
 import React from 'react';
 import Accordion from './Accordion';
@@ -28,7 +28,7 @@ const copy = {
   url: '#',
 };
 
-const CallToAction = ({url, cta}) => {
+const CallToAction = ({url, cta}: {url: string, cta: string}) => {
   return (
     <Flex marginTop="s">
       <Link href={url}>
@@ -41,7 +41,7 @@ const CallToAction = ({url, cta}) => {
   );
 };
 
-export const Default = args => (
+export const Default = (args: any) => (
   <Accordion {...args}>
     <AccordionItem title={copy.title}>
       {copy.description} <CallToAction url={copy.url} cta={copy.cta} />

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -6,7 +6,7 @@ import AccordionItem from './AccordionItem';
 import {Flex, Icon, Link} from '../../index';
 
 export default {
-  title: 'Components/Accordion',
+  title: 'Layout/Accordion',
   parameters: {
     component: Accordion,
     subcomponents: {AccordionItem},

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -9,6 +9,14 @@ export default {
   title: 'Components/Accordion',
   parameters: {
     component: Accordion,
+    subcomponents: {AccordionItem},
+  },
+  argTypes: {
+    children: {
+      control: {
+        disable: true,
+      },
+    },
   },
 };
 

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -23,6 +23,7 @@ export default {
 const copy = {
   title: 'Is this title for accordion?',
   description:
+    // eslint-disable-next-line max-len
     "Now your family member just needs to open the link and hit 'accept'. If they aren't already on Brainly, we'll hook them up with that too. Create your unique family link with a click and share it with your family via email, Messenger, WhatsApp, whatever you like.",
   cta: 'Learn more',
   url: '#',

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -29,7 +29,7 @@ const copy = {
   url: '#',
 };
 
-const CallToAction = ({url, cta}: {url: string, cta: string}) => {
+export const CallToAction = ({url, cta}: {url: string, cta: string}) => {
   return (
     <Flex marginTop="s">
       <Link href={url}>

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -109,6 +109,7 @@ const AccordionItem = ({
       onMouseLeave={() => {
         isHidden && setIsHover(false);
       }}
+      aria-expanded={!isHidden}
     >
       <Flex
         direction="row"

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -1,0 +1,165 @@
+//@flow strict
+
+import React, {useContext, useLayoutEffect, useRef, useState} from 'react';
+import type {Node} from 'react';
+import cx from 'classnames';
+import Box from '../box/Box';
+import Flex from '../flex/Flex';
+import Icon from '../icons/Icon';
+import Link from '../text/Link';
+import Text from '../text/Text';
+import {AccordionContext} from './Accordion';
+
+type PropType = $ReadOnly<{
+  title: Node,
+  titleSize?: 'small' | 'large',
+  children?: Node,
+  className?: string,
+}>;
+
+function generateId() {
+  return Math.random()
+    .toString(36)
+    .substring(7);
+}
+
+const AccordionItem = ({
+  title,
+  titleSize = 'large',
+  children,
+  className = '',
+}: PropType) => {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  const id = useRef<string>(`AccordionItem_${generateId()}`);
+  const [isHover, setIsHover] = useState(false);
+
+  const item = id.current;
+  const {opened, onChange} = useContext(AccordionContext);
+  const isHidden = !opened[item];
+
+  const handleClickOnBody = () => {
+    if (!isHidden) {
+      return;
+    }
+    onChange(item, true);
+    setIsHover(false);
+  };
+
+  const handleClickOnTitle = () => {
+    if (isHidden) {
+      return;
+    }
+    onChange(item, false);
+  };
+
+  useLayoutEffect(() => {
+    if (isHidden) {
+      collapse();
+    } else {
+      expand();
+    }
+  }, [isHidden]);
+
+  const collapse = () => {
+    if (!contentRef.current) {
+      return;
+    }
+    const sectionHeight = contentRef.current.scrollHeight;
+
+    requestAnimationFrame(function() {
+      if (!contentRef.current) {
+        return;
+      }
+      contentRef.current.style.height = `${sectionHeight}px`;
+
+      requestAnimationFrame(function() {
+        if (!contentRef.current) {
+          return;
+        }
+        contentRef.current.style.height = `${0}px`;
+      });
+    });
+  };
+
+  const expand = () => {
+    if (!contentRef.current) {
+      return;
+    }
+    const sectionHeight = contentRef.current.scrollHeight;
+
+    contentRef.current.style.height = `${sectionHeight}px`;
+  };
+
+  return (
+    <Box
+      color="light"
+      border
+      borderColor={isHover ? 'dark' : 'gray-secondary-lightest'}
+      onClick={handleClickOnBody}
+      className={cx(
+        'sg-accordion-item__pointer',
+        {
+          'sg-accordion-item__pointer': !isHidden,
+        },
+        className
+      )}
+      onMouseEnter={() => {
+        isHidden && setIsHover(true);
+      }}
+      onMouseLeave={() => {
+        isHidden && setIsHover(false);
+      }}
+    >
+      <Flex
+        direction="row"
+        justifyContent="space-between"
+        alignItems="center"
+        className={cx({
+          'sg-accordion-item__pointer': !isHidden,
+        })}
+        onClick={handleClickOnTitle}
+        onMouseEnter={() => {
+          !isHidden && setIsHover(true);
+        }}
+        onMouseLeave={() => {
+          !isHidden && setIsHover(false);
+        }}
+      >
+        <Link
+          type="h1"
+          size={titleSize}
+          color="black"
+          weight="bold"
+          underlined={isHover}
+        >
+          {title}
+        </Link>
+        <Flex
+          justifyContent="center"
+          alignItems="center"
+          className={cx('sg-accordion-item__icon', {
+            'sg-accordion-item__icon--hover': isHover,
+          })}
+        >
+          <Icon
+            type="arrow_down"
+            color="dark"
+            className={cx('sg-accordion-item__arrow', {
+              'sg-accordion-item__arrow--visible': !isHidden,
+            })}
+          />
+        </Flex>
+      </Flex>
+      <div
+        className={cx('sg-accordion-item__content', {
+          'sg-accordion-item__content--hidden': isHidden,
+        })}
+        ref={contentRef}
+      >
+        <Text>{children}</Text>
+      </div>
+    </Box>
+  );
+};
+
+export default AccordionItem;

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -53,42 +53,61 @@ const AccordionItem = ({
   };
 
   useLayoutEffect(() => {
-    if (isHidden) {
-      collapse();
-    } else {
-      expand();
-    }
-  }, [isHidden]);
+    const content = contentRef.current;
 
-  const collapse = () => {
-    if (!contentRef.current) {
-      return;
-    }
-    const sectionHeight = contentRef.current.scrollHeight;
-
-    requestAnimationFrame(function() {
+    function collapse() {
       if (!contentRef.current) {
         return;
       }
-      contentRef.current.style.height = `${sectionHeight}px`;
+      const sectionHeight = contentRef.current.scrollHeight;
 
       requestAnimationFrame(function() {
         if (!contentRef.current) {
           return;
         }
-        contentRef.current.style.height = `${0}px`;
+        contentRef.current.style.height = `${sectionHeight}px`;
+
+        requestAnimationFrame(function() {
+          if (!contentRef.current) {
+            return;
+          }
+          contentRef.current.style.height = `${0}px`;
+        });
       });
-    });
-  };
-
-  const expand = () => {
-    if (!contentRef.current) {
-      return;
     }
-    const sectionHeight = contentRef.current.scrollHeight;
 
-    contentRef.current.style.height = `${sectionHeight}px`;
-  };
+    function expand() {
+      if (!contentRef.current) {
+        return;
+      }
+      const sectionHeight = contentRef.current.scrollHeight;
+
+      contentRef.current.style.height = `${sectionHeight}px`;
+      contentRef.current.addEventListener('transitionend', onTransitionEnd);
+    }
+
+    function onTransitionEnd() {
+      if (!contentRef.current) {
+        return;
+      }
+
+      contentRef.current.style.height = 'auto';
+      contentRef.current.removeEventListener('transitionend', onTransitionEnd);
+    }
+
+    if (isHidden) {
+      collapse();
+    } else {
+      expand();
+    }
+
+    return () => {
+      if (!content) {
+        return;
+      }
+      content.removeEventListener('transitionend', onTransitionEnd);
+    };
+  }, [isHidden]);
 
   return (
     <Box

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1,7 +1,7 @@
 @if ($includeHtml) {
   .sg-accordion-item {
     &__content {
-      transition: 0.2s ease-in-out height;
+      transition: 0.2s ease-out height;
       height: 0;
       overflow: hidden;
       margin-top: spacing(m);
@@ -16,7 +16,7 @@
     }
 
     &__arrow {
-      transition: 0.2s ease-in-out transform;
+      transition: 0.2s ease-out transform;
       transform: rotateX(0);
 
       &--visible {

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1,7 +1,7 @@
 @if ($includeHtml) {
   .sg-accordion-item {
     &__content {
-      transition: 0.2s ease-in-out all;
+      transition: 0.2s ease-in-out height;
       height: 0;
       overflow: hidden;
       margin-top: spacing(m);
@@ -16,7 +16,7 @@
     }
 
     &__arrow {
-      transition: 0.2s ease-in-out all;
+      transition: 0.2s ease-in-out transform;
       transform: rotateX(0);
 
       &--visible {

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1,0 +1,38 @@
+@if ($includeHtml) {
+  .sg-accordion-item {
+    &__content {
+      transition: 0.2s ease-in-out all;
+      height: 0;
+      overflow: hidden;
+      margin-top: spacing(m);
+
+      &--hidden {
+        margin-top: 0;
+      }
+    }
+
+    &__pointer {
+      cursor: pointer;
+    }
+
+    &__arrow {
+      transition: 0.2s ease-in-out all;
+      transform: rotateX(0);
+
+      &--visible {
+        transform: rotate(180deg);
+      }
+    }
+
+    &__icon {
+      border-radius: 50%;
+      width: 40px;
+      height: 40px;
+      flex: none;
+
+      &--hover {
+        background: $graySecondaryLightest;
+      }
+    }
+  }
+}

--- a/src/components/accordion/pages/accordion-interactive.jsx
+++ b/src/components/accordion/pages/accordion-interactive.jsx
@@ -47,7 +47,10 @@ const Accordions = () => {
   return (
     <div>
       <DocsActiveBlock settings={settings}>
-        <Accordion>
+        <Accordion allowMultiple>
+          <AccordionItem title={copy.title}>
+            {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+          </AccordionItem>
           <AccordionItem title={copy.title}>
             {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
           </AccordionItem>

--- a/src/components/accordion/pages/accordion-interactive.jsx
+++ b/src/components/accordion/pages/accordion-interactive.jsx
@@ -13,7 +13,7 @@ const copy = {
   url: '#',
 };
 
-export const CallToAction = ({url, cta}: {url: string, cta: string}) => {
+export const CallToAction = ({url, cta}) => {
   return (
     <Flex marginTop="s">
       <Link href={url}>

--- a/src/components/accordion/pages/accordion-interactive.jsx
+++ b/src/components/accordion/pages/accordion-interactive.jsx
@@ -13,6 +13,7 @@ const copy = {
   url: '#',
 };
 
+// eslint-disable-next-line react/prop-types
 export const CallToAction = ({url, cta}) => {
   return (
     <Flex marginTop="s">
@@ -34,6 +35,8 @@ const Accordions = () => {
     },
     {
       name: 'spacing',
+      // we get object with {key: key} props,
+      // {xs: 'xs', s:'s', etc}
       values: Object.keys(spaceClasses).reduce(
         (acc, val) => ({
           ...acc,

--- a/src/components/accordion/pages/accordion-interactive.jsx
+++ b/src/components/accordion/pages/accordion-interactive.jsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import DocsActiveBlock from 'components/DocsActiveBlock';
+import Accordion, {spaceClasses} from '../Accordion';
+import AccordionItem from '../AccordionItem';
+import {Flex, Icon, Link} from '../../../index';
+
+const copy = {
+  title: 'Is this title for accordion?',
+  description:
+    // eslint-disable-next-line max-len
+    "Now your family member just needs to open the link and hit 'accept'. If they aren't already on Brainly, we'll hook them up with that too. Create your unique family link with a click and share it with your family via email, Messenger, WhatsApp, whatever you like.",
+  cta: 'Learn more',
+  url: '#',
+};
+
+export const CallToAction = ({url, cta}: {url: string, cta: string}) => {
+  return (
+    <Flex marginTop="s">
+      <Link href={url}>
+        <Flex inlineFlex alignItems="center">
+          <span>{cta}</span>
+          <Icon type="arrow_right" color="blue" size={16} />
+        </Flex>
+      </Link>
+    </Flex>
+  );
+};
+
+const Accordions = () => {
+  const settings = [
+    {
+      name: 'allowMultiple',
+      values: Boolean,
+    },
+    {
+      name: 'spacing',
+      values: Object.keys(spaceClasses).reduce(
+        (acc, val) => ({
+          ...acc,
+          [val]: val,
+        }),
+        {}
+      ),
+    },
+  ];
+
+  return (
+    <div>
+      <DocsActiveBlock settings={settings}>
+        <Accordion>
+          <AccordionItem title={copy.title}>
+            {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+          </AccordionItem>
+          <AccordionItem title={copy.title}>
+            {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+          </AccordionItem>
+        </Accordion>
+      </DocsActiveBlock>
+    </div>
+  );
+};
+
+export default Accordions;

--- a/src/components/accordion/pages/accordion.jsx
+++ b/src/components/accordion/pages/accordion.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import DocsBlock from 'components/DocsBlock';
+import {Default} from '../Accordion.stories';
+
+const accordion = () => (
+  <div>
+    <DocsBlock info="Doesn't allow multiple items expanded">
+      <Default />
+    </DocsBlock>
+    <DocsBlock info="Allows multiple items expanded">
+      <Default allowMultiple />
+    </DocsBlock>
+  </div>
+);
+
+export default accordion;

--- a/src/docs/navigation.js
+++ b/src/docs/navigation.js
@@ -49,6 +49,7 @@ import SpinnerContainers from '../components/spinner-container/pages/spinner-con
 import dropdowns from '../components/dropdowns/pages/dropdowns';
 import UtilsIntroduction from '../sass/pages/utils/introduction';
 import SpaceBetween from '../sass/pages/utils/space-between';
+import accordion from '../components/accordion/pages/accordion';
 
 const navigation = [
   {
@@ -209,6 +210,10 @@ const navigation = [
     name: 'Containers',
     location: 'containers',
     elements: [
+      {
+        name: 'Accordion',
+        component: accordion,
+      },
       {
         name: 'Bubble',
         component: bubble,

--- a/src/docs/page-components.jsx
+++ b/src/docs/page-components.jsx
@@ -43,8 +43,10 @@ import Helpers from 'helpers/pages/rwd-interactive';
 import ContentBoxes from 'content-box/pages/content-box-interactive';
 import Spinners from 'spinner/pages/spinners-interactive';
 import SpinnerContainers from 'spinner-container/pages/spinner-containers-interactive';
+import Accordion from 'accordion/pages/accordion-interactive';
 
 const demos = {
+  Accordion: <Accordion />,
   Avatars: <Avatars />,
   Bubbles: <Bubbles />,
   Buttons: <Buttons />,

--- a/src/index.js
+++ b/src/index.js
@@ -96,3 +96,5 @@ export {default as Text} from './components/text/Text';
 export {default as TextBit} from './components/text/TextBit';
 export {default as TopLayer} from './components/toplayer/TopLayer';
 export {default as hex} from './components/colors/hex';
+export {default as Accordion} from './components/accordion/Accordion';
+export {default as AccordionItem} from './components/accordion/AccordionItem';

--- a/src/sass/main.scss
+++ b/src/sass/main.scss
@@ -58,3 +58,4 @@ $sgFontsPath: 'fonts/' !default;
 @import '../components/layout/layout';
 @import '../components/spinner/spinner';
 @import '../components/spinner-container/spinner-container';
+@import '../components/accordion/accordion';


### PR DESCRIPTION
Accordion based on accordion compoent from `components/src/ui`:
- changed interface (`spacing` prop uses `sg-spacing-[...]` utility class internally)
- added storybook stories (next docs)
- added current docs. Note: Interactive part has problem related to `useLayoutEffect` for jsx rendering. Current docs don't handle that. I won't fix it as we move to storybook.
- edit: fixed responsiveness of component after expanding
- edit: changed transition function to ease out (which fits better for expanding, for collapsing it's better to have ease in but it's not a big issue)

responsive bug will be fixed in separate pr

![Screenshot 2020-11-02 at 17 11 09](https://user-images.githubusercontent.com/8572321/97891110-a93d4c80-1d2e-11eb-9a97-b65e968cfc69.png)
![Screenshot 2020-11-02 at 17 11 58](https://user-images.githubusercontent.com/8572321/97891120-ac383d00-1d2e-11eb-8c05-95cdb47707f2.png)
![Screenshot 2020-11-02 at 17 12 37](https://user-images.githubusercontent.com/8572321/97891122-acd0d380-1d2e-11eb-875c-4100c475acc7.png)
