### PR TITLE
Accordion a11y improvements

### DIFF
--- a/src/components/accordion/Accordion.jsx
+++ b/src/components/accordion/Accordion.jsx
@@ -67,7 +67,6 @@ type ContextType = {
   dispatch: (action: ActionType) => void,
   reduceMotion: boolean,
   onItemSelect: (id: string, value: boolean) => void,
-  isControlled: boolean,
   ...
 };
 
@@ -280,7 +279,6 @@ const Accordion = ({
       dispatch,
       reduceMotion: hasReduceMotion,
       onItemSelect,
-      isControlled,
     }),
     [
       hasReduceMotion,
@@ -288,7 +286,6 @@ const Accordion = ({
       onItemSelect,
       state.focusedElementId,
       state.expanded,
-      isControlled,
     ]
   );
 

--- a/src/components/accordion/Accordion.jsx
+++ b/src/components/accordion/Accordion.jsx
@@ -67,6 +67,7 @@ type ContextType = {
   dispatch: (action: ActionType) => void,
   reduceMotion: boolean,
   onItemSelect: (id: string, value: boolean) => void,
+  isControlled: boolean,
   ...
 };
 
@@ -279,6 +280,7 @@ const Accordion = ({
       dispatch,
       reduceMotion: hasReduceMotion,
       onItemSelect,
+      isControlled,
     }),
     [
       hasReduceMotion,
@@ -286,6 +288,7 @@ const Accordion = ({
       onItemSelect,
       state.focusedElementId,
       state.expanded,
+      isControlled,
     ]
   );
 

--- a/src/components/accordion/Accordion.stories.jsx
+++ b/src/components/accordion/Accordion.stories.jsx
@@ -9,8 +9,6 @@ const copy = {
   description:
     // eslint-disable-next-line max-len
     "Now your family member just needs to open the link and hit 'accept'. If they aren't already on Brainly, we'll hook them up with that too. Create your unique family link with a click and share it with your family via email, Messenger, WhatsApp, whatever you like.",
-  cta: 'Learn more',
-  url: '#',
 };
 
 const items = [

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -55,10 +55,12 @@ const AccordionItem = ({
     dispatch,
     reduceMotion,
     onItemSelect,
+    isControlled,
   } = useContext(AccordionContext);
   const [isHovered, setIsHovered] = useState(false);
 
   const isCollapsed = !expanded.includes(id);
+  const isDisabled = !isCollapsed && isControlled;
   const isFocused = focusedElementId === id;
   const isHighlighted = isHovered || isFocused;
   const isBorderHighlighted = isHighlighted && !noGapBetweenElements;
@@ -185,6 +187,7 @@ const AccordionItem = ({
           onBlur={handleBlur}
           aria-expanded={!isCollapsed}
           aria-controls={contentId}
+          aria-disabled={isDisabled}
           role="button"
           tabIndex={tabIndex}
         >

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -55,12 +55,10 @@ const AccordionItem = ({
     dispatch,
     reduceMotion,
     onItemSelect,
-    isControlled,
   } = useContext(AccordionContext);
   const [isHovered, setIsHovered] = useState(false);
 
   const isCollapsed = !expanded.includes(id);
-  const isDisabled = !isCollapsed && isControlled;
   const isFocused = focusedElementId === id;
   const isHighlighted = isHovered || isFocused;
   const isBorderHighlighted = isHighlighted && !noGapBetweenElements;
@@ -187,7 +185,6 @@ const AccordionItem = ({
           onBlur={handleBlur}
           aria-expanded={!isCollapsed}
           aria-controls={contentId}
-          aria-disabled={isDisabled}
           role="button"
           tabIndex={tabIndex}
         >

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -23,6 +23,7 @@ export type AccordionItemPropsType = $ReadOnly<{
   padding?: PaddingType,
   tabIndex?: number,
   id?: string,
+  headingLevel?: number,
 }>;
 
 function generateId() {
@@ -39,6 +40,7 @@ const AccordionItem = ({
   padding = 'm',
   tabIndex = 0,
   id: customId,
+  headingLevel = 2,
 }: AccordionItemPropsType) => {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const {current: id} = useRef<string>(
@@ -170,56 +172,57 @@ const AccordionItem = ({
       )}
       padding={null}
     >
-      <Box
-        padding={padding}
-        className={cx('sg-accordion-item__button', {
-          'sg-accordion-item__button--focused': isFocused,
-        })}
-        onClick={toggleOpen}
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        aria-expanded={!isCollapsed}
-        aria-controls={contentId}
-        id={id}
-        role="button"
-        tabIndex={tabIndex}
-      >
-        <Flex
-          direction="row"
-          justifyContent="space-between"
-          alignItems="center"
+      <div role="heading" aria-level={headingLevel} id={id}>
+        <Box
+          padding={padding}
+          className={cx('sg-accordion-item__button', {
+            'sg-accordion-item__button--focused': isFocused,
+          })}
+          onClick={toggleOpen}
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
+          aria-expanded={!isCollapsed}
+          aria-controls={contentId}
+          role="button"
+          tabIndex={tabIndex}
         >
-          {isTitleString ? (
-            <Link
-              size={titleSize}
-              color="black"
-              weight="bold"
-              underlined={isHighlighted}
-            >
-              {title}
-            </Link>
-          ) : (
-            <span className="sg-accordion-item__title">{title}</span>
-          )}
           <Flex
-            justifyContent="center"
+            direction="row"
+            justifyContent="space-between"
             alignItems="center"
-            className={cx('sg-accordion-item__icon', {
-              'sg-accordion-item__icon--hover': isHighlighted,
-            })}
           >
-            <Icon
-              type="arrow_down"
-              color="dark"
-              className={cx('sg-accordion-item__arrow', {
-                'sg-accordion-item__arrow--visible': !isCollapsed,
+            {isTitleString ? (
+              <Link
+                size={titleSize}
+                color="black"
+                weight="bold"
+                underlined={isHighlighted}
+              >
+                {title}
+              </Link>
+            ) : (
+              <span className="sg-accordion-item__title">{title}</span>
+            )}
+            <Flex
+              justifyContent="center"
+              alignItems="center"
+              className={cx('sg-accordion-item__icon', {
+                'sg-accordion-item__icon--hover': isHighlighted,
               })}
-            />
+            >
+              <Icon
+                type="arrow_down"
+                color="dark"
+                className={cx('sg-accordion-item__arrow', {
+                  'sg-accordion-item__arrow--visible': !isCollapsed,
+                })}
+              />
+            </Flex>
           </Flex>
-        </Flex>
-      </Box>
+        </Box>
+      </div>
 
       <div
         ref={contentRef}


### PR DESCRIPTION
- role `heading` and `headingLevel` prop (default value: `2`) added to `AccordionItem` 
- `aria-disabled` set `true` for expanded item in controlled accordion