### PR TITLE
Fix reduce motion check vol. 2

### DIFF
--- a/src/components/utils/useReducedMotion.js
+++ b/src/components/utils/useReducedMotion.js
@@ -29,9 +29,9 @@ export default function useReducedMotion(): boolean {
     };
 
     handleChange();
-    mediaQuery.addEventListener('change', handleChange);
+    mediaQuery.addListener(handleChange);
     return () => {
-      mediaQuery.removeEventListener('change', handleChange);
+      mediaQuery.removeListener(handleChange);
     };
   }, [supportsMatchMedia]);
   return matches;


### PR DESCRIPTION
It fixes:
`TypeError: mediaQuery.addEventListener is not a function. (In 'mediaQuery.addEventListener('change', handleChange)', 'mediaQuery.addEventListener' is undefined)` error that is thrown on devices with  iOS v12, but also on desktop ie. Firefox v52.

According to: https://developer.mozilla.org/en-US/docs/Web/API/MediaQueryList/addListener:

> "Older browsers should use addListener instead of addEventListener since MediaQueryList only inherits from EventTarget in newer browsers."

at the same time it should still work for newer browsers.
