### PR TITLE
Flex responsive props

### DIFF
--- a/src/components/flex/Flex.jsx
+++ b/src/components/flex/Flex.jsx
@@ -21,6 +21,26 @@ function generateResponsiveClassNames<T>(
     return [createBaseClassName(prop)];
   }
 
+  if (Array.isArray(prop)) {
+    const breakpoints = ['', 'md', 'lg', 'xl'];
+
+    return (prop.length > 4 ? prop.slice(0, 4) : prop).reduce(
+      (acc, propBreakpointValue, index) => {
+        if (propBreakpointValue === null || propBreakpointValue === undefined) {
+          return acc;
+        } else {
+          acc.push(
+            `${
+              breakpoints[index] ? `${breakpoints[index]}:` : ''
+            }${createBaseClassName(propBreakpointValue)}`
+          );
+          return acc;
+        }
+      },
+      []
+    );
+  }
+
   return ['sm', 'md', 'lg', 'xl']
     .filter(breakpoint => Object.keys(prop).includes(breakpoint))
     .map(breakpoint =>
@@ -32,6 +52,7 @@ function generateResponsiveClassNames<T>(
 
 type ResponsivePropType<T> =
   | T
+  | Array<T>
   | {
       sm: T,
       md: T,

--- a/src/components/flex/Flex.jsx
+++ b/src/components/flex/Flex.jsx
@@ -52,7 +52,7 @@ function generateResponsiveClassNames<T>(
 
 type ResponsivePropType<T> =
   | T
-  | Array<T>
+  | Array<?T>
   | {
       sm: T,
       md: T,

--- a/src/components/flex/Flex.jsx
+++ b/src/components/flex/Flex.jsx
@@ -42,22 +42,26 @@ function generateResponsiveClassNames<T>(
   }
 
   return ['sm', 'md', 'lg', 'xl']
-    .filter(breakpoint => Object.keys(prop).includes(breakpoint))
-    .map(breakpoint =>
-      breakpoint === 'sm'
-        ? createBaseClassName(prop[breakpoint])
-        : `${breakpoint}:${createBaseClassName(prop[breakpoint])}`
-    );
+    .map(breakpoint => {
+      if (prop[breakpoint] === null || prop[breakpoint] === undefined) {
+        return '';
+      } else {
+        return breakpoint === 'sm'
+          ? createBaseClassName(prop[breakpoint])
+          : `${breakpoint}:${createBaseClassName(prop[breakpoint])}`;
+      }
+    })
+    .filter(className => className);
 }
 
 type ResponsivePropType<T> =
   | T
   | Array<?T>
   | {
-      sm: T,
-      md: T,
-      lg: T,
-      xl: T,
+      sm?: T,
+      md?: T,
+      lg?: T,
+      xl?: T,
     };
 
 type FlexContainerType =

--- a/src/components/flex/Flex.jsx
+++ b/src/components/flex/Flex.jsx
@@ -9,9 +9,16 @@ import {
   FLEX_MARGINS,
 } from './FlexConsts';
 
-function generateResponsiveClassNames(createBaseClassName, prop: object) {
+function generateResponsiveClassNames<T>(
+  createBaseClassName: T => string,
+  prop?: ResponsivePropType<T>
+): Array<string> {
   if (!prop) {
     return [];
+  }
+
+  if (typeof prop !== 'object') {
+    return [createBaseClassName(prop)];
   }
 
   return ['sm', 'md', 'lg', 'xl']
@@ -24,7 +31,7 @@ function generateResponsiveClassNames(createBaseClassName, prop: object) {
 }
 
 type ResponsivePropType<T> =
-  | Array<T>
+  | T
   | {
       sm: T,
       md: T,
@@ -318,7 +325,7 @@ const Flex = React.forwardRef<FlexPropsType, HTMLElement>(
         inlineFlex
       ),
       ...generateResponsiveClassNames(
-        propValue => `sg-flex--justify-content-${propValue}`,
+        (propValue: string) => `sg-flex--justify-content-${propValue}`,
         justifyContent
       ),
       ...generateResponsiveClassNames(

--- a/src/components/flex/Flex.jsx
+++ b/src/components/flex/Flex.jsx
@@ -9,6 +9,29 @@ import {
   FLEX_MARGINS,
 } from './FlexConsts';
 
+function generateResponsiveClassNames(createBaseClassName, prop: object) {
+  if (!prop) {
+    return [];
+  }
+
+  return ['sm', 'md', 'lg', 'xl']
+    .filter(breakpoint => Object.keys(prop).includes(breakpoint))
+    .map(breakpoint =>
+      breakpoint === 'sm'
+        ? createBaseClassName(prop[breakpoint])
+        : `${breakpoint}:${createBaseClassName(prop[breakpoint])}`
+    );
+}
+
+type ResponsivePropType<T> =
+  | Array<T>
+  | {
+      sm: T,
+      md: T,
+      lg: T,
+      xl: T,
+    };
+
 type FlexContainerType =
   | 'a'
   | 'article'
@@ -95,21 +118,21 @@ export type FlexPropsType = {
    *            component content
    *          </Flex>
    */
-  fullWidth?: boolean,
+  fullWidth?: ResponsivePropType<boolean>,
   /**
    * component will be rendered on 100% height of a parent
    * @example <Flex fullHeight>
    *            component content
    *          </Flex>
    */
-  fullHeight?: boolean,
+  fullHeight?: ResponsivePropType<boolean>,
   /**
    * It will set flex-shirnk to 0
    * @example <Flex noShrink>
    *            component content
    *          </Flex>
    */
-  noShrink?: boolean,
+  noShrink?: ResponsivePropType<boolean>,
   /**
    * Specify flex direction
    * @example <Flex direction="column">
@@ -120,7 +143,7 @@ export type FlexPropsType = {
    * @see direction=row https://styleguide.brainly.com/latest/docs/interactive.html?direction=row#flexbox
    * @see direction=row-reverse https://styleguide.brainly.com/latest/docs/interactive.html?direction=row-reverse#flexbox
    */
-  direction?: FlexDirectionType,
+  direction?: ResponsivePropType<FlexDirectionType>,
   /**
    * Specify flex justify content
    * @example <Flex justifyContent="space-between">
@@ -135,7 +158,7 @@ export type FlexPropsType = {
    * @see justifyContent=space-evenly https://styleguide.brainly.com/latest/docs/interactive.html?justifyContent=space-evenly#flexbox
    * @see justifyContent=stretch https://styleguide.brainly.com/latest/docs/interactive.html?justifyContent=stretch#flexbox
    */
-  justifyContent?: FlexJustifyValuesType,
+  justifyContent?: ResponsivePropType<FlexJustifyValuesType>,
   /**
    * Specify flex align content
    * @example <Flex alignContent="center">
@@ -147,7 +170,7 @@ export type FlexPropsType = {
    * @see alignContent=baseline https://styleguide.brainly.com/latest/docs/interactive.html?alignContent=baseline#flexbox
    * @see alignContent=stretch https://styleguide.brainly.com/latest/docs/interactive.html?alignContent=stretch#flexbox
    */
-  alignContent?: FlexAlignmentValuesType,
+  alignContent?: ResponsivePropType<FlexAlignmentValuesType>,
   /**
    * Specify flex align items
    * @example <Flex alignItems="center">
@@ -159,7 +182,7 @@ export type FlexPropsType = {
    * @see alignItems=baseline https://styleguide.brainly.com/latest/docs/interactive.html?alignItems=baseline#flexbox
    * @see alignItems=stretch https://styleguide.brainly.com/latest/docs/interactive.html?alignContent=stretch#flexbox
    */
-  alignItems?: FlexAlignmentValuesType,
+  alignItems?: ResponsivePropType<FlexAlignmentValuesType>,
   /**
    * Specify flex align self
    * @example <Flex alignSelf="center">
@@ -171,63 +194,63 @@ export type FlexPropsType = {
    * @see alignSelf=baseline https://styleguide.brainly.com/latest/docs/interactive.html?alignSelf=baseline#flexbox
    * @see alignSelf=stretch https://styleguide.brainly.com/latest/docs/interactive.html?alignSelf=stretch#flexbox
    */
-  alignSelf?: FlexAlignmentValuesType,
+  alignSelf?: ResponsivePropType<FlexAlignmentValuesType>,
   /**
    * It will set flex display to inline-flex
    * @example <Flex inlineFlex>
    *            component content
    *          </Flex>
    */
-  inlineFlex?: boolean,
+  inlineFlex?: ResponsivePropType<boolean>,
   /**
    * It will wrap component
    * @example <Flex wrap>
    *            component content
    *          </Flex>
    */
-  wrap?: boolean,
+  wrap?: ResponsivePropType<boolean>,
   /**
    * It will wrap reverse component
    * @example <Flex wrapReverse>
    *            component content
    *          </Flex>
    */
-  wrapReverse?: boolean,
+  wrapReverse?: ResponsivePropType<boolean>,
   /**
    * Specify margin for flex based on spacings: xxs: 4px, xs: 8px, s: 16px, m: 24px, l: 40px, xl: 64px, xxl: 104px, xxxl: 168px, xxxxl: 272px
    * @example <Flex margin="m">
    *            component content
    *          </Flex>
    */
-  margin?: FlexMarginsType,
+  margin?: ResponsivePropType<FlexMarginsType>,
   /**
    * Specify margin top for flex based on spacings: xxs: 4px, xs: 8px, s: 16px, m: 24px, l: 40px, xl: 64px, xxl: 104px, xxxl: 168px, xxxxl: 272px
    * @example <Flex marginTop="m">
    *            component content
    *          </Flex>
    */
-  marginTop?: FlexMarginsType,
+  marginTop?: ResponsivePropType<FlexMarginsType>,
   /**
    * Specify margin right for flex based on spacings: xxs: 4px, xs: 8px, s: 16px, m: 24px, l: 40px, xl: 64px, xxl: 104px, xxxl: 168px, xxxxl: 272px
    * @example <Flex marginRight="m">
    *            component content
    *          </Flex>
    */
-  marginRight?: FlexMarginsType,
+  marginRight?: ResponsivePropType<FlexMarginsType>,
   /**
    * Specify margin bottom for flex based on spacings: xxs: 4px, xs: 8px, s: 16px, m: 24px, l: 40px, xl: 64px, xxl: 104px, xxxl: 168px, xxxxl: 272px
    * @example <Flex marginBottom="m">
    *            component content
    *          </Flex>
    */
-  marginBottom?: FlexMarginsType,
+  marginBottom?: ResponsivePropType<FlexMarginsType>,
   /**
    * Specify margin left for flex based on spacings: xxs: 4px, xs: 8px, s: 16px, m: 24px, l: 40px, xl: 64px, xxl: 104px, xxxl: 168px, xxxxl: 272px
    * @example <Flex marginLeft="m">
    *            component content
    *          </Flex>
    */
-  marginLeft?: FlexMarginsType,
+  marginLeft?: ResponsivePropType<FlexMarginsType>,
   ...
 };
 
@@ -258,27 +281,86 @@ const Flex = React.forwardRef<FlexPropsType, HTMLElement>(
 
     const flexClass = classNames(
       'sg-flex',
-      {
-        'sg-flex--full-width': fullWidth,
-        'sg-flex--full-height': fullHeight,
-        'sg-flex--no-shrink': noShrink,
-        'sg-flex--inline': inlineFlex,
-        [`sg-flex--align-items-${alignItems || ''}`]: alignItems,
-        [`sg-flex--align-content-${alignContent || ''}`]: alignContent,
-        [`sg-flex--align-self-${alignSelf || ''}`]: alignSelf,
-        [`sg-flex--justify-content-${justifyContent || ''}`]: justifyContent,
-        'sg-flex--wrap': wrap,
-        'sg-flex--wrap-reverse': wrapReverse,
-        'sg-flex--column': direction === FLEX_DIRECTION.COLUMN,
-        'sg-flex--column-reverse': direction === FLEX_DIRECTION.COLUMN_REVERSE,
-        'sg-flex--row': direction === FLEX_DIRECTION.ROW,
-        'sg-flex--row-reverse': direction === FLEX_DIRECTION.ROW_REVERSE,
-        [`sg-flex--margin-${margin || ''}`]: margin,
-        [`sg-flex--margin-top-${marginTop || ''}`]: marginTop,
-        [`sg-flex--margin-right-${marginRight || ''}`]: marginRight,
-        [`sg-flex--margin-bottom-${marginBottom || ''}`]: marginBottom,
-        [`sg-flex--margin-left-${marginLeft || ''}`]: marginLeft,
-      },
+      ...generateResponsiveClassNames(
+        propValue =>
+          propValue === true ? `sg-flex--full-width` : `sg-flex--auto-width`,
+        fullWidth
+      ),
+      ...generateResponsiveClassNames(
+        propValue =>
+          propValue === true ? `sg-flex--full-height` : `sg-flex--auto-height`,
+        fullHeight
+      ),
+      ...generateResponsiveClassNames(
+        propValue =>
+          propValue === true ? `sg-flex--no-shrink` : `sg-flex--shrink-1`,
+        noShrink
+      ),
+      ...generateResponsiveClassNames(
+        propValue => (propValue === true ? `sg-flex--inline` : `sg-flex--flex`),
+        inlineFlex
+      ),
+      ...generateResponsiveClassNames(direction => {
+        if (direction === FLEX_DIRECTION.COLUMN) {
+          return 'sg-flex--column';
+        } else if (direction === FLEX_DIRECTION.COLUMN_REVERSE) {
+          return 'sg-flex--column-reverse';
+        } else if (direction === FLEX_DIRECTION.ROW) {
+          return 'sg-flex--row';
+        } else if (direction === FLEX_DIRECTION.ROW_REVERSE) {
+          return 'sg-flex--row-reverse';
+        } else {
+          return 'sg-flex--row';
+        }
+      }, direction),
+      ...generateResponsiveClassNames(
+        propValue => (propValue === true ? `sg-flex--inline` : `sg-flex--flex`),
+        inlineFlex
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--justify-content-${propValue}`,
+        justifyContent
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--align-items-${propValue}`,
+        alignItems
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--align-content-${propValue}`,
+        alignContent
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--align-self-${propValue}`,
+        alignSelf
+      ),
+      ...generateResponsiveClassNames(
+        propValue => (propValue ? 'sg-flex--wrap' : 'sg-flex--nowrap'),
+        wrap
+      ),
+      ...generateResponsiveClassNames(
+        propValue => (propValue ? 'sg-flex--wrap-reverse' : 'sg-flex--nowrap'),
+        wrapReverse
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--margin-${propValue}`,
+        margin
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--margin-top-${propValue}`,
+        marginTop
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--margin-right-${propValue}`,
+        marginRight
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--margin-bottom-${propValue}`,
+        marginBottom
+      ),
+      ...generateResponsiveClassNames(
+        propValue => `sg-flex--margin-left-${propValue}`,
+        marginLeft
+      ),
       className
     );
 

--- a/src/components/flex/Flex.spec.jsx
+++ b/src/components/flex/Flex.spec.jsx
@@ -103,7 +103,7 @@ describe('<Flex>', () => {
   });
 
   it('renders responsive props passed as object', () => {
-    const component = shallow(
+    const componentWithAllBreakpoints = shallow(
       <Flex
         fullWidth={{
           sm: true,
@@ -116,59 +116,128 @@ describe('<Flex>', () => {
       </Flex>
     );
 
+    const componentWithSomeBreakpoints = shallow(
+      <Flex
+        fullWidth={{
+          sm: true,
+          md: false,
+          lg: true,
+        }}
+      >
+        <div>test</div>
+      </Flex>
+    );
+
+    const componentWithNoBreakpoints = shallow(
+      <Flex fullWidth={{}}>
+        <div>test</div>
+      </Flex>
+    );
+
     expect(
-      component.findWhere(
+      componentWithAllBreakpoints.findWhere(
         node =>
           node.prop('className') ===
           'sg-flex sg-flex--full-width md:sg-flex--auto-width lg:sg-flex--full-width xl:sg-flex--full-width'
       )
     ).toHaveLength(1);
-  });
-
-  it('renders responsive class names with prop passed as array', () => {
-    const component = shallow(
-      <Flex fullWidth={[true, true, false, false]}>
-        <div>test</div>
-      </Flex>
-    );
 
     expect(
-      component.findWhere(
+      componentWithSomeBreakpoints.findWhere(
         node =>
           node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width'
+          'sg-flex sg-flex--full-width md:sg-flex--auto-width lg:sg-flex--full-width'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      componentWithNoBreakpoints.findWhere(
+        node => node.prop('className') === 'sg-flex'
       )
     ).toHaveLength(1);
   });
 
   it('renders responsive class names with prop passed as array', () => {
-    const component = shallow(
+    const componentWithAllBreakpoints = shallow(
       <Flex fullWidth={[true, true, false, false]}>
         <div>test</div>
       </Flex>
     );
 
-    expect(
-      component.findWhere(
-        node =>
-          node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width'
-      )
-    ).toHaveLength(1);
-  });
-
-  it('renders responsive class names when passed null or undefined as item', () => {
-    const component = shallow(
+    const componentWithNullBreakpoints = shallow(
       <Flex fullWidth={[true, true, null, false]}>
         <div>test</div>
       </Flex>
     );
 
+    const componentWithUndefinedBreakpoints = shallow(
+      <Flex fullWidth={[true, true, undefined, false]}>
+        <div>test</div>
+      </Flex>
+    );
+
+    const componentWithSkippedBreakpoints = shallow(
+      // eslint-disable-next-line no-sparse-arrays
+      <Flex fullWidth={[true, true, , false]}>
+        <div>test</div>
+      </Flex>
+    );
+
+    const componentWithNoBreakpoints = shallow(
+      <Flex fullWidth={[]}>
+        <div>test</div>
+      </Flex>
+    );
+
+    const componentWithTooManyBreakpoints = shallow(
+      <Flex fullWidth={[true, true, false, false, true, true, true]}>
+        <div>test</div>
+      </Flex>
+    );
+
     expect(
-      component.findWhere(
+      componentWithAllBreakpoints.findWhere(
+        node =>
+          node.prop('className') ===
+          'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      componentWithNullBreakpoints.findWhere(
         node =>
           node.prop('className') ===
           'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      componentWithUndefinedBreakpoints.findWhere(
+        node =>
+          node.prop('className') ===
+          'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      componentWithSkippedBreakpoints.findWhere(
+        node =>
+          node.prop('className') ===
+          'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      componentWithNoBreakpoints.findWhere(
+        node => node.prop('className') === 'sg-flex'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      componentWithTooManyBreakpoints.findWhere(
+        node =>
+          node.prop('className') ===
+          'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width'
       )
     ).toHaveLength(1);
   });

--- a/src/components/flex/Flex.spec.jsx
+++ b/src/components/flex/Flex.spec.jsx
@@ -134,6 +134,16 @@ describe('<Flex>', () => {
       </Flex>
     );
 
+    const componentWithInvalidBreakpoints = shallow(
+      <Flex
+        fullWidth={{
+          foo: 'bar',
+        }}
+      >
+        <div>test</div>
+      </Flex>
+    );
+
     expect(
       componentWithAllBreakpoints.findWhere(
         node =>
@@ -152,6 +162,12 @@ describe('<Flex>', () => {
 
     expect(
       componentWithNoBreakpoints.findWhere(
+        node => node.prop('className') === 'sg-flex'
+      )
+    ).toHaveLength(1);
+
+    expect(
+      componentWithInvalidBreakpoints.findWhere(
         node => node.prop('className') === 'sg-flex'
       )
     ).toHaveLength(1);

--- a/src/components/flex/Flex.spec.jsx
+++ b/src/components/flex/Flex.spec.jsx
@@ -102,159 +102,83 @@ describe('<Flex>', () => {
     ).toEqual(true);
   });
 
-  it('renders responsive props passed as object', () => {
-    const componentWithAllBreakpoints = shallow(
-      <Flex
-        fullWidth={{
-          sm: true,
-          md: false,
-          lg: true,
-          xl: true,
-        }}
-      >
-        <div>test</div>
-      </Flex>
-    );
-
-    const componentWithSomeBreakpoints = shallow(
-      <Flex
-        fullWidth={{
-          sm: true,
-          md: false,
-          lg: true,
-        }}
-      >
-        <div>test</div>
-      </Flex>
-    );
-
-    const componentWithNoBreakpoints = shallow(
-      <Flex fullWidth={{}}>
-        <div>test</div>
-      </Flex>
-    );
-
-    const componentWithInvalidBreakpoints = shallow(
-      <Flex
-        fullWidth={{
-          foo: 'bar',
-        }}
-      >
-        <div>test</div>
-      </Flex>
-    );
-
-    expect(
-      componentWithAllBreakpoints.findWhere(
-        node =>
-          node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--auto-width lg:sg-flex--full-width xl:sg-flex--full-width'
-      )
-    ).toHaveLength(1);
-
-    expect(
-      componentWithSomeBreakpoints.findWhere(
-        node =>
-          node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--auto-width lg:sg-flex--full-width'
-      )
-    ).toHaveLength(1);
-
-    expect(
-      componentWithNoBreakpoints.findWhere(
-        node => node.prop('className') === 'sg-flex'
-      )
-    ).toHaveLength(1);
-
-    expect(
-      componentWithInvalidBreakpoints.findWhere(
-        node => node.prop('className') === 'sg-flex'
-      )
-    ).toHaveLength(1);
-  });
-
-  it('renders responsive class names with prop passed as array', () => {
-    const componentWithAllBreakpoints = shallow(
-      <Flex fullWidth={[true, true, false, false]}>
-        <div>test</div>
-      </Flex>
-    );
-
-    const componentWithNullBreakpoints = shallow(
-      <Flex fullWidth={[true, true, null, false]}>
-        <div>test</div>
-      </Flex>
-    );
-
-    const componentWithUndefinedBreakpoints = shallow(
-      <Flex fullWidth={[true, true, undefined, false]}>
-        <div>test</div>
-      </Flex>
-    );
-
-    const componentWithSkippedBreakpoints = shallow(
+  const responsivePropsCases = [
+    [
+      'object',
+      'all breakpoints',
+      {
+        sm: true,
+        md: false,
+        lg: true,
+        xl: true,
+      },
+      'sg-flex sg-flex--full-width md:sg-flex--auto-width lg:sg-flex--full-width xl:sg-flex--full-width',
+    ],
+    [
+      'object',
+      'some breakpoints',
+      {
+        sm: true,
+        md: false,
+        lg: true,
+      },
+      'sg-flex sg-flex--full-width md:sg-flex--auto-width lg:sg-flex--full-width',
+    ],
+    ['object', 'no breakpoints', {}, 'sg-flex'],
+    [
+      'object',
+      'invalid breakpoints',
+      {
+        foo: 'bar',
+      },
+      'sg-flex',
+    ],
+    [
+      'array',
+      'all breakpoints',
+      [true, true, false, false],
+      'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width',
+    ],
+    [
+      'array',
+      'null breakpoints',
+      [true, true, null, false],
+      'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width',
+    ],
+    [
+      'array',
+      'undefined breakpoints',
+      [true, true, undefined, false],
+      'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width',
+    ],
+    [
+      'array',
+      'skipped breakpoints',
       // eslint-disable-next-line no-sparse-arrays
-      <Flex fullWidth={[true, true, , false]}>
-        <div>test</div>
-      </Flex>
-    );
+      [true, true, , false],
+      'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width',
+    ],
+    ['array', 'no breakpoints', [], 'sg-flex'],
+    [
+      'array',
+      'too many breakpoints',
+      [true, true, false, false, true, true, true],
+      'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width',
+    ],
+  ];
 
-    const componentWithNoBreakpoints = shallow(
-      <Flex fullWidth={[]}>
-        <div>test</div>
-      </Flex>
-    );
+  it.each(responsivePropsCases)(
+    'renders responsive classNames when prop passed as %s with %s',
+    (type, testCase, prop, classNames) => {
+      const component = shallow(
+        <Flex fullWidth={prop}>
+          <div>test</div>
+        </Flex>
+      );
 
-    const componentWithTooManyBreakpoints = shallow(
-      <Flex fullWidth={[true, true, false, false, true, true, true]}>
-        <div>test</div>
-      </Flex>
-    );
-
-    expect(
-      componentWithAllBreakpoints.findWhere(
-        node =>
-          node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width'
-      )
-    ).toHaveLength(1);
-
-    expect(
-      componentWithNullBreakpoints.findWhere(
-        node =>
-          node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width'
-      )
-    ).toHaveLength(1);
-
-    expect(
-      componentWithUndefinedBreakpoints.findWhere(
-        node =>
-          node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width'
-      )
-    ).toHaveLength(1);
-
-    expect(
-      componentWithSkippedBreakpoints.findWhere(
-        node =>
-          node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width'
-      )
-    ).toHaveLength(1);
-
-    expect(
-      componentWithNoBreakpoints.findWhere(
-        node => node.prop('className') === 'sg-flex'
-      )
-    ).toHaveLength(1);
-
-    expect(
-      componentWithTooManyBreakpoints.findWhere(
-        node =>
-          node.prop('className') ===
-          'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width'
-      )
-    ).toHaveLength(1);
-  });
+      expect(
+        component.findWhere(node => node.prop('className') === classNames)
+      ).toHaveLength(1);
+    }
+  );
 });

--- a/src/components/flex/Flex.spec.jsx
+++ b/src/components/flex/Flex.spec.jsx
@@ -101,4 +101,75 @@ describe('<Flex>', () => {
         .is('ul')
     ).toEqual(true);
   });
+
+  it('renders responsive props passed as object', () => {
+    const component = shallow(
+      <Flex
+        fullWidth={{
+          sm: true,
+          md: false,
+          lg: true,
+          xl: true,
+        }}
+      >
+        <div>test</div>
+      </Flex>
+    );
+
+    expect(
+      component.findWhere(
+        node =>
+          node.prop('className') ===
+          'sg-flex sg-flex--full-width md:sg-flex--auto-width lg:sg-flex--full-width xl:sg-flex--full-width'
+      )
+    ).toHaveLength(1);
+  });
+
+  it('renders responsive class names with prop passed as array', () => {
+    const component = shallow(
+      <Flex fullWidth={[true, true, false, false]}>
+        <div>test</div>
+      </Flex>
+    );
+
+    expect(
+      component.findWhere(
+        node =>
+          node.prop('className') ===
+          'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width'
+      )
+    ).toHaveLength(1);
+  });
+
+  it('renders responsive class names with prop passed as array', () => {
+    const component = shallow(
+      <Flex fullWidth={[true, true, false, false]}>
+        <div>test</div>
+      </Flex>
+    );
+
+    expect(
+      component.findWhere(
+        node =>
+          node.prop('className') ===
+          'sg-flex sg-flex--full-width md:sg-flex--full-width lg:sg-flex--auto-width xl:sg-flex--auto-width'
+      )
+    ).toHaveLength(1);
+  });
+
+  it('renders responsive class names when passed null or undefined as item', () => {
+    const component = shallow(
+      <Flex fullWidth={[true, true, null, false]}>
+        <div>test</div>
+      </Flex>
+    );
+
+    expect(
+      component.findWhere(
+        node =>
+          node.prop('className') ===
+          'sg-flex sg-flex--full-width md:sg-flex--full-width xl:sg-flex--auto-width'
+      )
+    ).toHaveLength(1);
+  });
 });

--- a/src/components/flex/Flex.stories.jsx
+++ b/src/components/flex/Flex.stories.jsx
@@ -174,3 +174,18 @@ export const JustifyAndAlign = () => (
     </div>
   </div>
 );
+
+export const ResponsiveProps = () => (
+  <div style={{width: 300}}>
+    <Flex
+      marginLeft={{
+        sm: 's',
+        md: 'm',
+        lg: 'l',
+        xl: 'xxxxl',
+      }}
+    >
+      dsa
+    </Flex>
+  </div>
+);

--- a/src/components/flex/Flex.stories.jsx
+++ b/src/components/flex/Flex.stories.jsx
@@ -174,3 +174,9 @@ export const JustifyAndAlign = () => (
     </div>
   </div>
 );
+
+export const ResponsiveProps = () => (
+  <Flex fullWidth={[true, true, null, false]}>
+        <div>test</div>
+      </Flex>
+);

--- a/src/components/flex/Flex.stories.jsx
+++ b/src/components/flex/Flex.stories.jsx
@@ -174,9 +174,3 @@ export const JustifyAndAlign = () => (
     </div>
   </div>
 );
-
-export const ResponsiveProps = () => (
-  <Flex fullWidth={[true, true, null, false]}>
-        <div>test</div>
-      </Flex>
-);

--- a/src/components/flex/Flex.stories.jsx
+++ b/src/components/flex/Flex.stories.jsx
@@ -177,15 +177,6 @@ export const JustifyAndAlign = () => (
 
 export const ResponsiveProps = () => (
   <div style={{width: 300}}>
-    <Flex
-      marginLeft={{
-        sm: 's',
-        md: 'm',
-        lg: 'l',
-        xl: 'xxxxl',
-      }}
-    >
-      dsa
-    </Flex>
+    <Flex marginLeft={['s', 'm', null, 'l']}>dsa</Flex>
   </div>
 );

--- a/src/components/flex/Flex.stories.jsx
+++ b/src/components/flex/Flex.stories.jsx
@@ -174,9 +174,3 @@ export const JustifyAndAlign = () => (
     </div>
   </div>
 );
-
-export const ResponsiveProps = () => (
-  <div style={{width: 300}}>
-    <Flex marginLeft={['s', 'm', null, 'l']}>dsa</Flex>
-  </div>
-);

--- a/src/components/flex/_flex.scss
+++ b/src/components/flex/_flex.scss
@@ -10,98 +10,147 @@ $flexSpacingsMap: (
   'xxxxl': spacing(xxxxl),
 );
 
-$marginSides: (
-  top
-  right
-  bottom
-  left
-);
+$marginSides: (top right bottom left);
 
-$flexProps: (
-  justify-content
-  align-items
-  align-self
-);
-$flexJustifyValues: (
-  space-between
-  space-evenly
-  space-around
-);
-$flexAlignmentValues: (
-  center
-  flex-start
-  flex-end
-  baseline
-  stretch
-);
+$flexProps: (justify-content align-items align-self);
+$flexJustifyValues: (space-between space-evenly space-around);
+$flexAlignmentValues: (center flex-start flex-end baseline stretch);
+
+@mixin makeResponsive($class) {
+  @each $breakpoint, $variant in $responsiveVariants {
+    @include sgResponsive($breakpoint) {
+      .#{$variant}#{$class} {
+        @content;
+      }
+    }
+  }
+}
+
+@mixin makeResponsive($responsiveVariant, $class) {
+  .#{$responsiveVariant}#{$class} {
+    @content;
+  }
+}
 
 .sg-flex {
   display: flex;
 
-  &--full-width {
-    width: 100%;
-  }
+  // @each $propName in $flexProps {
+  //   @each $propValue in $flexAlignmentValues {
+  //     &--#{$propName}-#{$propValue} {
+  //       #{$propName}: #{$propValue};
+  //     }
+  //   }
+  // }
 
-  &--full-height {
-    height: 100%;
-  }
+  // @each $sizeName, $size in $flexSpacingsMap {
+  //   &--margin-#{$sizeName} {
+  //     margin: #{$size};
+  //   }
+  // }
 
-  &--no-shrink {
-    flex-shrink: 0;
-  }
+  // @each $sizeName, $size in $flexSpacingsMap {
+  //   @each $side in $marginSides {
+  //     &--margin-#{$side}-#{$sizeName} {
+  //       margin-#{$side}: #{$size};
+  //     }
+  //   }
+  // }
+}
 
-  &--inline {
-    display: inline-flex;
-  }
-
-  &--column {
-    flex-direction: column;
-  }
-
-  &--column-reverse {
-    flex-direction: column-reverse;
-  }
-
-  &--row {
-    flex-direction: row;
-  }
-
-  &--row-reverse {
-    flex-direction: row-reverse;
-  }
-
-  &--wrap {
-    flex-wrap: wrap;
-  }
-
-  &--wrap-reverse {
-    flex-wrap: wrap-reverse;
-  }
-
-  @each $value in $flexJustifyValues {
-    &--justify-content-#{$value} {
-      justify-content: #{$value};
+@each $breakpoint, $variant in $responsiveVariants {
+  @include sgResponsive($breakpoint) {
+    @include makeResponsive($variant, 'sg-flex--full-width') {
+      width: 100%;
     }
-  }
 
-  @each $propName in $flexProps {
-    @each $propValue in $flexAlignmentValues {
-      &--#{$propName}-#{$propValue} {
-        #{$propName}: #{$propValue};
+    @include makeResponsive($variant, 'sg-flex--auto-width') {
+      width: auto;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--full-height') {
+      height: 100%;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--auto-height') {
+      height: auto;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--no-shrink') {
+      flex-shrink: 0;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--shrink-1') {
+      flex-shrink: 1;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--inline') {
+      display: inline-flex;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--flex') {
+      display: flex;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--wrap') {
+      flex-wrap: wrap;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--wrap-reverse') {
+      flex-wrap: wrap-reverse;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--nowrap') {
+      flex-wrap: nowrap;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--column') {
+      flex-direction: column;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--column-reverse') {
+      flex-direction: column-reverse;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--row') {
+      flex-direction: row;
+    }
+
+    @include makeResponsive($variant, 'sg-flex--row-reverse') {
+      flex-direction: row-reverse;
+    }
+
+    @each $value in $flexJustifyValues {
+      @include makeResponsive($variant, 'sg-flex--justify-content-#{$value}') {
+        justify-content: #{$value};
       }
     }
-  }
 
-  @each $sizeName, $size in $flexSpacingsMap {
-    &--margin-#{$sizeName} {
-      margin: #{$size};
+    @each $propName in $flexProps {
+      @each $propValue in $flexAlignmentValues {
+        @include makeResponsive(
+          $variant,
+          'sg-flex--#{$propName}-#{$propValue}'
+        ) {
+          #{$propName}: #{$propValue};
+        }
+      }
     }
-  }
 
-  @each $sizeName, $size in $flexSpacingsMap {
-    @each $side in $marginSides {
-      &--margin-#{$side}-#{$sizeName} {
-        margin-#{$side}: #{$size};
+    @each $sizeName, $size in $flexSpacingsMap {
+      @include makeResponsive($variant, 'sg-flex--margin-#{$sizeName}') {
+        margin: #{$size};
+      }
+    }
+
+    @each $sizeName, $size in $flexSpacingsMap {
+      @each $side in $marginSides {
+        @include makeResponsive(
+          $variant,
+          'sg-flex--margin-#{$side}-#{$sizeName}'
+        ) {
+          margin-#{$side}: #{$size};
+        }
       }
     }
   }

--- a/src/components/flex/_flex.scss
+++ b/src/components/flex/_flex.scss
@@ -16,16 +16,6 @@ $flexProps: (justify-content align-items align-self);
 $flexJustifyValues: (space-between space-evenly space-around);
 $flexAlignmentValues: (center flex-start flex-end baseline stretch);
 
-@mixin makeResponsive($class) {
-  @each $breakpoint, $variant in $responsiveVariants {
-    @include sgResponsive($breakpoint) {
-      .#{$variant}#{$class} {
-        @content;
-      }
-    }
-  }
-}
-
 @mixin makeResponsive($responsiveVariant, $class) {
   .#{$responsiveVariant}#{$class} {
     @content;

--- a/src/components/flex/_flex.scss
+++ b/src/components/flex/_flex.scss
@@ -34,28 +34,6 @@ $flexAlignmentValues: (center flex-start flex-end baseline stretch);
 
 .sg-flex {
   display: flex;
-
-  // @each $propName in $flexProps {
-  //   @each $propValue in $flexAlignmentValues {
-  //     &--#{$propName}-#{$propValue} {
-  //       #{$propName}: #{$propValue};
-  //     }
-  //   }
-  // }
-
-  // @each $sizeName, $size in $flexSpacingsMap {
-  //   &--margin-#{$sizeName} {
-  //     margin: #{$size};
-  //   }
-  // }
-
-  // @each $sizeName, $size in $flexSpacingsMap {
-  //   @each $side in $marginSides {
-  //     &--margin-#{$side}-#{$sizeName} {
-  //       margin-#{$side}: #{$size};
-  //     }
-  //   }
-  // }
 }
 
 @each $breakpoint, $variant in $responsiveVariants {


### PR DESCRIPTION
### Features
This feature introduces responsive props for Flex component. It enables passing multiple of values for prop depending on screen width.

**Object notation**

Breakpoints keys: 'sm', 'md', 'lg', 'xl' (all optional)

`<Flex
      marginLeft={{
        sm: 's',
        lg: 'l'
      }}>content</Flex>`

result HTML:
```
<div class="sg-flex sg-flex--margin-left-s lg:sg-flex--margin-left-l">
  content
</div>
```

**Array notation**

Breakpoints items (use in the same order): 'sm', 'md', 'lg', 'xl' (all optional, can be null or undefined)

`<Flex marginLeft={['s', 'm', null, 'l']}>content</Flex>`

result HTML:
```
<div class="sg-flex sg-flex--margin-left-s md:sg-flex--margin-left-m xl:sg-flex--margin-left-l">
  content
</div>
```

List of supported responsive props:
- fullWidth
- fullHeight
- noShrink
- inlineFlex
- alignItems
- alignContent
- justifyContent
- wrap
- wrapReverse
- alignSelf
- direction
- margin
- marginTop
- marginBottom
- marginLeft
- marginRight

#### CSS size:
**without responsive props:**
original size: 119691 / gzipped size: 15822
**with responsive props:**
original size: 137531 / gzipped size: 17168



