### PR TITLE
Fix typography docs

### DIFF
--- a/src/components/text/stories/text.stories.mdx
+++ b/src/components/text/stories/text.stories.mdx
@@ -13,7 +13,6 @@ import {
 import Headline, {
   HEADLINE_TYPE,
   HEADLINE_SIZE,
-  TEXT_COLOR,
   HEADLINE_TRANSFORM,
   HEADLINE_ALIGN,
 } from '../Headline';


### PR DESCRIPTION
A small fix to remove an unnecessary import that made the entire typography page disappear.

**before:**
![image](https://user-images.githubusercontent.com/8572321/146188992-f5dcee84-444f-4afd-996a-59e971eba427.png)
 

**after:**
![image](https://user-images.githubusercontent.com/8572321/146189374-29a09ea3-cacc-4f8e-a010-a19347cd4910.png)
