### PR TITLE
Link, Text, Headline classnames generation

### DIFF
--- a/src/components/flash-messages/FlashMessage.jsx
+++ b/src/components/flash-messages/FlashMessage.jsx
@@ -37,7 +37,7 @@ const FlashMessage = ({
   return (
     <div {...props} className="sg-flash">
       <div className={messageClass}>
-        <Text size="small" color="default" weight="bold" align="to-center">
+        <Text size="small" weight="bold" align="to-center">
           {text}
         </Text>
       </div>

--- a/src/components/form-elements/Checkbox.jsx
+++ b/src/components/form-elements/Checkbox.jsx
@@ -53,7 +53,6 @@ class Checkbox extends React.PureComponent<
           <Text
             size="small"
             type="span"
-            color="default"
             weight="bold"
             className="sg-checkbox__label"
           >

--- a/src/components/form-elements/Radio.jsx
+++ b/src/components/form-elements/Radio.jsx
@@ -56,7 +56,6 @@ const Radio = (props: RadioPropsType) => {
         <Text
           size="small"
           type="span"
-          color="default"
           weight="bold"
           className="sg-radio__label"
         >

--- a/src/components/labels/Label.jsx
+++ b/src/components/labels/Label.jsx
@@ -76,7 +76,7 @@ const TRANSPARENT_COLOR_TEXT_MAP: {
   peach: 'peach-dark',
   mustard: 'mustard-dark',
   gray: 'gray-secondary',
-  achromatic: 'default',
+  achromatic: 'black',
 } = {
   blue: 'blue-dark',
   mint: 'mint-dark',
@@ -84,7 +84,7 @@ const TRANSPARENT_COLOR_TEXT_MAP: {
   peach: 'peach-dark',
   mustard: 'mustard-dark',
   gray: 'gray-secondary',
-  achromatic: 'default',
+  achromatic: 'black',
 };
 
 const TRANSPARENT_ICON_COLOR_MAP: {
@@ -222,7 +222,7 @@ const Label = ({
 
   const textColor =
     type === 'default' || type === 'transparent'
-      ? 'default'
+      ? 'black'
       : type === 'solid'
       ? 'white'
       : TRANSPARENT_COLOR_TEXT_MAP[color];

--- a/src/components/labels/Label.spec.jsx
+++ b/src/components/labels/Label.spec.jsx
@@ -96,7 +96,7 @@ describe('Label', () => {
     expect(label.hasClass('sg-label--mint-secondary-light')).toBe(true);
     expect(closeIcon.prop('color')).toBe('dark');
     expect(heartIcon.prop('color')).toBe('dark');
-    expect(label.find(Text).prop('color')).toBe('default');
+    expect(label.find(Text).prop('color')).toBe('black');
   });
 
   test('has proper styles if solid', () => {
@@ -144,7 +144,7 @@ describe('Label', () => {
     expect(label.hasClass('sg-label--mint-secondary-light')).toBe(false);
     expect(closeIcon.prop('color')).toBe('dark');
     expect(heartIcon.prop('color')).toBe('mint');
-    expect(label.find(Text).prop('color')).toBe('default');
+    expect(label.find(Text).prop('color')).toBe('black');
     expect(label.find('div').find(Icon)).toHaveLength(2);
   });
 

--- a/src/components/text/Headline.jsx
+++ b/src/components/text/Headline.jsx
@@ -17,7 +17,7 @@ export type HeadlineSizeType =
   | 'xxxlarge';
 
 export type HeadlineColorType =
-  | 'default'
+  | 'black'
   | 'white'
   | 'gray'
   | 'gray-secondary'
@@ -74,7 +74,7 @@ const Headline = ({
     'sg-headline',
     {
       'sg-headline--inherited': inherited,
-      [`sg-headline--${String(size)}`]: size !== HEADLINE_SIZE.MEDIUM,
+      [`sg-headline--${String(size)}`]: size && size !== HEADLINE_SIZE.MEDIUM,
       [`sg-headline--${String(color)}`]: color,
       [`sg-headline--${String(transform)}`]: transform,
       [`sg-headline--${align || ''}`]: align,

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -95,7 +95,7 @@ const Link = (props: LinkPropsType) => {
       'sg-text--link': !underlined && !unstyled,
       'sg-text--link-underlined': underlined && !unstyled,
       'sg-text--link-unstyled': !underlined && unstyled,
-      'sg-text--bold': emphasised,
+      'sg-text--bold': emphasised && !inherited,
       'sg-text--link-disabled': disabled,
       [`sg-text--${String(color)}`]: color && !unstyled,
       [`sg-text--${String(weight)}`]: weight,

--- a/src/components/text/Text.jsx
+++ b/src/components/text/Text.jsx
@@ -33,7 +33,7 @@ export type TextSizeType =
   | 'xxxlarge';
 
 export type TextColorType =
-  | 'default'
+  | 'black'
   | 'white'
   | 'gray'
   | 'gray-secondary'
@@ -106,9 +106,9 @@ const Text = ({
     'sg-text',
     {
       'sg-text--inherited': inherited,
-      [`sg-text--${String(size)}`]: size !== TEXT_SIZE.MEDIUM,
+      [`sg-text--${String(size)}`]: size && size !== TEXT_SIZE.MEDIUM,
       [`sg-text--${String(color)}`]: color,
-      [`sg-text--${String(weight)}`]: weight !== TEXT_WEIGHT.REGULAR,
+      [`sg-text--${String(weight)}`]: weight && weight !== TEXT_WEIGHT.REGULAR,
       [`sg-text--${transform || ''}`]: transform,
       [`sg-text--${align || ''}`]: align,
       'sg-text--container': asContainer,

--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -99,6 +99,10 @@ $headlineSizes: (
       color: $white;
     }
 
+    &--black {
+      color: $black;
+    }
+
     &--gray {
       color: $grayPrimary;
     }


### PR DESCRIPTION
- Link when inherited=true and emphasized=true, then it inherits font-weight (emphasized prop is not anymore overriding)
- Headline - black color class adds missing rules
- Headline - color value 'default' is replaced with 'black'
- Text - color value 'default' is replaced with 'black'
- removed usage of Text with color="default"
- Text does not generate broken class names for size and weight when not passed via props.