### PR TITLE
update node to 16

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v1
         with:
-          node-version: 14
+          node-version: 16
       - run: yarn
       - run: yarn build
       - run: yarn test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:14
+FROM mhart/alpine-node:16
 
 WORKDIR /style-guide
 


### PR DESCRIPTION
There is an issue on release pipeline caused by node version mismatch.

`error jest-matcher-utils@27.0.2: The engine "node" is incompatible with this module. Expected version "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0". Got "14.5.0"`

This change will affect GH actions and Teamcity pipeline. Node 16 LTS started last month so this might be also good idea to switch to it now.