### PR TITLE
Use path compatible with nonzero fill rule in shield icon

### DIFF
--- a/src/images/icons/shield.svg
+++ b/src/images/icons/shield.svg
@@ -2,5 +2,5 @@
   <title>
     shield
   </title>
-  <path fill-rule="evenodd" d="M256 448c-32 0-192-16-192-192V96c0-11 6-32 32-32h320c11 0 32 6 32 32v176c0 160-160 176-192 176zm0-320h128v128c0 43-26 128-128 128V128z" clip-rule="evenodd"/>
+  <path fill-rule="evenodd" d="M256 448C224 448 64 432 64 256V96C64 85 70 64 96 64H416C427 64 448 70 448 96V272C448 432 288 448 256 448ZM384 128H256V384C358 384 384 299 384 256V128Z" clip-rule="evenodd"/>
 </svg>


### PR DESCRIPTION
We need to use different order of points in path to be compatible with nonzero fill. Currently html sketch app doesn't handle properly evenodd. I will keep this fill rule just for marking that this is intended fill rule for this icon.

To make it work I redrawn inner shape to be counterclockwise. 
![image](https://user-images.githubusercontent.com/8572321/123312783-13f30080-d529-11eb-862c-17aec7bffe21.png)

This is of course to be fixed in `html sketch-app` but It's much bigger task than this and we need new lib exprted pretty soon