### PR TITLE
avoid directory collision on s3

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -14,7 +14,7 @@ phases:
       - export GIT_BRANCH=$(echo $GIT_BRANCH | sed "s|branch/||" | sed "s|/|-|g" | sed "s|refs-heads-||")
 
 artifacts:
-  name: '$GIT_BRANCH'
+  name: 'branches/$GIT_BRANCH'
   files:
     - '**/*'
   base-directory: '.storybook-static'


### PR DESCRIPTION
publish artifacts to branches/ to avoid name collision on top dir with release artifacts