### PR TITLE
Adjust title prop for AccordionItem

### DIFF
--- a/src/components/accordion/Accordion.spec.jsx
+++ b/src/components/accordion/Accordion.spec.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {mount} from 'enzyme';
 import Accordion from './Accordion';
 import AccordionItem from './AccordionItem';
+import Link from '../text/Link';
 
 describe('<Accordion>', () => {
   it('renders', () => {
@@ -164,18 +165,17 @@ describe('<Accordion>', () => {
     expect(accordion.find('[aria-expanded=true]').hostNodes()).toHaveLength(2);
   });
 
-  it('renders span with link styles when title is string', () => {
+  it('renders Link when title is string', () => {
     const accordion = mount(
       <Accordion>
         <AccordionItem title="Item 1">Accordion Item Description</AccordionItem>
       </Accordion>
     );
 
-    expect(accordion.find('.sg-text--link').exists()).toBe(true);
-    expect(accordion.find('.sg-accordion-item__title').exists()).toBe(false);
+    expect(accordion.find(Link).exists()).toBe(true);
   });
 
-  it('renders span when title is not string', () => {
+  it('does not render Link when title is not string', () => {
     const accordion = mount(
       <Accordion>
         <AccordionItem title={<div>info</div>}>
@@ -184,7 +184,6 @@ describe('<Accordion>', () => {
       </Accordion>
     );
 
-    expect(accordion.find('.sg-text--link').exists()).toBe(false);
-    expect(accordion.find('.sg-accordion-item__title').exists()).toBe(true);
+    expect(accordion.find(Link).exists()).toBe(false);
   });
 });

--- a/src/components/accordion/Accordion.spec.jsx
+++ b/src/components/accordion/Accordion.spec.jsx
@@ -163,4 +163,28 @@ describe('<Accordion>', () => {
     // hostNodes returns html elements and skip react components
     expect(accordion.find('[aria-expanded=true]').hostNodes()).toHaveLength(2);
   });
+
+  it('renders span with link styles when title is string', () => {
+    const accordion = mount(
+      <Accordion>
+        <AccordionItem title="Item 1">Accordion Item Description</AccordionItem>
+      </Accordion>
+    );
+
+    expect(accordion.find('.sg-text--link').exists()).toBe(true);
+    expect(accordion.find('.sg-accordion-item__title').exists()).toBe(false);
+  });
+
+  it('renders span when title is not string', () => {
+    const accordion = mount(
+      <Accordion>
+        <AccordionItem title={<div>info</div>}>
+          Accordion Item Description
+        </AccordionItem>
+      </Accordion>
+    );
+
+    expect(accordion.find('.sg-text--link').exists()).toBe(false);
+    expect(accordion.find('.sg-accordion-item__title').exists()).toBe(true);
+  });
 });

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -58,6 +58,7 @@ const AccordionItem = ({
   const isFocused = focusedElementId === id;
   const isHighlighted = isHovered || isFocused;
   const isBorderHighlighted = isHighlighted && !noGapBetweenElements;
+  const isTitleString = typeof title === 'string';
 
   const toggleOpen = () => {
     dispatch({
@@ -205,14 +206,18 @@ const AccordionItem = ({
           justifyContent="space-between"
           alignItems="center"
         >
-          <Link
-            size={titleSize}
-            color="black"
-            weight="bold"
-            underlined={isHighlighted}
-          >
-            {title}
-          </Link>
+          {isTitleString ? (
+            <Link
+              size={titleSize}
+              color="black"
+              weight="bold"
+              underlined={isHighlighted}
+            >
+              {title}
+            </Link>
+          ) : (
+            <span className="sg-accordion-item__title">{title}</span>
+          )}
           <Flex
             justifyContent="center"
             alignItems="center"

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -28,6 +28,10 @@
       }
     }
 
+    &__title {
+      flex: auto;
+    }
+
     &__content {
       transition: 0.2s ease-out;
       transition-property: height;


### PR DESCRIPTION
`title` is type of `React.Node`

For the most common case when `title` is `string`  we wrap it in `Link` component to have default styling:
<img width="677" alt="Screenshot 2021-05-19 at 11 34 34" src="https://user-images.githubusercontent.com/26112034/118790602-39d81600-b896-11eb-8886-bcccab1a4ec5.png">


For other cases we allow it to stretch to the whole width:
<img width="678" alt="Screenshot 2021-05-19 at 11 34 42" src="https://user-images.githubusercontent.com/26112034/118790617-3d6b9d00-b896-11eb-838f-78125d3eba02.png">

