### PR TITLE
catch and show Input errors

### DIFF
--- a/src/docs/_sass/_docs-active-block.scss
+++ b/src/docs/_sass/_docs-active-block.scss
@@ -12,13 +12,21 @@ $docsActiveBlockTransparent: rgba(0, 0, 0, 0);
   &--gray .docs-active-block__component {
     background-color: $graySecondaryLightest;
     background-size: 41px 40px;
-    background-image: radial-gradient(circle, $grayPrimary 1px, $docsActiveBlockTransparent 1px);
+    background-image: radial-gradient(
+      circle,
+      $grayPrimary 1px,
+      $docsActiveBlockTransparent 1px
+    );
   }
 
   &--dark .docs-active-block__component {
     background-color: $grayPrimary;
     background-size: 41px 40px;
-    background-image: radial-gradient(circle, $grayPrimary 1px, $docsActiveBlockTransparent 1px);
+    background-image: radial-gradient(
+      circle,
+      $grayPrimary 1px,
+      $docsActiveBlockTransparent 1px
+    );
   }
 
   &__label {
@@ -61,6 +69,10 @@ $docsActiveBlockTransparent: rgba(0, 0, 0, 0);
     &:hover {
       opacity: 1;
     }
+  }
+
+  &__error {
+    color: $peachPrimaryDark;
   }
 
   // Hack to display overlay only in the docs active block, not full screen

--- a/src/docs/components/DocsActiveBlock.jsx
+++ b/src/docs/components/DocsActiveBlock.jsx
@@ -166,7 +166,14 @@ class DocsActiveBlock extends Component<PropsType, StateType> {
     let code;
 
     if (this.state.renderNormally) {
-      component = React.cloneElement(this.props.children, this.getCleanProps());
+      try {
+        component = React.cloneElement(
+          this.props.children,
+          this.getCleanProps()
+        );
+      } catch (e) {
+        component = <div className="docs-active-block__error">{e.message}</div>;
+      }
 
       if (this.state.showCode === 'jsx') {
         const jsx = generateJSX(component);


### PR DESCRIPTION
- DocsActiveBlock is now error boundary and shows errors beneath component

Fixes #1926