### PR TITLE
Revert "Extend select with grouped options (#2067)"

### DIFF
--- a/src/components/form-elements/README.md
+++ b/src/components/form-elements/README.md
@@ -62,18 +62,6 @@ import {Select} from 'style-guide';
     {value: 'option1', text: 'Option1'},
     {value: 'option2', text: 'Option2'}
 ]} />
-
-<Select options={[
-    {value: 'option1', text: 'Option1'},
-    {
-        label: 'Label',
-        options: [
-            {value: 'option11', text: 'Option11'},
-            {value: 'option12', text: 'Option12'}
-        ]
-    }
-    {value: 'option2', text: 'Option2'},
-]} />
 ```
 
 ```HTML
@@ -82,15 +70,5 @@ import {Select} from 'style-guide';
     <option value="option2">Select selector</option>
     <option value="option3">Select selector</option>
 </select>
-
-<select class="sg-select__element">
-    <option value="option1">Option1</option>
-    <optgroup label="Label">
-        <option value="option11">Option 11</option>
-        <option value="option12">Option 12</option>
-    </optgroup>
-    <option value="option2">Option2</option>
-</select>
-
 ```
 

--- a/src/components/form-elements/Select.jsx
+++ b/src/components/form-elements/Select.jsx
@@ -7,11 +7,7 @@ import Icon from '../icons/Icon';
 type OptionsPropsType = {
   value: string,
   text: string,
-};
-
-type GroupedOptionsPropsType = {
-  label: string,
-  options: $ReadOnlyArray<OptionsPropsType>,
+  ...
 };
 
 type SelectSizeType = 'm' | 'l';
@@ -76,22 +72,15 @@ export type SelectPropsType = {
   fullWidth?: boolean,
   /**
    * Optional array of options of the select
-   * @example <Select size="m" options={[{value:"option1",text:"Option1"},{label:"Label title",options:[{value:"option1",text:"Option1"},{value:"option2",text:"Select selector"}]},{value:"option2",text:"Select selector"}]} />
+   * @example <Select size="m" options={[{value: 'option1', text: 'Option1'},{value: 'option2', text: 'Select selector'}]} />
    */
-  options?: $ReadOnlyArray<GroupedOptionsPropsType | OptionsPropsType>,
-  /**
+  options?: Array<OptionsPropsType>,
   /**
    * Additional class names
    */
   className?: string,
   ...
 };
-
-const getOptionElement = ({value, text}: OptionsPropsType) => (
-  <option key={value} value={value}>
-    {text}
-  </option>
-);
 
 const Select = (props: SelectPropsType) => {
   const {
@@ -126,22 +115,11 @@ const Select = (props: SelectPropsType) => {
     },
     className
   );
-
-  const optionsElements = options.map((item, index) => {
-    if (item.options) {
-      return (
-        <optgroup key={item.label + index} label={item.label}>
-          {item.options.map(getOptionElement)}
-        </optgroup>
-      );
-    }
-
-    if (item.text && item.value) {
-      return getOptionElement(item);
-    }
-
-    return null;
-  });
+  const optionsElements = options.map(({value, text}) => (
+    <option key={value} value={value}>
+      {text}
+    </option>
+  ));
 
   return (
     <div className={selectClass}>

--- a/src/components/form-elements/Select.spec.jsx
+++ b/src/components/form-elements/Select.spec.jsx
@@ -7,20 +7,6 @@ const exampleOptions = [
   {value: 'test2', text: 'test2'},
 ];
 
-const exampleGroupedOptions = [
-  {value: 'option1', text: 'Option1'},
-  {value: 'option2', text: 'Select selector'},
-  {
-    label: 'Label text',
-    options: [
-      {value: 'option31', text: 'Option1'},
-      {value: 'option32', text: 'Select selector'},
-      {value: 'option33', text: 'Select selector'},
-    ],
-  },
-  {value: 'option4', text: 'Select selector'},
-];
-
 const voidFunction = () => undefined;
 
 test('render', () => {
@@ -33,17 +19,6 @@ test('render options', () => {
   const select = shallow(<Select options={exampleOptions} />);
 
   expect(select.find('option')).toHaveLength(exampleOptions.length);
-});
-
-test('render grouped options', () => {
-  const select = shallow(<Select options={exampleGroupedOptions} />);
-
-  expect(select.find('option')).toHaveLength(6);
-
-  const optGroup = select.find('optgroup');
-
-  expect(optGroup).toHaveLength(1);
-  expect(optGroup.prop('label')).toEqual('Label text');
 });
 
 test('choose options', () => {

--- a/src/components/form-elements/pages/select-interactive.jsx
+++ b/src/components/form-elements/pages/select-interactive.jsx
@@ -8,15 +8,6 @@ const exampleOptions = [
   {value: 'option3', text: 'Option 3'},
 ];
 
-const exampleGroupedOptions = [
-  {value: 'option0', text: 'Option 0'},
-  {
-    label: 'Label',
-    options: exampleOptions,
-  },
-  {value: 'option4', text: 'Option 4'},
-];
-
 const Selects = () => {
   const settings = [
     {
@@ -46,10 +37,6 @@ const Selects = () => {
     <div>
       <DocsActiveBlock backgroundColor="dark" settings={settings}>
         <Select options={exampleOptions} size="m" color="white" />
-      </DocsActiveBlock>
-
-      <DocsActiveBlock backgroundColor="dark" settings={settings}>
-        <Select options={exampleGroupedOptions} size="m" color="white" />
       </DocsActiveBlock>
     </div>
   );

--- a/src/components/form-elements/pages/select.jsx
+++ b/src/components/form-elements/pages/select.jsx
@@ -9,21 +9,6 @@ const exampleOptions = [
   {value: 'option2', text: 'Select selector'},
   {value: 'option3', text: 'Select selector'},
 ];
-
-const exampleGroupedOptions = [
-  {value: 'option1', text: 'Option1'},
-  {value: 'option2', text: 'Select selector'},
-  {
-    label: 'Label text',
-    options: [
-      {value: 'option21', text: 'Option1'},
-      {value: 'option22', text: 'Select selector'},
-      {value: 'option23', text: 'Select selector'},
-    ],
-  },
-  {value: 'option3', text: 'Select selector'},
-];
-
 const exampleProps = {
   options: exampleOptions,
   value: exampleOptions[1].value,
@@ -71,9 +56,6 @@ const selects = () => (
     </DocsBlock>
     <DocsBlock info="Full width">
       <Select {...exampleProps} fullWidth />
-    </DocsBlock>
-    <DocsBlock info="With grouped options">
-      <Select {...exampleProps} options={exampleGroupedOptions} fullWidth />
     </DocsBlock>
   </div>
 );


### PR DESCRIPTION
This reverts commit 6650cd555b120b1c1b2b9a21c7b248407412af87.

Extending select component surfaced that we had wrong types previously (people passed to the component properties which weren't handled). Also there is some issues found in in [AskEditor feature which uses select](https://teamcity.z-dn.net/buildConfiguration/Frontend_Monorepo_CommitChecker_JsTests2/808601?).

I am reverting to unblock [this PR](https://github.com/brainly/brainly-frontend/pull/15984).  Extended version will be published in release following reverting one.