### PR TITLE
Add label to Radio and Checkbox

### DIFF
--- a/src/components/form-elements/Checkbox.jsx
+++ b/src/components/form-elements/Checkbox.jsx
@@ -10,7 +10,7 @@ export type CheckboxPropsType = {
   checked?: boolean,
   id?: string,
   className?: string,
-  children: React$Node,
+  children?: React$Node,
   ...
 };
 

--- a/src/components/form-elements/Checkbox.jsx
+++ b/src/components/form-elements/Checkbox.jsx
@@ -43,7 +43,7 @@ class Checkbox extends PureComponent<CheckboxPropsType, CheckboxStateType> {
           id={id}
           checked={checked}
         />
-        <div className="sg-checkbox__ghost">
+        <div className="sg-checkbox__ghost" aria-hidden="true">
           <Icon type="check" color="adaptive" size={16} />
         </div>
         {children !== undefined && children !== null && (
@@ -53,7 +53,6 @@ class Checkbox extends PureComponent<CheckboxPropsType, CheckboxStateType> {
             color="default"
             weight="bold"
             className="sg-checkbox__label"
-            aria-hidden="true"
           >
             {children}
           </Text>

--- a/src/components/form-elements/Checkbox.jsx
+++ b/src/components/form-elements/Checkbox.jsx
@@ -46,11 +46,11 @@ class Checkbox extends PureComponent<CheckboxPropsType, CheckboxStateType> {
         <div className="sg-checkbox__ghost">
           <Icon type="check" color="adaptive" size={16} />
         </div>
-        {children && (
+        {children !== undefined && children !== null && (
           <Text
             size="small"
             type="span"
-            color="black"
+            color="default"
             weight="bold"
             className="sg-checkbox__label"
             aria-hidden="true"

--- a/src/components/form-elements/Checkbox.jsx
+++ b/src/components/form-elements/Checkbox.jsx
@@ -52,9 +52,8 @@ class Checkbox extends PureComponent<CheckboxPropsType, CheckboxStateType> {
             type="span"
             color="black"
             weight="bold"
-            className="sg-radio__label"
+            className="sg-checkbox__label"
             aria-hidden="true"
-            data-checked={checked}
           >
             {children}
           </Text>

--- a/src/components/form-elements/Checkbox.jsx
+++ b/src/components/form-elements/Checkbox.jsx
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import React, {PureComponent} from 'react';
 import generateRandomString from '../../js/generateRandomString';
 import Icon from '../icons/Icon';
+import Text from '../text/Text';
 
 export type CheckboxPropsType = {
   checked?: boolean,
@@ -45,13 +46,19 @@ class Checkbox extends PureComponent<CheckboxPropsType, CheckboxStateType> {
         <div className="sg-checkbox__ghost">
           <Icon type="check" color="adaptive" size={16} />
         </div>
-        <small
-          className="sg-checkbox__label"
-          aria-hidden="true"
-          data-checked={checked}
-        >
-          {children}
-        </small>
+        {children && (
+          <Text
+            size="small"
+            type="span"
+            color="black"
+            weight="bold"
+            className="sg-radio__label"
+            aria-hidden="true"
+            data-checked={checked}
+          >
+            {children}
+          </Text>
+        )}
       </label>
     );
   }

--- a/src/components/form-elements/Checkbox.jsx
+++ b/src/components/form-elements/Checkbox.jsx
@@ -9,6 +9,7 @@ export type CheckboxPropsType = {
   checked?: boolean,
   id?: string,
   className?: string,
+  children: React$Node,
   ...
 };
 
@@ -27,13 +28,13 @@ class Checkbox extends PureComponent<CheckboxPropsType, CheckboxStateType> {
   }
 
   render() {
-    const {checked, className, ...additionalProps} = this.props;
+    const {checked, className, children, ...additionalProps} = this.props;
     const {id} = this.state;
 
     const checkboxClass = classNames('sg-checkbox', className);
 
     return (
-      <div className={checkboxClass}>
+      <label className={checkboxClass} htmlFor={id}>
         <input
           {...additionalProps}
           className="sg-checkbox__element"
@@ -41,10 +42,17 @@ class Checkbox extends PureComponent<CheckboxPropsType, CheckboxStateType> {
           id={id}
           checked={checked}
         />
-        <label className="sg-checkbox__ghost" htmlFor={id}>
+        <div className="sg-checkbox__ghost">
           <Icon type="check" color="adaptive" size={16} />
-        </label>
-      </div>
+        </div>
+        <small
+          className="sg-checkbox__label"
+          aria-hidden="true"
+          data-checked={checked}
+        >
+          {children}
+        </small>
+      </label>
     );
   }
 }

--- a/src/components/form-elements/Checkbox.spec.jsx
+++ b/src/components/form-elements/Checkbox.spec.jsx
@@ -9,6 +9,12 @@ test('render', () => {
   expect(checkbox.find('input[type="checkbox"]')).toHaveLength(1);
 });
 
+test('renders with label', () => {
+  const checkbox = shallow(<Checkbox>Checkbox</Checkbox>);
+
+  expect(checkbox.find('Text').contains('Checkbox')).toEqual(true);
+});
+
 test('not checked', () => {
   const checkbox = shallow(<Checkbox />);
   const input = checkbox.find('input[type="checkbox"]');

--- a/src/components/form-elements/Checkbox.stories.jsx
+++ b/src/components/form-elements/Checkbox.stories.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Checkbox from './Checkbox';
+
+export default {
+  title: 'Components/Checkbox',
+  parameters: {
+    component: Checkbox,
+  },
+};
+
+export const Default = () => <Checkbox>Button</Checkbox>;

--- a/src/components/form-elements/Checkbox.stories.jsx
+++ b/src/components/form-elements/Checkbox.stories.jsx
@@ -8,4 +8,10 @@ export default {
   },
 };
 
-export const Default = () => <Checkbox>Button</Checkbox>;
+export const Default = args => <Checkbox {...args} />;
+
+Default.args = {
+  children: 'Checkbox',
+};
+
+Default.argsTypes = {};

--- a/src/components/form-elements/Checkbox.stories.jsx
+++ b/src/components/form-elements/Checkbox.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Checkbox from './Checkbox';
 
 export default {
-  title: 'Components/Checkbox',
+  title: 'Components/Form/Checkbox',
   parameters: {
     component: Checkbox,
   },

--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -60,7 +60,6 @@ const Radio = (props: RadioPropsType) => {
           weight="bold"
           className="sg-radio__label"
           aria-hidden="true"
-          data-checked={checked}
         >
           {children}
         </Text>

--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -18,7 +18,7 @@ export type RadioPropsType = {
   id?: string,
   size?: ?RadioSizeType,
   className?: string,
-  children: React$Node,
+  children?: React$Node,
   ...
 };
 

--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import generateRandomString from '../../js/generateRandomString';
+import Text from '../text/Text';
 
 type RadioSizeType = 'xxs' | 's';
 
@@ -51,13 +52,19 @@ const Radio = (props: RadioPropsType) => {
         id={id}
       />
       <span className="sg-radio__ghost" aria-hidden />
-      <span
-        className="sg-radio__label"
-        aria-hidden="true"
-        data-checked={checked}
-      >
-        {children}
-      </span>
+      {children && (
+        <Text
+          size="small"
+          type="span"
+          color="black"
+          weight="bold"
+          className="sg-radio__label"
+          aria-hidden="true"
+          data-checked={checked}
+        >
+          {children}
+        </Text>
+      )}
     </label>
   );
 };

--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -52,11 +52,11 @@ const Radio = (props: RadioPropsType) => {
         id={id}
       />
       <span className="sg-radio__ghost" aria-hidden />
-      {children && (
+      {children !== undefined && children !== null && (
         <Text
           size="small"
           type="span"
-          color="black"
+          color="default"
           weight="bold"
           className="sg-radio__label"
           aria-hidden="true"

--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -51,7 +51,7 @@ const Radio = (props: RadioPropsType) => {
         name={name}
         id={id}
       />
-      <span className="sg-radio__ghost" aria-hidden />
+      <span className="sg-radio__ghost" aria-hidden="true" />
       {children !== undefined && children !== null && (
         <Text
           size="small"
@@ -59,7 +59,6 @@ const Radio = (props: RadioPropsType) => {
           color="default"
           weight="bold"
           className="sg-radio__label"
-          aria-hidden="true"
         >
           {children}
         </Text>

--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -17,6 +17,7 @@ export type RadioPropsType = {
   id?: string,
   size?: ?RadioSizeType,
   className?: string,
+  children: React$Node,
   ...
 };
 
@@ -27,6 +28,7 @@ const Radio = (props: RadioPropsType) => {
     size = 'xxs',
     className,
     id = generateRandomString(),
+    children,
     ...additionalProps
   } = props;
 
@@ -39,7 +41,7 @@ const Radio = (props: RadioPropsType) => {
   );
 
   return (
-    <div className={radioClass}>
+    <label className={radioClass} htmlFor={id}>
       <input
         {...additionalProps}
         className="sg-radio__element"
@@ -48,8 +50,15 @@ const Radio = (props: RadioPropsType) => {
         name={name}
         id={id}
       />
-      <label className="sg-radio__ghost" htmlFor={id} />
-    </div>
+      <span className="sg-radio__ghost" aria-hidden />
+      <span
+        className="sg-radio__label"
+        aria-hidden="true"
+        data-checked={checked}
+      >
+        {children}
+      </span>
+    </label>
   );
 };
 

--- a/src/components/form-elements/Radio.spec.jsx
+++ b/src/components/form-elements/Radio.spec.jsx
@@ -9,6 +9,12 @@ test('render', () => {
   expect(radio.find('input[type="radio"]')).toHaveLength(1);
 });
 
+test('renders with label', () => {
+  const checkbox = shallow(<Radio>Radio</Radio>);
+
+  expect(checkbox.find('Text').contains('Radio')).toEqual(true);
+});
+
 test('not checked', () => {
   const radio = shallow(<Radio />);
   const input = radio.find('input[type="radio"]');

--- a/src/components/form-elements/Radio.stories.jsx
+++ b/src/components/form-elements/Radio.stories.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import Radio from './Radio';
+
+export default {
+  title: 'Components/Radio',
+  parameters: {
+    component: Radio,
+  },
+};
+
+export const Default = () => <Radio>Button</Radio>;

--- a/src/components/form-elements/Radio.stories.jsx
+++ b/src/components/form-elements/Radio.stories.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Radio from './Radio';
 
 export default {
-  title: 'Components/Radio',
+  title: 'Components/Form/Radio',
   parameters: {
     component: Radio,
   },

--- a/src/components/form-elements/Radio.stories.jsx
+++ b/src/components/form-elements/Radio.stories.jsx
@@ -8,4 +8,10 @@ export default {
   },
 };
 
-export const Default = () => <Radio>Button</Radio>;
+export const Default = args => <Radio {...args} />;
+
+Default.args = {
+  children: 'Radio',
+};
+
+Default.argsTypes = {};

--- a/src/components/form-elements/_checkbox-radio.scss
+++ b/src/components/form-elements/_checkbox-radio.scss
@@ -1,4 +1,5 @@
 $radioSizeXXS: componentSize(xxs);
+$radioSizeXS: componentSize(xs);
 $radioSizeS: componentSize(s);
 $crInputColor: $white;
 $crInputBorderColor: $graySecondaryLight;
@@ -15,10 +16,11 @@ $includeHtml: false !default;
   .sg-radio {
     @include component();
     overflow: visible;
-    height: $radioSizeXXS;
-    min-height: $radioSizeXXS;
+    height: $radioSizeXS;
+    min-height: $radioSizeXS;
     display: inline-flex;
     align-items: center;
+    padding: spacing(xxs) 0;
 
     &__element {
       opacity: 0;

--- a/src/components/form-elements/_checkbox-radio.scss
+++ b/src/components/form-elements/_checkbox-radio.scss
@@ -15,11 +15,10 @@ $includeHtml: false !default;
   .sg-radio {
     @include component();
     overflow: visible;
-    width: $radioSizeXXS;
     height: $radioSizeXXS;
     min-height: $radioSizeXXS;
     display: inline-flex;
-    align-items: baseline;
+    align-items: center;
 
     &__element {
       opacity: 0;
@@ -48,7 +47,7 @@ $includeHtml: false !default;
     }
 
     &__label {
-      margin-left: 4px;
+      margin-left: 16px;
     }
   }
 
@@ -95,7 +94,6 @@ $includeHtml: false !default;
     }
 
     &--s {
-      width: $radioSizeS;
       height: $radioSizeS;
       min-height: $radioSizeS;
       line-height: $radioSizeS;

--- a/src/components/form-elements/_checkbox-radio.scss
+++ b/src/components/form-elements/_checkbox-radio.scss
@@ -18,6 +18,8 @@ $includeHtml: false !default;
     width: $radioSizeXXS;
     height: $radioSizeXXS;
     min-height: $radioSizeXXS;
+    display: inline-flex;
+    align-items: baseline;
 
     &__element {
       opacity: 0;
@@ -42,6 +44,11 @@ $includeHtml: false !default;
       align-items: center;
       justify-content: center;
       cursor: pointer;
+      flex: none;
+    }
+
+    &__label {
+      margin-left: 4px;
     }
   }
 

--- a/src/components/form-elements/pages/checkbox-interactive.jsx
+++ b/src/components/form-elements/pages/checkbox-interactive.jsx
@@ -13,7 +13,7 @@ const Checkboxes = () => {
   return (
     <div>
       <DocsActiveBlock settings={settings}>
-        <Checkbox />
+        <Checkbox>Checkbox</Checkbox>
       </DocsActiveBlock>
     </div>
   );

--- a/src/components/form-elements/pages/checkbox.jsx
+++ b/src/components/form-elements/pages/checkbox.jsx
@@ -8,22 +8,11 @@ const dumpProps = {onChange: () => undefined};
 const checkboxes = () => (
   <div>
     <DocsBlock info="Checkboxes">
-      <Checkbox />
-      <Checkbox checked {...dumpProps} />
-      <br />
-      <LabelDeprecated
-        secondary
-        text="Check me!"
-        htmlFor="checkbox-1"
-        iconContent={<Checkbox id="checkbox-1" />}
-      />
-      <LabelDeprecated
-        secondary
-        text="Check me!"
-        htmlFor="checkbox-2"
-        emphasised
-        iconContent={<Checkbox id="checkbox-2" />}
-      />
+      <Checkbox> First</Checkbox>
+      <Checkbox checked {...dumpProps}>
+        Second
+      </Checkbox>
+      <Checkbox> Third</Checkbox>
     </DocsBlock>
   </div>
 );

--- a/src/components/form-elements/pages/checkbox.jsx
+++ b/src/components/form-elements/pages/checkbox.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import Checkbox from '../Checkbox';
 import DocsBlock from 'components/DocsBlock';
-import LabelDeprecated from 'labels-deprecated/LabelDeprecated';
 
 const dumpProps = {onChange: () => undefined};
 

--- a/src/components/form-elements/pages/checkbox.jsx
+++ b/src/components/form-elements/pages/checkbox.jsx
@@ -7,11 +7,13 @@ const dumpProps = {onChange: () => undefined};
 const checkboxes = () => (
   <div>
     <DocsBlock info="Checkboxes">
-      <Checkbox> First</Checkbox>
-      <Checkbox checked {...dumpProps}>
-        Second
-      </Checkbox>
-      <Checkbox> Third</Checkbox>
+      <div className="sg-space-x-m">
+        <Checkbox> First</Checkbox>
+        <Checkbox checked {...dumpProps}>
+          Second
+        </Checkbox>
+        <Checkbox> Third</Checkbox>
+      </div>
     </DocsBlock>
   </div>
 );

--- a/src/components/form-elements/pages/radio-interactive.jsx
+++ b/src/components/form-elements/pages/radio-interactive.jsx
@@ -17,7 +17,7 @@ const Radios = () => {
   return (
     <div>
       <DocsActiveBlock settings={settings}>
-        <Radio />
+        <Radio>Radio</Radio>
       </DocsActiveBlock>
     </div>
   );

--- a/src/components/form-elements/pages/radio.jsx
+++ b/src/components/form-elements/pages/radio.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import DocsBlock from 'components/DocsBlock';
-import LabelDeprecated from 'labels-deprecated/LabelDeprecated';
 import Radio from '../Radio';
 
 const dumpProps = {onChange: () => undefined};

--- a/src/components/form-elements/pages/radio.jsx
+++ b/src/components/form-elements/pages/radio.jsx
@@ -8,25 +8,18 @@ const dumpProps = {onChange: () => undefined};
 const radios = () => (
   <div>
     <DocsBlock info="Radio Buttons">
-      <Radio name="group1" />
-      <Radio name="group1" checked {...dumpProps} />
-      <br />
-      <LabelDeprecated
-        secondary
-        htmlFor="radio-3"
-        text="Check me!"
-        iconContent={<Radio name="group2" />}
-      />
-      <LabelDeprecated
-        secondary
-        htmlFor="radio-4"
-        text="Check me!"
-        iconContent={<Radio name="group3" />}
-      />
+      <Radio name="group1">First</Radio>
+      <Radio name="group1" checked {...dumpProps}>
+        Second
+      </Radio>
     </DocsBlock>
     <DocsBlock info="Size S">
-      <Radio size="s" name="group4" />
-      <Radio size="s" name="group4" checked {...dumpProps} />
+      <Radio size="s" name="group2">
+        First
+      </Radio>
+      <Radio size="s" name="group2" checked {...dumpProps}>
+        Second
+      </Radio>
     </DocsBlock>
   </div>
 );

--- a/src/components/form-elements/pages/radio.jsx
+++ b/src/components/form-elements/pages/radio.jsx
@@ -8,18 +8,22 @@ const dumpProps = {onChange: () => undefined};
 const radios = () => (
   <div>
     <DocsBlock info="Radio Buttons">
-      <Radio name="group1">First</Radio>
-      <Radio name="group1" checked {...dumpProps}>
-        Second
-      </Radio>
+      <div className="sg-space-x-m">
+        <Radio name="group1">First</Radio>
+        <Radio name="group1" checked {...dumpProps}>
+          Second
+        </Radio>
+      </div>
     </DocsBlock>
     <DocsBlock info="Size S">
-      <Radio size="s" name="group2">
-        First
-      </Radio>
-      <Radio size="s" name="group2" checked {...dumpProps}>
-        Second
-      </Radio>
+      <div className="sg-space-x-m">
+        <Radio size="s" name="group2">
+          First
+        </Radio>
+        <Radio size="s" name="group2" checked {...dumpProps}>
+          Second
+        </Radio>
+      </div>
     </DocsBlock>
   </div>
 );


### PR DESCRIPTION
## Changes
This is enabler for further development.

- Adding built-in label to `checkbox` and `radio` components, making upcoming implementation of redesign (almost finished by designer) a bit easier from this point. This is backward compatible with current solution if label is not provided.
- Removing deprecated label from radio and checkbox examples.


![image](https://user-images.githubusercontent.com/8572321/104891679-90c5f100-5971-11eb-962c-4a8c08248454.png)

![image](https://user-images.githubusercontent.com/8572321/104891698-96233b80-5971-11eb-8c65-7a601f1d23d6.png)

![image](https://user-images.githubusercontent.com/8572321/104891762-a3d8c100-5971-11eb-8582-22c659ded089.png)

![image](https://user-images.githubusercontent.com/8572321/104891888-c965ca80-5971-11eb-9e33-28cdc92a699e.png)

![image](https://user-images.githubusercontent.com/8572321/104891919-d2569c00-5971-11eb-8fa6-945e0166bc8d.png)

