### PR TITLE
add missing black color class

### DIFF
--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -190,6 +190,10 @@ $bodyTextSizes: (
       color: $white;
     }
 
+    &--black {
+      color: $black;
+    }
+
     // backward compatibility for html, it should be replaced with sg-text--gray-primary
     &--gray {
       color: $grayPrimary;


### PR DESCRIPTION
### Fixes

- `sg-text--black` class sets color to black