### PR TITLE
Fix reduce motion check

### DIFF
--- a/src/components/utils/useReducedMotion.js
+++ b/src/components/utils/useReducedMotion.js
@@ -7,7 +7,8 @@ export default function useReducedMotion(): boolean {
 
   const [matches, setMatch] = useState(
     supportsMatchMedia
-      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      ? window.matchMedia('(prefers-reduced-motion: reduce)').matches ||
+          window.matchMedia('(prefers-reduced-motion)').matches
       : false
   );
 
@@ -15,10 +16,17 @@ export default function useReducedMotion(): boolean {
     if (!supportsMatchMedia) {
       return noop => noop;
     }
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const mediaQuery =
+      window.matchMedia('(prefers-reduced-motion: reduce)') ||
+      window.matchMedia('(prefers-reduced-motion)');
+
     const handleChange = () => {
       setMatch(mediaQuery.matches);
     };
+
+    if (!mediaQuery) {
+      return;
+    }
 
     handleChange();
     mediaQuery.addEventListener('change', handleChange);

--- a/src/components/utils/useReducedMotion.js
+++ b/src/components/utils/useReducedMotion.js
@@ -20,13 +20,13 @@ export default function useReducedMotion(): boolean {
       window.matchMedia('(prefers-reduced-motion: reduce)') ||
       window.matchMedia('(prefers-reduced-motion)');
 
-    const handleChange = () => {
-      setMatch(mediaQuery.matches);
-    };
-
     if (!mediaQuery) {
       return;
     }
+
+    const handleChange = () => {
+      setMatch(mediaQuery.matches);
+    };
 
     handleChange();
     mediaQuery.addEventListener('change', handleChange);


### PR DESCRIPTION
Apparently on ios12 `window.matchMedia('(prefers-reduced-motion: reduce)')` returns undefined instead of proper match media object (looks like a bug, matchMedia is supported there). We need to have extensive cheking. Additionally `(prefers-reduced-motion)` is added as some devices supports only this shorter form