### PR TITLE
v183.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "183.6.0",
+  "version": "183.7.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",


### PR DESCRIPTION
## Features
- Add extra large breakpoint to scss

## Maintenance
- Mark `sgBreakpoint`, `sg-hide-for-xxx` and `RwdHelper` component as deprecated. Promote `sgResponsive` as a main mixin utility for handling responsiveness using mobile first approach.