### PR TITLE
nesting Text, Link, Headline with inherited styles

### DIFF
--- a/src/components/text/Headline.jsx
+++ b/src/components/text/Headline.jsx
@@ -53,25 +53,28 @@ export type HeadlinePropsType = {
   align?: ?HeadlineAlignType,
   className?: ?string,
   extraBold?: ?boolean,
+  inherited?: ?boolean,
   ...
 };
 
 const Headline = ({
   children,
   type = HEADLINE_TYPE.H1,
-  size = HEADLINE_SIZE.MEDIUM,
+  size,
   extraBold,
   transform,
   align,
   color,
   className,
+  inherited = false,
   ...props
 }: HeadlinePropsType) => {
   const Type = type;
   const headlineClass = classNames(
     'sg-headline',
     {
-      [`sg-headline--${size}`]: size !== HEADLINE_SIZE.MEDIUM,
+      'sg-headline--inherited': inherited,
+      [`sg-headline--${String(size)}`]: size !== HEADLINE_SIZE.MEDIUM,
       [`sg-headline--${String(color)}`]: color,
       [`sg-headline--${String(transform)}`]: transform,
       [`sg-headline--${align || ''}`]: align,

--- a/src/components/text/Headline.stories.jsx
+++ b/src/components/text/Headline.stories.jsx
@@ -26,9 +26,9 @@ Nested.args = {
   color: TEXT_COLOR.PEACH_DARK,
   children: (
     <>
-      This is outer Headline{' '}
+      Outer headline{' '}
       <Headline inherited type="span">
-        [this is nested Headline with inherited styles]
+        nested Headline with inherited styles
       </Headline>
     </>
   ),

--- a/src/components/text/Headline.stories.jsx
+++ b/src/components/text/Headline.stories.jsx
@@ -27,7 +27,7 @@ Nested.args = {
   children: (
     <>
       This is outer Headline{' '}
-      <Headline inherited>
+      <Headline inherited type="span">
         [this is nested Headline with inherited styles]
       </Headline>
     </>

--- a/src/components/text/Headline.stories.jsx
+++ b/src/components/text/Headline.stories.jsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import Headline from './Headline';
+import {TEXT_COLOR} from './textConsts';
+
+export default {
+  title: 'Components/Headline',
+  parameters: {
+    component: Headline,
+  },
+};
+
+export const Default = args => <Headline {...args} />;
+
+Default.args = {
+  children: 'Some text',
+};
+
+Default.argTypes = {
+  children: 'string',
+};
+
+export const Nested = args => <Headline {...args} />;
+
+Nested.args = {
+  type: 'h2',
+  color: TEXT_COLOR.PEACH_DARK,
+  children: (
+    <>
+      This is outer Headline{' '}
+      <Headline inherited>
+        [this is nested Headline with inherited styles]
+      </Headline>
+    </>
+  ),
+};
+
+Nested.argTypes = {
+  children: 'string',
+};

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -5,7 +5,6 @@ import classNames from 'classnames';
 import Text from './Text';
 import {
   TEXT_TYPE,
-  LINK_COLOR,
   TEXT_SIZE,
   TEXT_WEIGHT,
   TEXT_TRANSFORM,
@@ -65,6 +64,7 @@ export type LinkPropsType = {
   emphasised?: boolean,
   disabled?: boolean,
   className?: ?string,
+  inherited?: boolean,
   ...
 };
 
@@ -79,17 +79,19 @@ const Link = (props: LinkPropsType) => {
   const {
     children,
     href,
-    color = LINK_COLOR.BLUE_DARK,
+    color,
     underlined = false,
     unstyled = false,
     emphasised = true, // backward compatibility
     disabled = false, // backward compatibility
     weight,
     className,
+    inherited = false,
     ...additionalProps
   } = props;
   const linkClass = classNames(
     {
+      [`sg-text--inherited`]: inherited,
       'sg-text--link': !underlined && !unstyled,
       'sg-text--link-underlined': underlined && !unstyled,
       'sg-text--link-unstyled': !underlined && unstyled,

--- a/src/components/text/Link.stories.jsx
+++ b/src/components/text/Link.stories.jsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import Link from './Link';
+import {TEXT_COLOR} from './textConsts';
+
+export default {
+  title: 'Components/Link',
+  parameters: {
+    component: Link,
+  },
+};
+
+export const Default = args => <Link {...args} />;
+
+Default.args = {
+  children: 'Some text',
+};
+
+Default.argTypes = {
+  children: 'string',
+};
+
+export const Nested = args => <Link {...args} />;
+
+Nested.args = {
+  type: 'h2',
+  color: TEXT_COLOR.PEACH_DARK,
+  children: (
+    <>
+      This is outer Link{' '}
+      <Link inherited type="span">
+        [this is nested Link with inherited styles]
+      </Link>
+    </>
+  ),
+};
+
+Nested.argTypes = {
+  children: 'string',
+};

--- a/src/components/text/Link.stories.jsx
+++ b/src/components/text/Link.stories.jsx
@@ -26,9 +26,9 @@ Nested.args = {
   color: TEXT_COLOR.PEACH_DARK,
   children: (
     <>
-      This is outer Link{' '}
+      Outer Link{' '}
       <Link inherited type="span">
-        [this is nested Link with inherited styles]
+        nested Link with inherited styles
       </Link>
     </>
   ),

--- a/src/components/text/Text.jsx
+++ b/src/components/text/Text.jsx
@@ -80,14 +80,15 @@ export type TextPropsType = {
   whiteSpace?: TextWhiteSpaceType,
   className?: ?string,
   href?: string,
+  inherited?: boolean,
   ...
 };
 
 const Text = ({
   children,
   type = TEXT_TYPE.DIV,
-  size = TEXT_SIZE.MEDIUM,
-  weight = TEXT_WEIGHT.REGULAR,
+  size,
+  weight,
   color,
   transform,
   align,
@@ -97,12 +98,14 @@ const Text = ({
   breakWords,
   whiteSpace,
   className,
+  inherited = false,
   ...props
 }: TextPropsType) => {
   const Type = type;
   const textClass = classNames(
     'sg-text',
     {
+      'sg-text--inherited': inherited,
       [`sg-text--${String(size)}`]: size !== TEXT_SIZE.MEDIUM,
       [`sg-text--${String(color)}`]: color,
       [`sg-text--${String(weight)}`]: weight !== TEXT_WEIGHT.REGULAR,

--- a/src/components/text/Text.stories.jsx
+++ b/src/components/text/Text.stories.jsx
@@ -26,9 +26,9 @@ Nested.args = {
   color: TEXT_COLOR.PEACH_DARK,
   children: (
     <>
-      This is outer Text{' '}
+      Outer Text{' '}
       <Text inherited type="span">
-        [this is nested Text with inherited styles]
+        nested Text with inherited styles
       </Text>
     </>
   ),

--- a/src/components/text/Text.stories.jsx
+++ b/src/components/text/Text.stories.jsx
@@ -1,0 +1,39 @@
+import * as React from 'react';
+import Text from './Text';
+import {TEXT_COLOR} from './textConsts';
+
+export default {
+  title: 'Components/Text',
+  parameters: {
+    component: Text,
+  },
+};
+
+export const Default = args => <Text {...args} />;
+
+Default.args = {
+  children: 'Some text',
+};
+
+Default.argTypes = {
+  children: 'string',
+};
+
+export const Nested = args => <Text {...args} />;
+
+Nested.args = {
+  type: 'h2',
+  color: TEXT_COLOR.PEACH_DARK,
+  children: (
+    <>
+      This is outer Text{' '}
+      <Text inherited type="span">
+        [this is nested Text with inherited styles]
+      </Text>
+    </>
+  ),
+};
+
+Nested.argTypes = {
+  children: 'string',
+};

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -56,6 +56,7 @@ $headlineSizes: (
     max-width: 100%;
 
     &--inherited {
+      display: revert;
       font-size: inherit;
       line-height: inherit;
       font-weight: inherit;

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -55,6 +55,13 @@ $headlineSizes: (
     font-weight: $fontWeightBold;
     max-width: 100%;
 
+    &--inherited {
+      font-size: inherit;
+      line-height: inherit;
+      font-weight: inherit;
+      color: inherit;
+    }
+
     &--xxsmall {
       @include headlineTypeSizeVariant(xxsmall);
     }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -3,36 +3,36 @@ $includeHtml: false !default;
 $bodyTextSizes: (
   xxxlarge: (
     fontSize: 66px,
-    lineHeight: 88px
+    lineHeight: 88px,
   ),
   xxlarge: (
     fontSize: 45px,
-    lineHeight: 60px
+    lineHeight: 60px,
   ),
   xlarge: (
     fontSize: 33px,
-    lineHeight: 44px
+    lineHeight: 44px,
   ),
   large: (
     fontSize: 24px,
-    lineHeight: 32px
+    lineHeight: 32px,
   ),
   medium: (
     fontSize: 18px,
-    lineHeight: 24px
+    lineHeight: 24px,
   ),
   small: (
     fontSize: 15px,
-    lineHeight: 20px
+    lineHeight: 20px,
   ),
   xsmall: (
     fontSize: 12px,
-    lineHeight: 16px
+    lineHeight: 16px,
   ),
   xxsmall: (
     fontSize: 9px,
-    lineHeight: 12px
-  )
+    lineHeight: 12px,
+  ),
 );
 
 @function getBodyTextSizeFromMap($map, $keys...) {
@@ -48,12 +48,19 @@ $bodyTextSizes: (
 }
 
 @if ($includeHtml) {
-
   .sg-text {
     @include bodyTextTypeSizeVariant(medium);
     font-family: $fontFamilyPrimary;
     font-weight: $fontWeightNormal;
     color: $black;
+
+    &--inherited {
+      font-size: inherit;
+      line-height: inherit;
+      font-family: inherit;
+      font-weight: inherit;
+      color: inherit;
+    }
 
     &--container {
       position: relative;
@@ -90,6 +97,7 @@ $bodyTextSizes: (
     &--link {
       cursor: pointer;
       text-decoration: none;
+      color: $bluePrimaryDark;
 
       &:hover,
       &:active {

--- a/src/components/text/pages/headlines-interactive.jsx
+++ b/src/components/text/pages/headlines-interactive.jsx
@@ -57,11 +57,9 @@ const Headlines = () => {
       </DocsActiveBlock>
       <DocsActiveBlock settings={settings}>
         <Headline>
-          This is parent Headline component, containing{' '}
+          Parent Headline component{' '}
           <Headline inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
-            nested Headline with prop inherited=true inheriting styles from
-            parent though still is able to override some of them with props
-            (color=peach).
+            nested Headline inheriting styles from parent Headline
           </Headline>
         </Headline>
       </DocsActiveBlock>

--- a/src/components/text/pages/headlines-interactive.jsx
+++ b/src/components/text/pages/headlines-interactive.jsx
@@ -58,7 +58,7 @@ const Headlines = () => {
       <DocsActiveBlock settings={settings}>
         <Headline>
           Parent Headline component{' '}
-          <Headline inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
+          <Headline inherited type="span" color={TEXT_COLOR.MINT_DARK}>
             nested Headline inheriting styles from parent Headline
           </Headline>
         </Headline>

--- a/src/components/text/pages/headlines-interactive.jsx
+++ b/src/components/text/pages/headlines-interactive.jsx
@@ -6,6 +6,7 @@ import Headline, {
   HEADLINE_TRANSFORM,
   HEADLINE_ALIGN,
 } from '../Headline';
+import {TEXT_COLOR} from 'text/textConsts';
 import DocsActiveBlock from 'components/DocsActiveBlock';
 
 const Headlines = () => {
@@ -34,6 +35,10 @@ const Headlines = () => {
       name: 'extraBold',
       values: Boolean,
     },
+    {
+      name: 'inherited',
+      values: Boolean,
+    },
   ];
 
   return (
@@ -48,6 +53,16 @@ const Headlines = () => {
           color={HEADLINE_COLOR.WHITE}
         >
           We&apos;ve got your back!
+        </Headline>
+      </DocsActiveBlock>
+      <DocsActiveBlock settings={settings}>
+        <Headline>
+          This is parent Headline component, containing{' '}
+          <Headline inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
+            nested Headline with prop inherited=true inheriting styles from
+            parent though still is able to override some of them with props
+            (color=peach).
+          </Headline>
         </Headline>
       </DocsActiveBlock>
     </div>

--- a/src/components/text/pages/links-interactive.jsx
+++ b/src/components/text/pages/links-interactive.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Link, {LINK_SIZE, LINK_COLOR, LINK_WEIGHT} from 'text/Link';
+import {TEXT_COLOR} from 'text/textConsts';
 
 import DocsActiveBlock from 'components/DocsActiveBlock';
 
@@ -25,6 +26,10 @@ const Links = () => {
       name: 'underlined',
       values: Boolean,
     },
+    {
+      name: 'inherited',
+      values: Boolean,
+    },
   ];
 
   return (
@@ -40,6 +45,16 @@ const Links = () => {
           weight={LINK_WEIGHT.REGULAR}
         >
           Terms of use
+        </Link>
+      </DocsActiveBlock>
+      <DocsActiveBlock settings={settings}>
+        <Link>
+          This is parent Link component, containing{' '}
+          <Link inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
+            nested Link with prop inherited=true inheriting styles from parent
+            though still is able to override some of them with props
+            (color=peach).
+          </Link>
         </Link>
       </DocsActiveBlock>
     </div>

--- a/src/components/text/pages/links-interactive.jsx
+++ b/src/components/text/pages/links-interactive.jsx
@@ -49,11 +49,9 @@ const Links = () => {
       </DocsActiveBlock>
       <DocsActiveBlock settings={settings}>
         <Link>
-          This is parent Link component, containing{' '}
+          Parent Link component{' '}
           <Link inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
-            nested Link with prop inherited=true inheriting styles from parent
-            though still is able to override some of them with props
-            (color=peach).
+            nested Link inheriting styles from parent Link
           </Link>
         </Link>
       </DocsActiveBlock>

--- a/src/components/text/pages/links-interactive.jsx
+++ b/src/components/text/pages/links-interactive.jsx
@@ -50,7 +50,7 @@ const Links = () => {
       <DocsActiveBlock settings={settings}>
         <Link>
           Parent Link component{' '}
-          <Link inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
+          <Link inherited type="span" color={TEXT_COLOR.MINT_DARK}>
             nested Link inheriting styles from parent Link
           </Link>
         </Link>

--- a/src/components/text/pages/text-interactive.jsx
+++ b/src/components/text/pages/text-interactive.jsx
@@ -74,7 +74,7 @@ const Nested = () => {
     <DocsActiveBlock settings={settings}>
       <Text>
         Parent Text component{' '}
-        <Text inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
+        <Text inherited type="span" color={TEXT_COLOR.MINT_DARK}>
           nested Text inheriting styles from parent Text
         </Text>
       </Text>

--- a/src/components/text/pages/text-interactive.jsx
+++ b/src/components/text/pages/text-interactive.jsx
@@ -73,11 +73,9 @@ const Nested = () => {
   return (
     <DocsActiveBlock settings={settings}>
       <Text>
-        This is parent Text component, containing{' '}
+        Parent Text component{' '}
         <Text inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
-          nested Text with prop inherited=true inheriting styles from parent
-          though still is able to override some of them with props
-          (color=peach).
+          nested Text inheriting styles from parent Text
         </Text>
       </Text>
     </DocsActiveBlock>

--- a/src/components/text/pages/text-interactive.jsx
+++ b/src/components/text/pages/text-interactive.jsx
@@ -12,57 +12,83 @@ import {
 
 import DocsActiveBlock from 'components/DocsActiveBlock';
 
-const Texts = () => {
-  const settings = [
-    {
-      name: 'type',
-      values: TEXT_TYPE,
-    },
-    {
-      name: 'size',
-      values: TEXT_SIZE,
-    },
-    {
-      name: 'color',
-      values: TEXT_COLOR,
-    },
-    {
-      name: 'weight',
-      values: TEXT_WEIGHT,
-    },
-    {
-      name: 'transform',
-      values: TEXT_TRANSFORM,
-    },
-    {
-      name: 'align',
-      values: TEXT_ALIGN,
-    },
-    {
-      name: 'noWrap',
-      values: Boolean,
-    },
-    {
-      name: 'full',
-      values: Boolean,
-    },
-    {
-      name: 'breakWords',
-      values: Boolean,
-    },
-    {
-      name: 'whiteSpace',
-      values: TEXT_WHITE_SPACE,
-    },
-  ];
+const settings = [
+  {
+    name: 'type',
+    values: TEXT_TYPE,
+  },
+  {
+    name: 'size',
+    values: TEXT_SIZE,
+  },
+  {
+    name: 'color',
+    values: TEXT_COLOR,
+  },
+  {
+    name: 'weight',
+    values: TEXT_WEIGHT,
+  },
+  {
+    name: 'transform',
+    values: TEXT_TRANSFORM,
+  },
+  {
+    name: 'align',
+    values: TEXT_ALIGN,
+  },
+  {
+    name: 'noWrap',
+    values: Boolean,
+  },
+  {
+    name: 'full',
+    values: Boolean,
+  },
+  {
+    name: 'breakWords',
+    values: Boolean,
+  },
+  {
+    name: 'whiteSpace',
+    values: TEXT_WHITE_SPACE,
+  },
+  {
+    name: 'inherited',
+    values: Boolean,
+  },
+];
 
+const Default = () => {
   const text = 'Lorem Ipsum \ndolor sit amet';
 
   return (
+    <DocsActiveBlock settings={settings}>
+      <Text>{text}</Text>
+    </DocsActiveBlock>
+  );
+};
+
+const Nested = () => {
+  return (
+    <DocsActiveBlock settings={settings}>
+      <Text>
+        This is parent Text component, containing{' '}
+        <Text inherited type="span" color={TEXT_COLOR.PEACH_DARK}>
+          nested Text with prop inherited=true inheriting styles from parent
+          though still is able to override some of them with props
+          (color=peach).
+        </Text>
+      </Text>
+    </DocsActiveBlock>
+  );
+};
+
+const Texts = () => {
+  return (
     <div>
-      <DocsActiveBlock settings={settings}>
-        <Text>{text}</Text>
-      </DocsActiveBlock>
+      <Default />
+      <Nested />
     </div>
   );
 };


### PR DESCRIPTION
Text, Link, Headline will now accept new prop `inherited` which makes component styles inherited. This will allow us to nest those components without extra effort of duplicating styles on nested text component.

Example: 
To make nested bold text same colour:

```js
// before
<Text color="mustard">
  Some text
  <Text color="mustard" weight="bold">bolded part</Text>
</Text>

// after
<Text color="mustard">
  Some text
  <Text inherited weight="bold">bolded part</Text>
</Text>
```