### PR TITLE
A11y improvements icon

### DIFF
--- a/src/components/accordion/Accordion.a11y.spec.jsx
+++ b/src/components/accordion/Accordion.a11y.spec.jsx
@@ -30,10 +30,9 @@ describe('Accordion a11y', () => {
       </Accordion>
     );
 
-    const heading = accordion.getByRole('heading');
+    const heading = accordion.getByRole('heading', {name: title});
 
     expect(heading.getAttribute('aria-level')).toBeTruthy();
-    expect(heading.textContent).toBe(title);
 
     expect(accordion.getByRole('region', {name: title})).toBeTruthy();
     expect(accordion.getByRole('button').getAttribute('aria-controls')).toEqual(

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -218,6 +218,7 @@ const AccordionItem = ({
                 className={cx('sg-accordion-item__arrow', {
                   'sg-accordion-item__arrow--visible': !isCollapsed,
                 })}
+                aria-hidden="true"
               />
             </Flex>
           </Flex>

--- a/src/components/buttons/_buttons-mixins.scss
+++ b/src/components/buttons/_buttons-mixins.scss
@@ -188,7 +188,6 @@ $buttonPrimaryFbHoverColor: #4367a9;
     &:active:focus {
       background-color: mix($yellow-40, $transparentWhite, 12%);
       color: $yellow-40;
-      fill: $yellow-40;
     }
 
     &.sg-button-outline--disabled {
@@ -197,7 +196,6 @@ $buttonPrimaryFbHoverColor: #4367a9;
       &:focus {
         background-color: $buttonActiveInverseColor;
         color: $yellow-40;
-        fill: $yellow-40;
       }
     }
   }
@@ -212,7 +210,6 @@ $buttonPrimaryFbHoverColor: #4367a9;
     &:active:focus {
       background-color: mix($red-40, $transparentWhite, 12%);
       color: $red-40;
-      fill: $red-40;
     }
 
     &.sg-button-outline--disabled {
@@ -221,7 +218,6 @@ $buttonPrimaryFbHoverColor: #4367a9;
       &:focus {
         background-color: $buttonActiveInverseColor;
         color: $buttonActiveInverseFontColor;
-        fill: $buttonActiveInverseFontColor;
       }
     }
   }

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -11,7 +11,7 @@ $largeButtonSize: componentSize(l);
   }
 }
 
-@mixin iconColor($color) {
+@mixin buttonIconColor($color) {
   & .sg-button__icon {
     color: $color;
   }
@@ -160,19 +160,19 @@ $largeButtonSize: componentSize(l);
 
     &-toggle-peach {
       @include buttonHover($red-40, $red-20, 12%);
-      @include iconColor($red-40);
+      @include buttonIconColor($red-40);
       background-color: $red-20;
     }
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $yellow-20, 12%);
-      @include iconColor($yellow-40);
+      @include buttonIconColor($yellow-40);
       background-color: $yellow-20;
     }
 
     &-toggle-blue {
       @include buttonHover($blue-40, $blue-20, 12%);
-      @include iconColor($blue-40);
+      @include buttonIconColor($blue-40);
       background-color: $blue-20;
     }
   }
@@ -185,19 +185,19 @@ $largeButtonSize: componentSize(l);
 
     &-toggle-peach {
       @include buttonHover($red-40, $transparent, 12%);
-      @include iconColor($red-40);
+      @include buttonIconColor($red-40);
       border-color: $red-40;
     }
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $transparent, 12%);
-      @include iconColor($yellow-40);
+      @include buttonIconColor($yellow-40);
       border-color: $yellow-40;
     }
 
     &-toggle-blue {
       @include buttonHover($blue-40, $transparent, 12%);
-      @include iconColor($blue-40);
+      @include buttonIconColor($blue-40);
       border-color: $blue-40;
     }
   }
@@ -209,17 +209,17 @@ $largeButtonSize: componentSize(l);
 
     &-toggle-peach {
       @include buttonHover($red-40, $transparent, 12%);
-      @include iconColor($red-40);
+      @include buttonIconColor($red-40);
     }
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $transparent, 12%);
-      @include iconColor($yellow-40);
+      @include buttonIconColor($yellow-40);
     }
 
     &-toggle-blue {
       @include buttonHover($blue-40, $transparent, 12%);
-      @include iconColor($blue-40);
+      @include buttonIconColor($blue-40);
     }
   }
 
@@ -230,17 +230,17 @@ $largeButtonSize: componentSize(l);
 
     &-toggle-peach {
       @include buttonHover($red-40, $transparent, 12%);
-      @include iconColor($red-40);
+      @include buttonIconColor($red-40);
     }
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $transparent, 12%);
-      @include iconColor($yellow-40);
+      @include buttonIconColor($yellow-40);
     }
 
     &-toggle-blue {
       @include buttonHover($blue-40, $transparent, 12%);
-      @include iconColor($blue-40);
+      @include buttonIconColor($blue-40);
     }
   }
 

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -11,6 +11,12 @@ $largeButtonSize: componentSize(l);
   }
 }
 
+@mixin iconColor($color) {
+  & .sg-button__icon {
+    color: $color;
+  }
+}
+
 .sg-button {
   position: relative;
   display: inline-flex;
@@ -34,7 +40,6 @@ $largeButtonSize: componentSize(l);
   transition-timing-function: ease-in-out;
   cursor: pointer;
   box-sizing: border-box;
-  fill: $white;
 
   &__text {
     position: relative;
@@ -136,7 +141,6 @@ $largeButtonSize: componentSize(l);
     @include buttonHover($gray-10, $white, 80%);
     background-color: $white;
     color: $black;
-    fill: $black;
   }
 
   &--solid-blue {
@@ -153,24 +157,23 @@ $largeButtonSize: componentSize(l);
     @include buttonHover($gray-40, $gray-20, 12%);
     background-color: $gray-20;
     color: $black;
-    fill: $black;
 
     &-toggle-peach {
       @include buttonHover($red-40, $red-20, 12%);
+      @include iconColor($red-40);
       background-color: $red-20;
-      fill: $red-40;
     }
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $yellow-20, 12%);
+      @include iconColor($yellow-40);
       background-color: $yellow-20;
-      fill: $yellow-40;
     }
 
     &-toggle-blue {
       @include buttonHover($blue-40, $blue-20, 12%);
+      @include iconColor($blue-40);
       background-color: $blue-20;
-      fill: $blue-40;
     }
   }
 
@@ -179,24 +182,23 @@ $largeButtonSize: componentSize(l);
     background-color: $transparent;
     border: 2px solid $black;
     color: $black;
-    fill: $black;
 
     &-toggle-peach {
       @include buttonHover($red-40, $transparent, 12%);
+      @include iconColor($red-40);
       border-color: $red-40;
-      fill: $red-40;
     }
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $transparent, 12%);
+      @include iconColor($yellow-40);
       border-color: $yellow-40;
-      fill: $yellow-40;
     }
 
     &-toggle-blue {
       @include buttonHover($blue-40, $transparent, 12%);
+      @include iconColor($blue-40);
       border-color: $blue-40;
-      fill: $blue-40;
     }
   }
 
@@ -204,21 +206,20 @@ $largeButtonSize: componentSize(l);
     @include buttonHover($gray-50, $transparent, 12%);
     background-color: $transparent;
     color: $black;
-    fill: $black;
 
     &-toggle-peach {
       @include buttonHover($red-40, $transparent, 12%);
-      fill: $red-40;
+      @include iconColor($red-40);
     }
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $transparent, 12%);
-      fill: $yellow-40;
+      @include iconColor($yellow-40);
     }
 
     &-toggle-blue {
       @include buttonHover($blue-40, $transparent, 12%);
-      fill: $blue-40;
+      @include iconColor($blue-40);
     }
   }
 
@@ -226,21 +227,20 @@ $largeButtonSize: componentSize(l);
     @include buttonHover($gray-50, $transparent, 12%);
     background-color: $transparent;
     color: $gray-50;
-    fill: $gray-50;
 
     &-toggle-peach {
       @include buttonHover($red-40, $transparent, 12%);
-      fill: $red-40;
+      @include iconColor($red-40);
     }
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $transparent, 12%);
-      fill: $yellow-40;
+      @include iconColor($yellow-40);
     }
 
     &-toggle-blue {
       @include buttonHover($blue-40, $transparent, 12%);
-      fill: $blue-40;
+      @include iconColor($blue-40);
     }
   }
 
@@ -248,14 +248,12 @@ $largeButtonSize: componentSize(l);
     @include buttonHover($white, $transparent, 12%);
     background-color: $transparent;
     color: $white;
-    fill: $white;
   }
 
   &--transparent-peach {
     @include buttonHover($red-40, $transparent, 12%);
     background-color: $transparent;
     color: $red-40;
-    fill: $red-40;
 
     &-toggle-peach {
       @include buttonHover($red-40, $transparent, 12%);
@@ -266,7 +264,6 @@ $largeButtonSize: componentSize(l);
     @include buttonHover($yellow-40, $transparent, 12%);
     background-color: $transparent;
     color: $yellow-40;
-    fill: $yellow-40;
 
     &-toggle-mustard {
       @include buttonHover($yellow-40, $transparent, 12%);
@@ -277,7 +274,6 @@ $largeButtonSize: componentSize(l);
     @include buttonHover($blue-40, $transparent, 12%);
     background-color: $transparent;
     color: $blue-40;
-    fill: $blue-40;
 
     &-toggle-blue {
       @include buttonHover($blue-40, $transparent, 12%);

--- a/src/components/form-elements/_checkbox-radio.scss
+++ b/src/components/form-elements/_checkbox-radio.scss
@@ -40,7 +40,7 @@ $includeHtml: false !default;
       width: $radioSizeXXS;
       height: $radioSizeXXS;
       border: 2px solid $crInputBorderColor;
-      fill: $crInputColor;
+      color: $crInputColor;
       display: flex;
       align-items: center;
       justify-content: center;

--- a/src/components/icon-as-button/IconAsButton.jsx
+++ b/src/components/icon-as-button/IconAsButton.jsx
@@ -31,6 +31,7 @@ export type IconAsButtonPropsType = {
   active?: boolean,
   href?: string,
   className?: string,
+  title?: string,
   ...
 };
 
@@ -46,6 +47,7 @@ const IconAsButton = ({
   active,
   border,
   className,
+  title,
   ...props
 }: IconAsButtonPropsType) => {
   const buttonClass = classNames(
@@ -67,7 +69,12 @@ const IconAsButton = ({
 
   if (type) {
     content = (
-      <Icon type={type} size={ICON_SIZE[size]} color={ICON_COLOR.ADAPTIVE} />
+      <Icon
+        type={type}
+        color={ICON_COLOR.ADAPTIVE}
+        size={ICON_SIZE[size]}
+        title={title}
+      />
     );
   } else {
     content = children;

--- a/src/components/icon-as-button/_icon-as-button.scss
+++ b/src/components/icon-as-button/_icon-as-button.scss
@@ -27,16 +27,16 @@ $includeHtml: false !default;
 
 @mixin colorTheme($modifierName, $color, $colorActive, $actionForegroundColor: $iconAsButtonActionColor) {
   &.sg-icon-as-button--#{$modifierName} {
-    fill: $color;
+    color: $color;
 
     @media (hover: hover) {
       &:hover {
-        fill: $colorActive;
+        color: $colorActive;
       }
     }
 
     &:active {
-      fill: $colorActive;
+      color: $colorActive;
     }
 
     .sg-icon-as-button__hole {
@@ -47,7 +47,7 @@ $includeHtml: false !default;
   &.sg-icon-as-button--action {
     &:active {
       &.sg-icon-as-button--#{$modifierName} {
-        fill: $actionForegroundColor;
+        color: $actionForegroundColor;
         background: $color;
       }
     }
@@ -55,7 +55,7 @@ $includeHtml: false !default;
     @media (hover: hover) {
       &:hover {
         &.sg-icon-as-button--#{$modifierName} {
-          fill: $actionForegroundColor;
+          color: $actionForegroundColor;
           background: $color;
         }
       }
@@ -64,7 +64,7 @@ $includeHtml: false !default;
 
   &--action-active {
     &.sg-icon-as-button--#{$modifierName} {
-      fill: $actionForegroundColor;
+      color: $actionForegroundColor;
       background: $color;
     }
   }
@@ -78,15 +78,15 @@ $includeHtml: false !default;
     padding: 0;
     cursor: pointer;
     overflow: visible;
-    fill: $iconAsButtonColor;
+    color: $iconAsButtonColor;
 
     &:active {
-      fill: $iconAsButtonActiveColor;
+      color: $iconAsButtonActiveColor;
     }
 
     @media (hover: hover) {
       &:hover {
-        fill: $iconAsButtonActiveColor;
+        color: $iconAsButtonActiveColor;
       }
     }
 
@@ -106,11 +106,11 @@ $includeHtml: false !default;
     }
 
     &--adaptive {
-      fill: inherit;
+      color: inherit;
 
       &:hover,
       &:active {
-        fill: inherit;
+        color: inherit;
       }
 
       .sg-icon-as-button__hole {
@@ -137,12 +137,12 @@ $includeHtml: false !default;
     @include colorTheme('icon-red-50', $iconAsButtonPeachColor, $iconAsButtonPeachActiveColor);
 
     &--action {
-      transition: background 0.3s ease-out, fill 0.3s ease-out;
+      transition: background 0.3s ease-out, color 0.3s ease-out;
       border-radius: 50%;
     }
 
     &--transparent {
-      transition: background 0.3s ease-out, fill 0.3s ease-out;
+      transition: background 0.3s ease-out, color 0.3s ease-out;
       border-radius: 50%;
 
       &:active {
@@ -158,21 +158,21 @@ $includeHtml: false !default;
 
     &--action-active {
       background: $iconAsButtonColor;
-      fill: $iconAsButtonActionColor;
+      color: $iconAsButtonActionColor;
       border-radius: 50%;
 
       &.sg-icon-as-button--adaptive {
-        fill: inherit;
+        color: inherit;
         background: inherit;
       }
     }
 
     &--transparent-active {
-      fill: $iconAsButtonColor;
+      color: $iconAsButtonColor;
       background: $iconAsButtonTransparentColor;
 
       &.sg-icon-as-button--adaptive {
-        fill: inherit;
+        color: inherit;
       }
     }
   }

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -485,6 +485,14 @@ export type IconPropsType =
                   </Button>
       */
       tagType?: IconTagType,
+      /**
+       * An accessible, short-text description; defaults to `type`
+       */
+      title?: string,
+      /**
+       * An accessible, long-text description
+       */
+      description?: string,
       ...
     }
   | {
@@ -523,8 +531,24 @@ export type IconPropsType =
                   </Button>
       */
       tagType?: IconTagType,
+      /**
+       * An accessible, short-text description; defaults to `type`
+       */
+      title?: string,
+      /**
+       * An accessible, long-text description
+       */
+      description?: string,
       ...
     };
+
+function generateIdSuffix(type: string) {
+  const randomIndex = Math.random()
+    .toString(36)
+    .substring(7);
+
+  return `${type}-${randomIndex}`;
+}
 
 const Icon = ({
   color = ICON_COLOR['icon-white'],
@@ -537,6 +561,8 @@ const Icon = ({
   children,
   tagType = 'div',
   className,
+  title,
+  description,
   ...props
 }: IconPropsType) => {
   const iconClass = classNames(
@@ -551,11 +577,27 @@ const Icon = ({
   const iconType = `#icon-${type}`;
   const Tag = tagType;
 
+  const idSuffix = generateIdSuffix(type);
+  const titleId = `title-${idSuffix}`;
+  const titleFallback = String(type).replace(/_/g, ' ');
+  const descId = `desc-${idSuffix}`;
+  const labelledBy = description ? `${titleId} ${descId}` : titleId;
+  const ariaLabel = type
+    ? undefined
+    : [title, description].filter(Boolean).join(', ');
+
   return (
-    <Tag {...props} className={iconClass}>
+    <Tag {...props} className={iconClass} aria-label={ariaLabel}>
       {type ? (
-        <svg className="sg-icon__svg">
-          <use xlinkHref={iconType} />
+        <svg
+          className="sg-icon__svg"
+          role="img"
+          aria-labelledby={labelledBy}
+          focusable="false"
+        >
+          <title id={titleId}>{title || titleFallback}</title>
+          {description && <desc id={descId}>{description}</desc>}
+          <use xlinkHref={iconType} aria-hidden="true" />
         </svg>
       ) : (
         children

--- a/src/components/icons/_icons-mixin.scss
+++ b/src/components/icons/_icons-mixin.scss
@@ -1,45 +1,45 @@
 @mixin iconColor() {
   &--adaptive {
-    fill: inherit;
+    color: inherit;
   }
 
   &--icon-black {
-    fill: $icon-black;
+    color: $icon-black;
   }
 
   &--icon-white {
-    fill: $icon-white;
+    color: $icon-white;
   }
 
   &--icon-gray-70 {
-    fill: $icon-gray-70;
+    color: $icon-gray-70;
   }
 
   &--icon-gray-50 {
-    fill: $icon-gray-50;
+    color: $icon-gray-50;
   }
 
   &--icon-gray-40 {
-    fill: $icon-gray-40;
+    color: $icon-gray-40;
   }
 
   &--icon-blue-50 {
-    fill: $icon-blue-50;
+    color: $icon-blue-50;
   }
 
   &--icon-indigo-50 {
-    fill: $icon-indigo-50;
+    color: $icon-indigo-50;
   }
 
   &--icon-green-50 {
-    fill: $icon-green-50;
+    color: $icon-green-50;
   }
 
   &--icon-yellow-50 {
-    fill: $icon-yellow-50;
+    color: $icon-yellow-50;
   }
 
   &--icon-red-50 {
-    fill: $icon-red-50;
+    color: $icon-red-50;
   }
 }

--- a/src/components/icons/_icons-mixin.scss
+++ b/src/components/icons/_icons-mixin.scss
@@ -5,7 +5,7 @@
   @media (forced-colors: active) {
     fill: CanvasText;
   }
-  
+
   &--adaptive {
     color: inherit;
   }

--- a/src/components/icons/_icons-mixin.scss
+++ b/src/components/icons/_icons-mixin.scss
@@ -1,4 +1,11 @@
 @mixin iconColor() {
+  color: $white;
+  fill: currentColor;
+
+  @media (forced-colors: active) {
+    fill: CanvasText;
+  }
+  
   &--adaptive {
     color: inherit;
   }

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -9,12 +9,17 @@ $iconSizes: 16, 24, 32, 40, 56, 80, 104;
   .sg-icon {
     @include iconColor();
 
-    fill: $icon-white;
+    color: $icon-white;
+    fill: currentColor;
     max-width: 24px;
     max-height: 24px;
     height: 24px;
     width: 24px;
     flex-shrink: 0;
+
+    @media (forced-colors: active) {
+      fill: CanvasText;
+    }
 
     @each $size in $iconSizes {
       &--x#{$size} {

--- a/src/components/icons/_icons.scss
+++ b/src/components/icons/_icons.scss
@@ -9,17 +9,11 @@ $iconSizes: 16, 24, 32, 40, 56, 80, 104;
   .sg-icon {
     @include iconColor();
 
-    color: $icon-white;
-    fill: currentColor;
     max-width: 24px;
     max-height: 24px;
     height: 24px;
     width: 24px;
     flex-shrink: 0;
-
-    @media (forced-colors: active) {
-      fill: CanvasText;
-    }
 
     @each $size in $iconSizes {
       &--x#{$size} {

--- a/src/components/math-symbols/MathSymbol.jsx
+++ b/src/components/math-symbols/MathSymbol.jsx
@@ -83,6 +83,7 @@ export type MathSymbolPropsType = {
   size?: MathSymbolSizeType,
   color?: IconColorType,
   className?: string,
+  title?: string,
   ...
 };
 
@@ -91,6 +92,7 @@ const MathSymbol = ({
   size = SIZE.NORMAL,
   color,
   className,
+  title,
   ...props
 }: MathSymbolPropsType) => {
   const isWide = WIDE.indexOf(type) !== -1;
@@ -105,9 +107,12 @@ const MathSymbol = ({
     className
   );
   const iconType = `#sg-math-symbol-icon-${type}`;
+  const titleId = `sg-math-symbol-icon-${type}-title`;
+  const defaultTitle = type.replace(/-/g, ' ');
 
   return (
-    <svg {...props} className={iconClass}>
+    <svg {...props} className={iconClass} aria-labelledby={titleId} role="img">
+      <title id={titleId}>{title || defaultTitle}</title>
       <use xlinkHref={iconType} />
     </svg>
   );

--- a/src/components/math-symbols/MathSymbol.jsx
+++ b/src/components/math-symbols/MathSymbol.jsx
@@ -113,7 +113,7 @@ const MathSymbol = ({
   return (
     <svg {...props} className={iconClass} aria-labelledby={titleId} role="img">
       <title id={titleId}>{title || defaultTitle}</title>
-      <use xlinkHref={iconType} />
+      <use xlinkHref={iconType} arya-hidden="true" />
     </svg>
   );
 };

--- a/src/components/math-symbols/_math-symbol-icon.scss
+++ b/src/components/math-symbols/_math-symbol-icon.scss
@@ -3,7 +3,8 @@
 .sg-math-symbol-icon {
   height: 64px;
   width: 64px;
-  fill: $icon-white;
+  color: $icon-white;
+  fill: currentColor;
 
   &--wide {
     width: 128px;

--- a/src/components/math-symbols/_math-symbol-icon.scss
+++ b/src/components/math-symbols/_math-symbol-icon.scss
@@ -3,8 +3,6 @@
 .sg-math-symbol-icon {
   height: 64px;
   width: 64px;
-  color: $icon-white;
-  fill: currentColor;
 
   &--wide {
     width: 128px;

--- a/src/components/mobile-icons/_mobile-icon.scss
+++ b/src/components/mobile-icons/_mobile-icon.scss
@@ -6,7 +6,8 @@ $iconSizes: 104, 102, 80, 78, 56, 54, 40, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10
   @include iconColor();
   height: 24px;
   width: 24px;
-  fill: $white;
+  color: $white;
+  fill: currentColor;
 
   @each $size in $iconSizes {
     &--x#{$size} {

--- a/src/components/mobile-icons/_mobile-icon.scss
+++ b/src/components/mobile-icons/_mobile-icon.scss
@@ -6,8 +6,6 @@ $iconSizes: 104, 102, 80, 78, 56, 54, 40, 32, 30, 26, 24, 22, 20, 18, 16, 14, 10
   @include iconColor();
   height: 24px;
   width: 24px;
-  color: $white;
-  fill: currentColor;
 
   @each $size in $iconSizes {
     &--x#{$size} {

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -46,20 +46,20 @@ $includeHtml: false !default;
       .sg-rate-box__background-stars {
 
         .sg-rate-box__star:hover ~ .sg-rate-box__star {
-          fill: $rateStarColor;
+          color: $rateStarColor;
         }
 
         &:active .sg-rate-box__star:hover ~ .sg-rate-box__star {
-          fill: $rateStarActiveColor;
+          color: $rateStarActiveColor;
         }
 
         &:hover .sg-rate-box__star {
-          fill: $rateStarCheckedColor;
-          transition: fill 0.1s ease-in;
+          color: $rateStarCheckedColor;
+          transition: color 0.1s ease-in;
         }
 
         &:active:hover .sg-rate-box__star {
-          fill: $rateStarActiveCheckedColor;
+          color: $rateStarActiveCheckedColor;
           transition: none;
         }
       }
@@ -71,12 +71,12 @@ $includeHtml: false !default;
 
     &__background-stars {
       display: flex;
-      fill: $rateStarColor;
+      color: $rateStarColor;
     }
 
     &__filled-stars {
       display: flex;
-      fill: $rateStarCheckedColor;
+      color: $rateStarCheckedColor;
 
       position: absolute;
       left: 0;

--- a/src/components/search/_search.scss
+++ b/src/components/search/_search.scss
@@ -7,14 +7,14 @@ $includeHtml: false !default;
     overflow: visible;
 
     &__icon {
-      transition: fill 0.3s ease-out;
+      transition: color 0.3s ease-out;
       position: absolute;
       top: 0;
       bottom: 0;
       display: flex;
       align-items: center;
       justify-content: center;
-      fill: $white;
+      color: $white;
       background: none;
       border: none;
       right: 5px;
@@ -25,7 +25,7 @@ $includeHtml: false !default;
     }
 
     &__input:focus + &__icon {
-      fill: $gray-50;
+      color: $gray-50;
     }
 
     &--full-width {

--- a/src/components/subject-icons/SubjectIcon.jsx
+++ b/src/components/subject-icons/SubjectIcon.jsx
@@ -290,7 +290,7 @@ const SubjectIcon = ({
   return (
     <svg {...props} className={iconClass} aria-labelledby={titleId} role="img">
       <title id={titleId}>{title || defaultTitle}</title>
-      <use xlinkHref={iconType} />
+      <use xlinkHref={iconType} aria-hidden="true" />
     </svg>
   );
 };

--- a/src/components/subject-icons/SubjectIcon.jsx
+++ b/src/components/subject-icons/SubjectIcon.jsx
@@ -262,6 +262,7 @@ export type SubjectIconPropsType = {
   type: IconTypeType,
   size?: SizeType,
   monoColor?: IconColorType,
+  title?: string,
   ...
 };
 
@@ -270,6 +271,7 @@ const SubjectIcon = ({
   size = SIZE.NORMAL,
   monoColor,
   className,
+  title,
   ...props
 }: SubjectIconPropsType) => {
   const iconClass = classNames(
@@ -282,9 +284,12 @@ const SubjectIcon = ({
     className
   );
   const iconType = `#icon-subject-${monoColor ? 'mono-' : ''}${type}`;
+  const titleId = `sg-math-symbol-icon-${type}-title`;
+  const defaultTitle = type.replace(/-alt$/g, '').replace(/-/g, ' ');
 
   return (
-    <svg {...props} className={iconClass}>
+    <svg {...props} className={iconClass} aria-labelledby={titleId} role="img">
+      <title id={titleId}>{title || defaultTitle}</title>
       <use xlinkHref={iconType} />
     </svg>
   );

--- a/src/components/subject-icons/_subject-icon.scss
+++ b/src/components/subject-icons/_subject-icon.scss
@@ -3,7 +3,6 @@
 .sg-subject-icon {
   height: 64px;
   width: 64px;
-  fill: $icon-white;
 
   &--medium {
     height: 32px;


### PR DESCRIPTION
- added accessible `title` & `description` props for `Icon`
- added `role` to `svg` in `Icon` (default: `"img"`)
- adjusted colors for high contrast mode (only Windows):
normal colors: 
![dark1](https://user-images.githubusercontent.com/60467496/141791000-de8ec530-bece-4f1d-a50d-b921a760741f.png)
high contrast mode before change:
![dark2](https://user-images.githubusercontent.com/60467496/141791060-d04d0f79-6776-43bb-a2e8-724ca16c2e01.png)
high contrast mode after change:
![dark3](https://user-images.githubusercontent.com/60467496/141791105-9a8fbdf3-9751-4d61-abb3-705a393d05a4.png)


closes: #2035