### PR TITLE
Replace storybook env with const during package build process

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -1,37 +1,45 @@
-const babelEnv = params => [
-  "@babel/preset-env",
+const babelEnv = (params) => [
+  '@babel/preset-env',
   Object.assign(
     {
-      targets: "> 0.2%, not dead, not ie < 11"
+      targets: '> 0.2%, not dead, not ie < 11',
     },
-    params
-  )
+    params,
+  ),
 ];
 
-module.exports = api => {
+module.exports = (api) => {
   api.cache(true);
   return {
     presets: [
       babelEnv({ modules: false }),
-      "@babel/preset-react",
-      "@babel/preset-flow"
+      '@babel/preset-react',
+      '@babel/preset-flow',
     ],
     plugins: [
-      "@babel/plugin-proposal-object-rest-spread",
-      "@babel/plugin-proposal-class-properties"
+      '@babel/plugin-proposal-object-rest-spread',
+      '@babel/plugin-proposal-class-properties',
+      [
+        'transform-define',
+        {
+          'process.env.STORYBOOK_ENV': JSON.stringify(
+            process.env.STORYBOOK_ENV,
+          ),
+        },
+      ],
     ],
     env: {
       test: {
-        presets: [babelEnv({ modules: "auto" })],
-        plugins: [["@babel/plugin-transform-runtime"]]
+        presets: [babelEnv({ modules: 'auto' })],
+        plugins: [['@babel/plugin-transform-runtime']],
       },
       commonjs: {
-        presets: [babelEnv({ modules: "auto" })],
+        presets: [babelEnv({ modules: 'auto' })],
       },
       esm: {
         presets: [babelEnv({ modules: false })],
-        plugins: [["@babel/plugin-transform-runtime", { useESModules: true }]]
-      }
-    }
+        plugins: [['@babel/plugin-transform-runtime', { useESModules: true }]],
+      },
+    },
   };
 };

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "babel-eslint": "^10.0.2",
     "babel-jest": "^20.0.3",
     "babel-loader": "^8.0.5",
+    "babel-plugin-transform-define": "^2.0.1",
     "concurrently": "^5.0.2",
     "css-loader": "^3.1.0",
     "del": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4995,6 +4995,14 @@ babel-plugin-syntax-object-rest-spread@^6.13.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
   integrity sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=
 
+babel-plugin-transform-define@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-define/-/babel-plugin-transform-define-2.0.1.tgz#6a34fd6ea89989feb75721ee4cce817ec779be7f"
+  integrity sha512-7lDR1nFGSJHmhq/ScQtp9LTDmNE2yKPoLtwfiu+WQZnj84XL/J/5AZWZXwYcOwbDtUPhtg+y0yxTiP/oGDU6Kw==
+  dependencies:
+    lodash "^4.17.11"
+    traverse "0.6.6"
+
 babel-preset-jest@^20.0.3:
   version "20.0.3"
   resolved "https://registry.yarnpkg.com/babel-preset-jest/-/babel-preset-jest-20.0.3.tgz#cbacaadecb5d689ca1e1de1360ebfc66862c178a"
@@ -17345,7 +17353,7 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-traverse@^0.6.6:
+traverse@0.6.6, traverse@^0.6.6:
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/traverse/-/traverse-0.6.6.tgz#cbdf560fd7b9af632502fed40f918c157ea97137"
   integrity sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=


### PR DESCRIPTION
Use babel define plugin (similar to webpack define plugin) to replace env variable during package build process. 

The effects of the plugin are as follows:

**source**
```
LOGOS_BASE_URL =
  process.env.STORYBOOK_ENV === 'dev' ||
  process.env.STORYBOOK_ENV === 'chromatic'
    ? 'images/logos/'
    : 'https://styleguide.brainly.com/images/logos/';
```

**output** (when no STORYBOOK_ENV is defined)
```
LOGOS_BASE_URL = false || false ? 'images/logos/' : 'https://styleguide.brainly.com/images/logos/';
```