### PR TITLE
Trim long texts in Label

### DIFF
--- a/src/components/labels/Label.jsx
+++ b/src/components/labels/Label.jsx
@@ -257,7 +257,12 @@ const Label = ({
         {children}
       </Text>
       {onClose ? (
-        <button className="sg-label__close-button" onClick={onClose}>
+        <button
+          className="sg-label__close-button"
+          onClick={onClose}
+          title="close"
+          aria-label="close"
+        >
           <Icon type="close" color={closeIconColor} size={16} />
         </button>
       ) : null}

--- a/src/components/labels/Label.jsx
+++ b/src/components/labels/Label.jsx
@@ -248,11 +248,14 @@ const Label = ({
           <Icon type={iconType} color={iconColor} size={16} />
         </div>
       )}
-      <span className="sg-label__text">
-        <Text size="small" weight="bold" color={textColor}>
-          {children}
-        </Text>
-      </span>
+      <Text
+        size="small"
+        weight="bold"
+        color={textColor}
+        className="sg-label__text"
+      >
+        {children}
+      </Text>
       {onClose ? (
         <button className="sg-label__close-button" onClick={onClose}>
           <Icon type="close" color={closeIconColor} size={16} />

--- a/src/components/labels/Label.stories.jsx
+++ b/src/components/labels/Label.stories.jsx
@@ -62,6 +62,7 @@ const onCloseMock = () => {};
 
 LongText.args = {
   ...Default.args,
+  title: 'Long long long text',
   children: 'Very very long label',
   onClose: {control: onCloseMock},
 };

--- a/src/components/labels/Label.stories.jsx
+++ b/src/components/labels/Label.stories.jsx
@@ -27,3 +27,43 @@ Default.argTypes = {
   type: {control: {type: 'select', options: LABEL_TYPE}},
   onClose: {control: null},
 };
+
+export const LongText = args => {
+  const {children} = args;
+
+  return (
+    <div>
+      <div
+        style={{
+          width: '300px',
+          background: 'lightgray',
+          padding: '20px',
+        }}
+      >
+        <Label {...args}>{children}</Label>
+      </div>
+
+      <div
+        style={{
+          width: '200px',
+          background: 'lightgray',
+          padding: '20px',
+          marginTop: '10px',
+        }}
+      >
+        <Label {...args}>{children}</Label>
+      </div>
+    </div>
+  );
+};
+
+// eslint-disable-next-line
+const onCloseMock = () => {};
+
+LongText.args = {
+  ...Default.args,
+  children: 'Very very long label',
+  onClose: {control: onCloseMock},
+};
+
+LongText.argTypes = Default.argTypes;

--- a/src/components/labels/_labels.scss
+++ b/src/components/labels/_labels.scss
@@ -6,6 +6,7 @@
   border-radius: 6px;
   padding: spacing(xs);
   cursor: default;
+  max-width: 100%;
 
   &__icon {
     margin-right: spacing(xs);
@@ -14,6 +15,9 @@
   &__text {
     position: relative;
     top: 1px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   &--closable {

--- a/src/components/labels/pages/labels.jsx
+++ b/src/components/labels/pages/labels.jsx
@@ -787,7 +787,12 @@ const Labels = () => (
             width: '300px',
           }}
         >
-          <Label iconType="heart" color="blue" onClose={closeCallback}>
+          <Label
+            iconType="heart"
+            color="blue"
+            onClose={closeCallback}
+            title="Long long long text"
+          >
             Long long long text
           </Label>
         </ContrastBox>
@@ -797,7 +802,12 @@ const Labels = () => (
             marginTop: '10px',
           }}
         >
-          <Label iconType="heart" color="blue" onClose={closeCallback}>
+          <Label
+            iconType="heart"
+            color="blue"
+            onClose={closeCallback}
+            title="Long long long text"
+          >
             Long long long text
           </Label>
         </ContrastBox>

--- a/src/components/labels/pages/labels.jsx
+++ b/src/components/labels/pages/labels.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import DocsBlock from 'components/DocsBlock';
 import Label from '../Label';
 import Flex from '../../flex/Flex';
+import ContrastBox from 'components/ContrastBox';
 
 const closeCallback = () => undefined;
 
@@ -777,6 +778,29 @@ const Labels = () => (
           <br />
           <br />
         </Flex>
+      </Flex>
+    </DocsBlock>
+    <DocsBlock info="Long text">
+      <Flex direction="column">
+        <ContrastBox
+          style={{
+            width: '300px',
+          }}
+        >
+          <Label iconType="heart" color="blue" onClose={closeCallback}>
+            Long long long text
+          </Label>
+        </ContrastBox>
+        <ContrastBox
+          style={{
+            width: '200px',
+            marginTop: '10px',
+          }}
+        >
+          <Label iconType="heart" color="blue" onClose={closeCallback}>
+            Long long long text
+          </Label>
+        </ContrastBox>
       </Flex>
     </DocsBlock>
   </div>


### PR DESCRIPTION
### Summary

From now label component is single line of text only and will will trim text if it takes more horizontal space than 100% of container. Ellipsis will be added at the end of trimmed text. 
I was thinking about adding title attribute to have access to full text when trimmed but I wasn't sure whether it can conflict with tooltips. Could you add some thoughts?

Since I'm fairly new in the team I've been thinking about other solution but not sure if it fits principles. Let me explain in few points:
1. Add option (via prop) to Text component to be single line only
2. Use single line Text on  Label component, since it's using Text

<img width="391" alt="Screenshot 2021-08-11 at 14 45 58" src="https://user-images.githubusercontent.com/25419830/129030969-ff6d272c-686e-4c3e-8bdf-200855d2b51b.png">

Fixes #2068 