### PR TITLE
Add extra large breakpoint to scss

### DIFF
--- a/src/components/helpers/pages/rwd.jsx
+++ b/src/components/helpers/pages/rwd.jsx
@@ -5,7 +5,7 @@ import Icon, {TYPE as icoTypes, ICON_COLOR} from 'icons/Icon';
 
 const RwdHelpers = () => (
   <div>
-    <DocsBlock info="RwdHelper (deprecated)" additionalInfo="use custom ">
+    <DocsBlock info="RwdHelper (deprecated)">
       <ul>
         <li>
           <RwdHelper hide={TYPE.SMALL_ONLY}>

--- a/src/components/helpers/pages/rwd.jsx
+++ b/src/components/helpers/pages/rwd.jsx
@@ -5,7 +5,7 @@ import Icon, {TYPE as icoTypes, ICON_COLOR} from 'icons/Icon';
 
 const RwdHelpers = () => (
   <div>
-    <DocsBlock info="Top (middle)" additionalInfo="--top">
+    <DocsBlock info="RwdHelper (deprecated)" additionalInfo="use custom ">
       <ul>
         <li>
           <RwdHelper hide={TYPE.SMALL_ONLY}>

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,7 @@
 // @flow strict
 
 export {default as ActionList} from './components/action-list/ActionList';
-export {
-  default as ActionListHole,
-} from './components/action-list/ActionListHole';
+export {default as ActionListHole} from './components/action-list/ActionListHole';
 export {default as Avatar} from './components/avatar/Avatar';
 export {default as Box} from './components/box/Box';
 export {default as Breadcrumb} from './components/breadcrumbs/Breadcrumb';
@@ -14,22 +12,12 @@ export {default as Card} from './components/card/Card';
 export {default as CardHole} from './components/card/CardHole';
 export {default as ContentBox} from './components/content-box/ContentBox';
 export {default as Counter} from './components/counters/Counter';
-export {
-  default as ContentBoxActions,
-} from './components/content-box/ContentBoxActions';
-export {
-  default as ContentBoxContent,
-} from './components/content-box/ContentBoxContent';
-export {
-  default as ContentBoxHeader,
-} from './components/content-box/ContentBoxHeader';
-export {
-  default as ContentBoxTitle,
-} from './components/content-box/ContentBoxTitle';
+export {default as ContentBoxActions} from './components/content-box/ContentBoxActions';
+export {default as ContentBoxContent} from './components/content-box/ContentBoxContent';
+export {default as ContentBoxHeader} from './components/content-box/ContentBoxHeader';
+export {default as ContentBoxTitle} from './components/content-box/ContentBoxTitle';
 export {default as Dropdown} from './components/dropdowns/Dropdown';
-export {
-  default as FlashMessage,
-} from './components/flash-messages/FlashMessage';
+export {default as FlashMessage} from './components/flash-messages/FlashMessage';
 export {default as Flex} from './components/flex/Flex';
 export {default as Footer} from './components/footer/Footer';
 export {default as FooterLine} from './components/footer/FooterLine';
@@ -46,24 +34,16 @@ export {default as HeaderMiddle} from './components/header/HeaderMiddle';
 export {default as HeaderRight} from './components/header/HeaderRight';
 export {default as RwdHelper} from './components/helpers/RwdHelper';
 export {default as HomeButton} from './components/home-button/HomeButton';
-export {
-  default as IconAsButton,
-} from './components/icon-as-button/IconAsButton';
+export {default as IconAsButton} from './components/icon-as-button/IconAsButton';
 export {default as Icon} from './components/icons/Icon';
 export {default as MobileIcon} from './components/mobile-icons/MobileIcon';
-export {
-  default as LabelDeprecated,
-} from './components/labels-deprecated/LabelDeprecated';
+export {default as LabelDeprecated} from './components/labels-deprecated/LabelDeprecated';
 export {default as Label} from './components/labels/Label';
 export {default as FileHandler} from './components/file-handler/FileHandler';
 export {default as Layout} from './components/layout/Layout';
-export {
-  default as LayoutAsideContent,
-} from './components/layout/LayoutAsideContent';
+export {default as LayoutAsideContent} from './components/layout/LayoutAsideContent';
 export {default as LayoutContent} from './components/layout/LayoutContent';
-export {
-  default as LayoutSecondaryContent,
-} from './components/layout/LayoutSecondaryContent';
+export {default as LayoutSecondaryContent} from './components/layout/LayoutSecondaryContent';
 export {default as List} from './components/list/List';
 export {default as ListItem} from './components/list/ListItem';
 export {default as ListItemIcon} from './components/list/ListItemIcon';
@@ -76,20 +56,12 @@ export {default as OverlayedBox} from './components/overlayed-box/OverlayedBox';
 export {default as PopupMenu} from './components/popup-menu/PopupMenu';
 export {default as Rating} from './components/rating/Rating';
 export {default as Search} from './components/search/Search';
-export {
-  default as SeparatorHorizontal,
-} from './components/separators/SeparatorHorizontal';
-export {
-  default as SeparatorVertical,
-} from './components/separators/SeparatorVertical';
+export {default as SeparatorHorizontal} from './components/separators/SeparatorHorizontal';
+export {default as SeparatorVertical} from './components/separators/SeparatorVertical';
 export {default as Spinner} from './components/spinner/Spinner';
-export {
-  default as SpinnerContainer,
-} from './components/spinner-container/SpinnerContainer';
+export {default as SpinnerContainer} from './components/spinner-container/SpinnerContainer';
 export {default as SubjectIcon} from './components/subject-icons/SubjectIcon';
-export {
-  default as SubjectIconBox,
-} from './components/subject-icons/SubjectIconBox';
+export {default as SubjectIconBox} from './components/subject-icons/SubjectIconBox';
 export {default as Headline} from './components/text/Headline';
 export {default as Link} from './components/text/Link';
 export {default as Text} from './components/text/Text';

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,9 @@
 // @flow strict
 
 export {default as ActionList} from './components/action-list/ActionList';
-export {default as ActionListHole} from './components/action-list/ActionListHole';
+export {
+  default as ActionListHole,
+} from './components/action-list/ActionListHole';
 export {default as Avatar} from './components/avatar/Avatar';
 export {default as Box} from './components/box/Box';
 export {default as Breadcrumb} from './components/breadcrumbs/Breadcrumb';
@@ -12,12 +14,22 @@ export {default as Card} from './components/card/Card';
 export {default as CardHole} from './components/card/CardHole';
 export {default as ContentBox} from './components/content-box/ContentBox';
 export {default as Counter} from './components/counters/Counter';
-export {default as ContentBoxActions} from './components/content-box/ContentBoxActions';
-export {default as ContentBoxContent} from './components/content-box/ContentBoxContent';
-export {default as ContentBoxHeader} from './components/content-box/ContentBoxHeader';
-export {default as ContentBoxTitle} from './components/content-box/ContentBoxTitle';
+export {
+  default as ContentBoxActions,
+} from './components/content-box/ContentBoxActions';
+export {
+  default as ContentBoxContent,
+} from './components/content-box/ContentBoxContent';
+export {
+  default as ContentBoxHeader,
+} from './components/content-box/ContentBoxHeader';
+export {
+  default as ContentBoxTitle,
+} from './components/content-box/ContentBoxTitle';
 export {default as Dropdown} from './components/dropdowns/Dropdown';
-export {default as FlashMessage} from './components/flash-messages/FlashMessage';
+export {
+  default as FlashMessage,
+} from './components/flash-messages/FlashMessage';
 export {default as Flex} from './components/flex/Flex';
 export {default as Footer} from './components/footer/Footer';
 export {default as FooterLine} from './components/footer/FooterLine';
@@ -34,16 +46,24 @@ export {default as HeaderMiddle} from './components/header/HeaderMiddle';
 export {default as HeaderRight} from './components/header/HeaderRight';
 export {default as RwdHelper} from './components/helpers/RwdHelper';
 export {default as HomeButton} from './components/home-button/HomeButton';
-export {default as IconAsButton} from './components/icon-as-button/IconAsButton';
+export {
+  default as IconAsButton,
+} from './components/icon-as-button/IconAsButton';
 export {default as Icon} from './components/icons/Icon';
 export {default as MobileIcon} from './components/mobile-icons/MobileIcon';
-export {default as LabelDeprecated} from './components/labels-deprecated/LabelDeprecated';
+export {
+  default as LabelDeprecated,
+} from './components/labels-deprecated/LabelDeprecated';
 export {default as Label} from './components/labels/Label';
 export {default as FileHandler} from './components/file-handler/FileHandler';
 export {default as Layout} from './components/layout/Layout';
-export {default as LayoutAsideContent} from './components/layout/LayoutAsideContent';
+export {
+  default as LayoutAsideContent,
+} from './components/layout/LayoutAsideContent';
 export {default as LayoutContent} from './components/layout/LayoutContent';
-export {default as LayoutSecondaryContent} from './components/layout/LayoutSecondaryContent';
+export {
+  default as LayoutSecondaryContent,
+} from './components/layout/LayoutSecondaryContent';
 export {default as List} from './components/list/List';
 export {default as ListItem} from './components/list/ListItem';
 export {default as ListItemIcon} from './components/list/ListItemIcon';
@@ -56,12 +76,20 @@ export {default as OverlayedBox} from './components/overlayed-box/OverlayedBox';
 export {default as PopupMenu} from './components/popup-menu/PopupMenu';
 export {default as Rating} from './components/rating/Rating';
 export {default as Search} from './components/search/Search';
-export {default as SeparatorHorizontal} from './components/separators/SeparatorHorizontal';
-export {default as SeparatorVertical} from './components/separators/SeparatorVertical';
+export {
+  default as SeparatorHorizontal,
+} from './components/separators/SeparatorHorizontal';
+export {
+  default as SeparatorVertical,
+} from './components/separators/SeparatorVertical';
 export {default as Spinner} from './components/spinner/Spinner';
-export {default as SpinnerContainer} from './components/spinner-container/SpinnerContainer';
+export {
+  default as SpinnerContainer,
+} from './components/spinner-container/SpinnerContainer';
 export {default as SubjectIcon} from './components/subject-icons/SubjectIcon';
-export {default as SubjectIconBox} from './components/subject-icons/SubjectIconBox';
+export {
+  default as SubjectIconBox,
+} from './components/subject-icons/SubjectIconBox';
 export {default as Headline} from './components/text/Headline';
 export {default as Link} from './components/text/Link';
 export {default as Text} from './components/text/Text';

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -137,7 +137,7 @@ $breakpointsMap: (
   'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
   'medium-down': '(max-width: #{$breakpointLarge - 1px})',
   'medium-up': '(min-width: #{$breakpointMedium})',
-  'large-only': '(min-width: #{$breakpointLarge})' // deprecated
+  'large-only': '(min-width: #{$breakpointLarge})',
   'large-up': '(min-width: #{$breakpointLarge})',
   'xlarge-up': '(min-width: #{$breakpointXLarge})',
 );

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -133,6 +133,7 @@ $breakpointsMap: (
   'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
   'medium-down': '(max-width: #{$breakpointLarge - 1px})',
   'medium-up': '(min-width: #{$breakpointMedium})',
+  'large-down': '(max-width: #{$breakpointLarge - 1px})',
   'large-only': '(min-width: #{$breakpointLarge})',
   'large-up': '(min-width: #{$breakpointLarge})',
   'xlarge-up': '(min-width: #{$breakpointXLarge})',

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -126,26 +126,35 @@ $toplayerZIndex: 1000;
 // Breakpoints
 $breakpointMedium: 768px !default;
 $breakpointLarge: 1024px !default;
+$breakpointXLarge: 1280px !default;
+
+// Max width of the content
+// TODO(mskowronek): to be verified with designers
+$contentMaxWidth: 1224px;
 
 $breakpointsMap: (
   'small-only': '(max-width: #{$breakpointMedium - 1px})',
   'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
   'medium-down': '(max-width: #{$breakpointLarge - 1px})',
   'medium-up': '(min-width: #{$breakpointMedium})',
-  'large-only': '(min-width: #{$breakpointLarge})'
+  'large-only': '(min-width: #{$breakpointLarge})' // deprecated
+  'large-up': '(min-width: #{$breakpointLarge})',
+  'xlarge-up': '(min-width: #{$breakpointXLarge})',
 );
 
 // Breakpoints map for mobile first approach usage
 $responsiveBreakpointsMap: (
   'md': '(min-width: #{$breakpointMedium})',
   'lg': '(min-width: #{$breakpointLarge})',
+  'xl': '(min-width: #{$breakpointXLarge})',
 );
 
-// Breakpoints variants for generating reposnive utility classes
+// Breakpoints variants for generating responsive utility classes
 $responsiveVariants: (
   '': '',
   md: 'md\\:',
   lg: 'lg\\:',
+  xl: 'xl\\:',
 );
 
 // Form elements configuration

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -133,7 +133,6 @@ $breakpointsMap: (
   'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',
   'medium-down': '(max-width: #{$breakpointLarge - 1px})',
   'medium-up': '(min-width: #{$breakpointMedium})',
-  'large-down': '(max-width: #{$breakpointLarge - 1px})',
   'large-only': '(min-width: #{$breakpointLarge})',
   'large-up': '(min-width: #{$breakpointLarge})',
   'xlarge-up': '(min-width: #{$breakpointXLarge})',

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -128,10 +128,6 @@ $breakpointMedium: 768px !default;
 $breakpointLarge: 1024px !default;
 $breakpointXLarge: 1280px !default;
 
-// Max width of the content
-// TODO(mskowronek): to be verified with designers
-$contentMaxWidth: 1224px;
-
 $breakpointsMap: (
   'small-only': '(max-width: #{$breakpointMedium - 1px})',
   'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',

--- a/src/sass/_config.scss
+++ b/src/sass/_config.scss
@@ -128,6 +128,8 @@ $breakpointMedium: 768px !default;
 $breakpointLarge: 1024px !default;
 $breakpointXLarge: 1280px !default;
 
+/// @deprecated Adding values to this map should be avoided.
+/// Use $responsiveBreakpointsMap
 $breakpointsMap: (
   'small-only': '(max-width: #{$breakpointMedium - 1px})',
   'medium-only': '(min-width: #{$breakpointMedium}) and (max-width: #{$breakpointLarge - 1px})',

--- a/src/sass/_helpers.scss
+++ b/src/sass/_helpers.scss
@@ -11,6 +11,7 @@ $includeHtml: false !default;
 @if ($includeHtml) {
 
   @each $breakpointName, $media in $breakpointsMap {
+    /// @deprecated Use sgResponsive mixin instead. sgResponsive promotes mobile first approach.
     .sg-hide-for-#{$breakpointName} {
       @include sgBreakpoint($breakpointName) {
         //sass-lint:disable no-important

--- a/src/sass/_mixins.scss
+++ b/src/sass/_mixins.scss
@@ -74,6 +74,7 @@
   @return $baselines * $baseline;
 }
 
+/// @deprecated Use sgResponsive instead. sgResponsive promotes mobile first approach.
 @mixin sgBreakpoint($name) {
   $media: map-get($breakpointsMap, $name);
   @if($media) {


### PR DESCRIPTION
Exposing extra large breakpoint which is part of our design system.

Available as 
- **scss variable: `$breakpointXLarge`**
- **mobile first mixin: `sgResponsive(xl)`** - this should be preferred way. Mobile first approach.
- class: `sg-hide-for-xlarge-up`
- mixin `sgBreakpoint(xlarge-up)` -  this mixin shuld be avoided as it mixes 3 different approaches (strict resolution, mobile first and desktop first)


Notes:
- **`sgBreakpoint`, `sg-hide-for-xxx` classes and `RwdHelper` (uses internally sg-hide) are marked as deprecated**
- I added `large-up` to breakpoint map which is the same as wrongly named `large-only`. I leave `large-only` as it is for backward compatibility but `large-up` should be used from now on.


