### PR TITLE
Fix Accordion item scrolling issue part II

### DIFF
--- a/src/components/accordion/Accordion.jsx
+++ b/src/components/accordion/Accordion.jsx
@@ -79,7 +79,13 @@ const Accordion = ({
       const key = KEY_CODES[event.keyCode];
 
       if (['space', 'enter'].includes(key)) {
-        event.preventDefault();
+        if (
+          event.target instanceof HTMLElement &&
+          event.target.id === state.focusedElementId
+        ) {
+          event.preventDefault();
+        }
+
         dispatch({type: 'accordion/KEYBOARD_SET_OPENED'});
       }
     }
@@ -91,7 +97,7 @@ const Accordion = ({
       if (!wrapper) return;
       wrapper.removeEventListener('keydown', handleKeyDown);
     };
-  }, []);
+  }, [state.focusedElementId]);
 
   function getUpdatedOpenedItems(
     opened: OpenedItemsType,

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -51,6 +51,36 @@ export const Default = (args: any) => (
     <AccordionItem title={copy.title}>
       {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
     </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
+    <AccordionItem title={copy.title}>
+      {copy.description} <CallToAction url={copy.url} cta={copy.cta} />
+    </AccordionItem>
   </Accordion>
 );
 

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -58,9 +58,7 @@ const AccordionItem = ({
   const isHighlighted = isHovered || isFocused;
   const isBorderHighlighted = isHighlighted && !noGapBetweenElements;
 
-  const toggleOpen = (event: SyntheticEvent<HTMLElement>) => {
-    event.preventDefault();
-
+  const toggleOpen = () => {
     dispatch({
       type: 'accordion/SET_OPENED',
       payload: {id, value: isHidden},

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -1,5 +1,7 @@
 @if ($includeHtml) {
   .sg-accordion-item {
+    overflow-anchor: none;
+
     &--no-gap {
       border-radius: 0;
       border-top: none;


### PR DESCRIPTION
Turned out preventDefault is not needed, what we need is `overflow-anchor: none` 😅 