### PR TITLE
Fix padding top in AccordionItem content

### DIFF
--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -201,7 +201,7 @@ const AccordionItem = ({
       </Box>
 
       <div className="sg-accordion-item__content" ref={contentRef}>
-        <Box padding={padding}>
+        <Box padding={padding} className="sg-accordion-item__content-box">
           <Text>{children}</Text>
         </Box>
       </div>

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -23,6 +23,10 @@
       overflow: hidden;
     }
 
+    &__content-box {
+      padding-top: 0;
+    }
+
     &__pointer {
       cursor: pointer;
     }


### PR DESCRIPTION
before:
![image](https://user-images.githubusercontent.com/14280367/100451921-792c6380-30b8-11eb-9595-c9c98d70b009.png)

after:
![image](https://user-images.githubusercontent.com/14280367/100451942-821d3500-30b8-11eb-8ba4-b43c0db55259.png)
