### PR TITLE
Adjust spinner container to new spinner

### DIFF
--- a/src/components/file-handler/FileHandler.jsx
+++ b/src/components/file-handler/FileHandler.jsx
@@ -144,7 +144,7 @@ const FileHandler = ({
   return (
     <div {...props} className={fileHandlerClass}>
       <div className="sg-file-handler__icon">
-        {loading ? <Spinner size="small" /> : thumbnail}
+        {loading ? <Spinner size="xsmall" /> : thumbnail}
       </div>
       <span className="sg-file-handler__text" ref={textRef}>
         {src !== undefined ? (

--- a/src/components/spinner-container/SpinnerContainer.jsx
+++ b/src/components/spinner-container/SpinnerContainer.jsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 import Spinner from '../spinner/Spinner';
 import classnames from 'classnames';
 
+export {SPINNER_SIZE, SPINNER_COLOR} from '../spinner/Spinner';
 export type SpinnerContainerSizeType = 'small' | 'xsmall' | 'xxsmall';
 
 export type SpinnerContainerColorType =

--- a/src/components/spinner-container/SpinnerContainer.jsx
+++ b/src/components/spinner-container/SpinnerContainer.jsx
@@ -1,24 +1,32 @@
 // @flow strict
 
 import * as React from 'react';
-import type {SpinnerSizeType} from '../spinner/Spinner';
 import Spinner from '../spinner/Spinner';
 import classnames from 'classnames';
 
-export {SPINNER_SIZE} from '../spinner/Spinner';
+export type SpinnerContainerSizeType = 'small' | 'xsmall' | 'xxsmall';
+
+export type SpinnerContainerColorType =
+  | 'black'
+  | 'white'
+  | 'gray-900'
+  | 'gray-700'
+  | 'peach-700'
+  | 'mustard-700'
+  | 'blue-700';
 
 export type SpinnerContainerPropsType = {
   loading?: boolean,
-  light?: boolean,
+  color?: SpinnerContainerColorType,
   fullWidth?: boolean,
-  size?: SpinnerSizeType,
+  size?: SpinnerContainerSizeType,
   children?: React.Node,
   ...
 };
 
 const SpinnerContainer = ({
   loading,
-  light,
+  color,
   fullWidth,
   size,
   children,
@@ -33,7 +41,7 @@ const SpinnerContainer = ({
     {children}
     {loading === true && (
       <div className="sg-spinner-container__overlay">
-        <Spinner light={light} size={size} />
+        <Spinner color={color} size={size} />
       </div>
     )}
   </div>

--- a/src/components/spinner-container/SpinnerContainer.stories.jsx
+++ b/src/components/spinner-container/SpinnerContainer.stories.jsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import SpinnerContainer from './SpinnerContainer';
+import Box from '../box/Box';
+
+export default {
+  title: 'Components/SpinnerContainer',
+  parameters: {
+    component: SpinnerContainer,
+  },
+};
+
+export const Default = args => (
+  <SpinnerContainer {...args}>
+    <Box color="mint-secondary-light">
+      Any component could be wrapped into spinner container.
+    </Box>
+  </SpinnerContainer>
+);

--- a/src/components/spinner-container/pages/spinner-containers-interactive.jsx
+++ b/src/components/spinner-container/pages/spinner-containers-interactive.jsx
@@ -1,5 +1,8 @@
 import * as React from 'react';
-import SpinnerContainer, {SPINNER_SIZE} from '../SpinnerContainer';
+import SpinnerContainer, {
+  SPINNER_SIZE,
+  SPINNER_COLOR,
+} from '../SpinnerContainer';
 import Button from 'buttons/Button';
 import DocsActiveBlock from 'components/DocsActiveBlock';
 
@@ -14,8 +17,8 @@ const SpinnerContainers = () => {
       values: Boolean,
     },
     {
-      name: 'light',
-      values: Boolean,
+      name: 'color',
+      values: SPINNER_COLOR,
     },
     {
       name: 'fullWidth',

--- a/src/components/spinner-container/pages/spinner-containers.jsx
+++ b/src/components/spinner-container/pages/spinner-containers.jsx
@@ -23,7 +23,7 @@ const SpinnerContainers = () => (
           Ask your question
         </Button>
       </SpinnerContainer>
-      <SpinnerContainer loading light size={SPINNER_SIZE.SMALL}>
+      <SpinnerContainer loading color="white" size={SPINNER_SIZE.SMALL}>
         <Button disabled={IS_LOADING} type="solid">
           Ask your question
         </Button>
@@ -39,7 +39,7 @@ const SpinnerContainers = () => (
           Ask your question
         </Button>
       </SpinnerContainer>
-      <SpinnerContainer loading light size={SPINNER_SIZE.XSMALL}>
+      <SpinnerContainer loading color="white" size={SPINNER_SIZE.XSMALL}>
         <Button disabled={IS_LOADING} type="solid">
           Ask your question
         </Button>
@@ -71,8 +71,8 @@ const SpinnerContainers = () => (
       </SpinnerContainer>
     </DocsBlock>
 
-    <DocsBlock info="with Box" additionalInfo="(light)">
-      <SpinnerContainer loading light>
+    <DocsBlock info="with Box" additionalInfo="color white">
+      <SpinnerContainer loading color="white">
         <Box color={COLOR.blueSecondary}>
           blue-secondary (no border by default)
         </Box>

--- a/src/components/spinner/Spinner.jsx
+++ b/src/components/spinner/Spinner.jsx
@@ -38,7 +38,7 @@ export type SpinnerPropsType = {
 };
 
 const Spinner = ({
-  color = SPINNER_COLOR.BLACK,
+  color = SPINNER_COLOR.GRAY900,
   size = SPINNER_SIZE.SMALL,
   className,
   ...props


### PR DESCRIPTION
## Summary
- fixed spinner container to reflect new spinner props
- added story for spinner container (this requires types to be defined in related component and not imported from other one)
- Changed the default spinner color to `grey-900`. Previously it was `black` to meet the new loading state in the button, but this is explicitly mapped. Setting it back to grey-900 will make adopting spinner breaking changes a little less painful in the app.
- fix spinner in file handler

![Screenshot 2021-06-07 at 14 52 29](https://user-images.githubusercontent.com/8572321/121020250-7bc2f080-c7a0-11eb-8d4b-4558ff439e85.png)
