### PR TITLE
Generate correct html attributes.

### DIFF
--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -48,6 +48,21 @@ files.forEach(sourceFile => {
     transformedCode = transformedCode.replace(/forwardRef<.*>/g, 'forwardRef');
   }
 
+  // For all inexact prop types make sure that all pass through props are declared as
+  // intersection with HTMLAttributes<HTMLElement>
+  ast
+    .find(jsc.TypeAlias)
+    .filter(path => path.node.id.name.match(/.*PropsType/))
+    .filter(path => path.node.right.inexact)
+    .forEach(path => {
+      const [start, end] = path.node.range;
+      // get code without last character which is semicolon
+      const code = transformedCode.substring(start, end - 1);
+      const newCode = `${code} & React.HTMLAttributes<HTMLElement>;`;
+
+      transformedCode = transformedCode.replace(code, newCode);
+    });
+
   const typescriptCode = convert(transformedCode, {
     printWidth: 80,
     singleQuote: true,

--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -53,7 +53,9 @@ files.forEach(sourceFile => {
   ast
     .find(jsc.TypeAlias)
     .filter(path => path.node.id.name.match(/.*PropsType/))
-    .filter(path => path.node.right.inexact)
+    .filter(
+      path => jsc(path).find(jsc.ObjectTypeAnnotation, {inexact: true}).length
+    )
     .forEach(path => {
       const [start, end] = path.node.range;
       // get code without last character which is semicolon


### PR DESCRIPTION
New codemod for inexact PropTypes in TypeScript declaration. 


We treat a lot of components like native ones and inexact type is not enough for TypeScript to handle native properties in Style Guide components.

All inexact types which are PropTypes of a component will result in following definition.

![Screenshot 2021-02-02 at 18 00 56](https://user-images.githubusercontent.com/8572321/106674355-669c4200-65b3-11eb-8cd9-3b31559ac7ff.png)


Before change in our `components` package in frontend app.
![Screenshot 2021-02-02 at 17 36 27](https://user-images.githubusercontent.com/8572321/106674508-a19e7580-65b3-11eb-806b-341f91e81915.png)

After change, in `components` package in frontend app.
![image](https://user-images.githubusercontent.com/8572321/106674581-d1e61400-65b3-11eb-8fee-018ab8738872.png)

Outstanding issues are correctly caught problems in code. I will fix them separately.
