### PR TITLE
add navy-blue icon color

### DIFF
--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -399,6 +399,7 @@ export const ICON_COLOR: {
   MINT: 'mint',
   MUSTARD: 'mustard',
   PEACH: 'peach',
+  NAVY_BLUE: 'navy-blue',
 } = {
   ADAPTIVE: 'adaptive',
   BLUE: 'blue',
@@ -411,6 +412,7 @@ export const ICON_COLOR: {
   MINT: 'mint',
   MUSTARD: 'mustard',
   PEACH: 'peach',
+  NAVY_BLUE: 'navy-blue',
 };
 
 export const ICON_TAG_TYPE: {

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -136,7 +136,7 @@ export type IconColorType =
   | 'light'
   | 'mint'
   | 'mustard'
-  | 'navy-blue'
+  | 'blue-dark'
   | 'peach';
 
 export type IconTagType = 'div' | 'span';
@@ -399,7 +399,7 @@ export const ICON_COLOR: {
   MINT: 'mint',
   MUSTARD: 'mustard',
   PEACH: 'peach',
-  NAVY_BLUE: 'navy-blue',
+  BLUE_DARK: 'blue-dark',
 } = {
   ADAPTIVE: 'adaptive',
   BLUE: 'blue',
@@ -412,7 +412,7 @@ export const ICON_COLOR: {
   MINT: 'mint',
   MUSTARD: 'mustard',
   PEACH: 'peach',
-  NAVY_BLUE: 'navy-blue',
+  BLUE_DARK: 'blue-dark',
 };
 
 export const ICON_TAG_TYPE: {

--- a/src/components/icons/_icons-mixin.scss
+++ b/src/components/icons/_icons-mixin.scss
@@ -23,6 +23,10 @@
     fill: $bluePrimary;
   }
 
+  &--navy-blue {
+    fill: $bluePrimaryDark;
+  }
+
   &--mustard {
     fill: $mustardPrimary;
   }

--- a/src/components/icons/_icons-mixin.scss
+++ b/src/components/icons/_icons-mixin.scss
@@ -23,7 +23,7 @@
     fill: $bluePrimary;
   }
 
-  &--navy-blue {
+  &--blue-dark {
     fill: $bluePrimaryDark;
   }
 


### PR DESCRIPTION
It was already specified in `IconTypeType`, but not working
closes https://github.com/brainly/style-guide/issues/2114

usage:
<img width="445" alt="Screenshot 2021-09-13 at 11 48 23@2x" src="https://user-images.githubusercontent.com/9083292/133062809-3b4f9872-c5f2-440d-a2a0-e353ad4c5b3b.png">
