### PR TITLE
Allow grouping of options within select component (fixed)

### DIFF
--- a/src/components/form-elements/README.md
+++ b/src/components/form-elements/README.md
@@ -62,6 +62,18 @@ import {Select} from 'style-guide';
     {value: 'option1', text: 'Option1'},
     {value: 'option2', text: 'Option2'}
 ]} />
+
+<Select options={[
+    {value: 'option1', text: 'Option1'},
+    {
+        label: 'Label',
+        options: [
+            {value: 'option11', text: 'Option11'},
+            {value: 'option12', text: 'Option12'}
+        ]
+    }
+    {value: 'option2', text: 'Option2'},
+]} />
 ```
 
 ```HTML
@@ -70,5 +82,15 @@ import {Select} from 'style-guide';
     <option value="option2">Select selector</option>
     <option value="option3">Select selector</option>
 </select>
+
+<select class="sg-select__element">
+    <option value="option1">Option1</option>
+    <optgroup label="Label">
+        <option value="option11">Option 11</option>
+        <option value="option12">Option 12</option>
+    </optgroup>
+    <option value="option2">Option2</option>
+</select>
+
 ```
 

--- a/src/components/form-elements/Select.jsx
+++ b/src/components/form-elements/Select.jsx
@@ -136,7 +136,7 @@ const Select = (props: SelectPropsType) => {
       );
     }
 
-    if (item.text && item.value) {
+    if (item.text || item.value) {
       return getOptionElement(item);
     }
 

--- a/src/components/form-elements/Select.jsx
+++ b/src/components/form-elements/Select.jsx
@@ -7,7 +7,11 @@ import Icon from '../icons/Icon';
 type OptionsPropsType = {
   value: string,
   text: string,
-  ...
+};
+
+type GroupedOptionsPropsType = {
+  label: string,
+  options: $ReadOnlyArray<OptionsPropsType>,
 };
 
 type SelectSizeType = 'm' | 'l';
@@ -72,15 +76,22 @@ export type SelectPropsType = {
   fullWidth?: boolean,
   /**
    * Optional array of options of the select
-   * @example <Select size="m" options={[{value: 'option1', text: 'Option1'},{value: 'option2', text: 'Select selector'}]} />
+   * @example <Select size="m" options={[{value:"option1",text:"Option1"},{label:"Label title",options:[{value:"option1",text:"Option1"},{value:"option2",text:"Select selector"}]},{value:"option2",text:"Select selector"}]} />
    */
-  options?: Array<OptionsPropsType>,
+  options?: $ReadOnlyArray<GroupedOptionsPropsType | OptionsPropsType>,
+  /**
   /**
    * Additional class names
    */
   className?: string,
   ...
 };
+
+const getOptionElement = ({value, text}: OptionsPropsType) => (
+  <option key={value} value={value}>
+    {text}
+  </option>
+);
 
 const Select = (props: SelectPropsType) => {
   const {
@@ -115,11 +126,22 @@ const Select = (props: SelectPropsType) => {
     },
     className
   );
-  const optionsElements = options.map(({value, text}) => (
-    <option key={value} value={value}>
-      {text}
-    </option>
-  ));
+
+  const optionsElements = options.map((item, index) => {
+    if (item.options) {
+      return (
+        <optgroup key={item.label + index} label={item.label}>
+          {item.options.map(getOptionElement)}
+        </optgroup>
+      );
+    }
+
+    if (item.text && item.value) {
+      return getOptionElement(item);
+    }
+
+    return null;
+  });
 
   return (
     <div className={selectClass}>

--- a/src/components/form-elements/Select.spec.jsx
+++ b/src/components/form-elements/Select.spec.jsx
@@ -7,6 +7,20 @@ const exampleOptions = [
   {value: 'test2', text: 'test2'},
 ];
 
+const exampleGroupedOptions = [
+  {value: 'option1', text: 'Option1'},
+  {value: 'option2', text: 'Select selector'},
+  {
+    label: 'Label text',
+    options: [
+      {value: 'option31', text: 'Option1'},
+      {value: 'option32', text: 'Select selector'},
+      {value: 'option33', text: 'Select selector'},
+    ],
+  },
+  {value: 'option4', text: 'Select selector'},
+];
+
 const voidFunction = () => undefined;
 
 test('render', () => {
@@ -19,6 +33,17 @@ test('render options', () => {
   const select = shallow(<Select options={exampleOptions} />);
 
   expect(select.find('option')).toHaveLength(exampleOptions.length);
+});
+
+test('render grouped options', () => {
+  const select = shallow(<Select options={exampleGroupedOptions} />);
+
+  expect(select.find('option')).toHaveLength(6);
+
+  const optGroup = select.find('optgroup');
+
+  expect(optGroup).toHaveLength(1);
+  expect(optGroup.prop('label')).toEqual('Label text');
 });
 
 test('choose options', () => {

--- a/src/components/form-elements/pages/select-interactive.jsx
+++ b/src/components/form-elements/pages/select-interactive.jsx
@@ -8,6 +8,15 @@ const exampleOptions = [
   {value: 'option3', text: 'Option 3'},
 ];
 
+const exampleGroupedOptions = [
+  {value: 'option0', text: 'Option 0'},
+  {
+    label: 'Label',
+    options: exampleOptions,
+  },
+  {value: 'option4', text: 'Option 4'},
+];
+
 const Selects = () => {
   const settings = [
     {
@@ -37,6 +46,10 @@ const Selects = () => {
     <div>
       <DocsActiveBlock backgroundColor="dark" settings={settings}>
         <Select options={exampleOptions} size="m" color="white" />
+      </DocsActiveBlock>
+
+      <DocsActiveBlock backgroundColor="dark" settings={settings}>
+        <Select options={exampleGroupedOptions} size="m" color="white" />
       </DocsActiveBlock>
     </div>
   );

--- a/src/components/form-elements/pages/select.jsx
+++ b/src/components/form-elements/pages/select.jsx
@@ -9,6 +9,21 @@ const exampleOptions = [
   {value: 'option2', text: 'Select selector'},
   {value: 'option3', text: 'Select selector'},
 ];
+
+const exampleGroupedOptions = [
+  {value: 'option1', text: 'Option1'},
+  {value: 'option2', text: 'Select selector'},
+  {
+    label: 'Label text',
+    options: [
+      {value: 'option21', text: 'Option1'},
+      {value: 'option22', text: 'Select selector'},
+      {value: 'option23', text: 'Select selector'},
+    ],
+  },
+  {value: 'option3', text: 'Select selector'},
+];
+
 const exampleProps = {
   options: exampleOptions,
   value: exampleOptions[1].value,
@@ -56,6 +71,9 @@ const selects = () => (
     </DocsBlock>
     <DocsBlock info="Full width">
       <Select {...exampleProps} fullWidth />
+    </DocsBlock>
+    <DocsBlock info="With grouped options">
+      <Select {...exampleProps} options={exampleGroupedOptions} fullWidth />
     </DocsBlock>
   </div>
 );


### PR DESCRIPTION
Getting back to the grouped options in select component (https://github.com/brainly/style-guide/pull/2067)

Change:
- This reverts commit ba8155b7c71255ce07643168f9efdca3526934ec.
- changed condition for non grouped elements `item.text && item.value` → `item.text || item.value`. This fixes [failing tests](https://teamcity.z-dn.net/buildConfiguration/Frontend_Monorepo_CommitChecker_JsTests2/808601?)

All failing types in the app need to be fixed though. They actually caught wrong usage of the component (we accepted non exact types as an options but additional props weren't passed to the option element)