### PR TITLE
Select - remove custom line-height (a11y fix)

### DIFF
--- a/src/components/form-elements/_select.scss
+++ b/src/components/form-elements/_select.scss
@@ -16,7 +16,6 @@ $includeHtml: false !default;
       font-size: $formElementDefaultFontSize;
       color: $formElementPlacholderTextColor;
       height: $formElementSizeM;
-      line-height: $formElementSizeM - 4px; // subtraction due to top and bottom border
       background: $formElementDefaultBackgroundColor;
       border-radius: $formElementStandardBorderRadius;
 
@@ -97,7 +96,6 @@ $includeHtml: false !default;
 
       .sg-select__element {
         height: $formElementSizeL;
-        line-height: $formElementSizeL - 4px; // subtraction due to top and bottom border
         font-size: $formElementLargeFontSize;
         border-radius: $formElementLargeBorderRadius;
         padding: 0 50px 0 spacing(m);


### PR DESCRIPTION
It's changed to fulfill the following obligation:

"Text can be resized without assistive technology up to 200 percent without loss of content or functionality, except for captions and images of text."

ref: https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-scale.html

checked on: chrome, safari, firefox, edge and ie11

moreover, setting `line-height` there didn't result in any visual change for default (100%) size.

## before:

**when 200% of text resize**

<img width="1075" alt="Screenshot 2020-12-08 at 09 44 15" src="https://user-images.githubusercontent.com/1231144/101460980-92e06d00-393a-11eb-8998-d8e0b00ec850.png">

**when 100% of text size** (no influence)

<img width="951" alt="Screenshot 2020-12-08 at 09 44 29" src="https://user-images.githubusercontent.com/1231144/101460985-94aa3080-393a-11eb-863f-a89b0d9d0776.png">


## after:

**when 200% of text resize**
<img width="1152" alt="Screenshot 2020-12-08 at 09 43 49" src="https://user-images.githubusercontent.com/1231144/101460964-8fe57c80-393a-11eb-9ab0-5eaf77650d30.png">

**when 100% of text size** (no influence)
<img width="856" alt="Screenshot 2020-12-08 at 09 44 21" src="https://user-images.githubusercontent.com/1231144/101460982-93790380-393a-11eb-9260-5fdfdb52f7a8.png">