### PR TITLE
Update styles in FileHandler

### DIFF
--- a/src/components/file-handler/_file-handler.scss
+++ b/src/components/file-handler/_file-handler.scss
@@ -1,12 +1,12 @@
 .sg-file-handler {
   display: inline-flex;
-  justify-content: center;
   align-items: center;
   height: componentSize(m);
   border-radius: 6px;
   padding: spacing(xs);
   padding-right: 12px;
   cursor: default;
+  max-width: 100%;
 
   &__icon {
     display: flex;
@@ -26,6 +26,7 @@
   &__text {
     position: relative;
     top: 1px;
+    min-width: 0;
   }
 
   &__close-button {


### PR DESCRIPTION
This change is connected with the bug: https://brainly.atlassian.net/browse/PBUGS-1371

The problem: hook `useAttachmentName` from brainly-frontend repo was used to trim name of the attachment. It checked text height vs container height and removed one char at a time until text height was smaller than container height. In case of very long names, it had to do this operation more than e.g. 50 times (by setting local state), what caused `maximum update depth exceeded` error.

In order to fix that, in the separate PR I'm introducing pure css solution to trim the text (https://github.com/brainly/brainly-frontend/pull/17684). Unfortunately, additional change in styles inside FileHandler is needed to do that. 

I believe that this small update is non-breaking change.

Video showing the changes I want to introduce in SG:


https://user-images.githubusercontent.com/14280367/139435609-4fc051a0-584a-4aae-8c6d-18ddfe5f5a64.mov


FileHandler in style-guide after changes:
![Screenshot 2021-10-29 at 13 39 33](https://user-images.githubusercontent.com/14280367/139435479-3fdeaa46-ee2f-4b45-85d3-ae73f72ca522.png)

