### PR TITLE
v188.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "188.1.0",
+  "version": "188.1.1",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",


### PR DESCRIPTION
## Bug Fixes
- Fix size of brainly tutor small logo by setting explicit size: `134px` for mobile and `180px` above.