### PR TITLE
FileHandler a11y imprv

### DIFF
--- a/src/components/file-handler/FileHandler.a11y.spec.jsx
+++ b/src/components/file-handler/FileHandler.a11y.spec.jsx
@@ -1,0 +1,65 @@
+import * as React from 'react';
+import {render} from '@testing-library/react';
+import FileHandler from './FileHandler';
+import {testA11y} from '../../axe';
+import userEvent from '@testing-library/user-event';
+
+describe('FileHandler', () => {
+  it('fires onClick on click, space and enter', () => {
+    const handleOnClick = jest.fn();
+    const fileName = 'file name';
+    const fileHandler = render(
+      <FileHandler onClick={handleOnClick}>{fileName}</FileHandler>
+    );
+
+    userEvent.click(fileHandler.getByText(fileName));
+    fileHandler.getByText(fileName).focus();
+    userEvent.keyboard('{space}');
+    userEvent.keyboard('{enter}');
+
+    expect(handleOnClick).toHaveBeenCalledTimes(3);
+  });
+
+  it('passes src to link href and does not act on space', () => {
+    const src = '#src';
+    const fileName = 'file name';
+    const fileHandler = render(<FileHandler src={src}>{fileName}</FileHandler>);
+
+    fileHandler.getByText(fileName).focus();
+    userEvent.keyboard('{space}');
+
+    expect(fileHandler.getByRole('link').href).toContain(src);
+    expect(window.location.href).not.toContain(src);
+  });
+
+  it('should have status in accessibility tree', () => {
+    const fileHandler = render(<FileHandler loading />);
+
+    expect(fileHandler.getByText('loading')).toBeTruthy();
+  });
+});
+
+describe('FileHandler a11y', () => {
+  it('should have no a11y violations', async () => {
+    await testA11y(<FileHandler />);
+  });
+  it('should have no a11y violations when loading', async () => {
+    await testA11y(<FileHandler loading>loading</FileHandler>);
+  });
+
+  it('should have no a11y violations when thumbanailSrc and src are provided', async () => {
+    await testA11y(
+      <FileHandler thumbnailSrc="#" src="#">
+        fileName.jpg
+      </FileHandler>
+    );
+  });
+
+  it('should have no a11y violations when onClick is provided', async () => {
+    const handleOnClick = jest.fn();
+
+    await testA11y(
+      <FileHandler onClick={handleOnClick}>file name</FileHandler>
+    );
+  });
+});

--- a/src/components/file-handler/FileHandler.a11y.spec.jsx
+++ b/src/components/file-handler/FileHandler.a11y.spec.jsx
@@ -5,7 +5,7 @@ import {testA11y} from '../../axe';
 import userEvent from '@testing-library/user-event';
 
 describe('FileHandler', () => {
-  it('fires onClick on click, space and enter', () => {
+  it('has onClick, so it acts like a button: fires onClick on click, space and enter', () => {
     const handleOnClick = jest.fn();
     const fileName = 'file name';
     const fileHandler = render(
@@ -20,16 +20,12 @@ describe('FileHandler', () => {
     expect(handleOnClick).toHaveBeenCalledTimes(3);
   });
 
-  it('passes src to link href and does not act on space', () => {
+  it('has src, so it acts like a link: passes src to link href', () => {
     const src = '#src';
     const fileName = 'file name';
     const fileHandler = render(<FileHandler src={src}>{fileName}</FileHandler>);
 
-    fileHandler.getByText(fileName).focus();
-    userEvent.keyboard('{space}');
-
     expect(fileHandler.getByRole('link').href).toContain(src);
-    expect(window.location.href).not.toContain(src);
   });
 
   it('should have status in accessibility tree', () => {

--- a/src/components/file-handler/FileHandler.a11y.spec.jsx
+++ b/src/components/file-handler/FileHandler.a11y.spec.jsx
@@ -18,20 +18,28 @@ describe('FileHandler', () => {
     userEvent.keyboard('{enter}');
 
     expect(handleOnClick).toHaveBeenCalledTimes(3);
+    expect(fileHandler.getByRole('button')).toBeTruthy();
   });
 
   it('has src, so it acts like a link: passes src to link href', () => {
     const src = '#src';
     const fileName = 'file name';
-    const fileHandler = render(<FileHandler src={src}>{fileName}</FileHandler>);
+    const fileHandler = render(
+      <FileHandler src={src} thumbnailSrc={src}>
+        {fileName}
+      </FileHandler>
+    );
 
     expect(fileHandler.getByRole('link').href).toContain(src);
+    expect(fileHandler.queryByRole('img')).toBeFalsy();
   });
 
-  it('should have status in accessibility tree', () => {
+  it('should have a noticeable status in accessibility tree', () => {
     const fileHandler = render(<FileHandler loading />);
 
-    expect(fileHandler.getByText('loading')).toBeTruthy();
+    expect(fileHandler.getByText('loading').getAttribute('aria-live')).toEqual(
+      'polite'
+    );
   });
 });
 
@@ -56,6 +64,14 @@ describe('FileHandler a11y', () => {
 
     await testA11y(
       <FileHandler onClick={handleOnClick}>file name</FileHandler>
+    );
+  });
+
+  it('should have no a11y violations when onClose is provided', async () => {
+    const handleOnClose = jest.fn();
+
+    await testA11y(
+      <FileHandler onClose={handleOnClose}>file name</FileHandler>
     );
   });
 });

--- a/src/components/file-handler/FileHandler.jsx
+++ b/src/components/file-handler/FileHandler.jsx
@@ -135,40 +135,67 @@ const FileHandler = ({
     className
   );
 
-  const clickProps =
-    thumbnailSrc !== undefined && onClick
-      ? {onClick}
-      : {
-          href: src,
-          target: '_blank',
-          rel: 'noopener noreferrer',
-        };
+  const preventedOnClick =
+    onClick &&
+    (e => {
+      e.preventDefault();
+      return onClick();
+    });
 
-  const ThumbnailTag = clickProps.onClick ? 'button' : 'a';
+  const isActionProvided = src !== undefined || preventedOnClick;
 
-  const thumbnail = (
-    <ThumbnailTag {...clickProps} aria-hidden>
-      {thumbnailSrc !== undefined ? (
-        <img src={thumbnailSrc} alt="" className="cursor-pointer" />
-      ) : (
-        <Icon type={iconType} size={24} color={ICON_COLOR['icon-black']} />
-      )}
-    </ThumbnailTag>
+  const buttonEventProps = {
+    onClick: preventedOnClick,
+    onKeyDown: e => {
+      if (e.keyCode === 32 || e.keyCode === 13) {
+        return preventedOnClick && preventedOnClick(e);
+      }
+    },
+  };
+
+  const clickProps = preventedOnClick
+    ? buttonEventProps
+    : {
+        href: src,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      };
+
+  const role = clickProps.onClick && 'button';
+  const thumbnail =
+    thumbnailSrc !== undefined ? (
+      <img src={thumbnailSrc} alt="" className="cursor-pointer" />
+    ) : (
+      <Icon type={iconType} size={24} color={ICON_COLOR['icon-black']} />
+    );
+
+  const interactiveThumbnail = isActionProvided ? (
+    <a {...clickProps} role={role} tabIndex="0" aria-hidden>
+      {thumbnail}
+    </a>
+  ) : (
+    thumbnail
   );
 
   return (
     <div {...props} className={fileHandlerClass}>
       <div className="sg-file-handler__icon">
-        {loading ? <Spinner size="xsmall" /> : thumbnail}
+        {loading ? <Spinner size="xsmall" /> : interactiveThumbnail}
       </div>
       <span className="sg-file-handler__text" ref={textRef}>
         <span className="sg-visually-hidden" aria-live="polite">
-          {loading
+          {loading || isActionProvided
             ? statusLabel?.loading || 'loading'
             : statusLabel?.uploaded || 'uploaded'}
         </span>
-        {src !== undefined ? (
-          <Link {...clickProps} size="small" color="text-black">
+        {isActionProvided ? (
+          <Link
+            {...clickProps}
+            size="small"
+            color="text-black"
+            role={role}
+            tabIndex="0"
+          >
             {children}
           </Link>
         ) : (

--- a/src/components/file-handler/FileHandler.jsx
+++ b/src/components/file-handler/FileHandler.jsx
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 
 import Text from '../text/Text';
 import Link from '../text/Link';
-import Icon, {ICON_COLOR} from '../icons/Icon';
+import Icon from '../icons/Icon';
 import Spinner from '../spinner/Spinner';
 
 import type {IconTypeType} from '../icons/Icon';
@@ -22,10 +22,10 @@ export const FILE_HANDLER_COLORS_SET = {
   WHITE: 'white',
 };
 
-export interface AriaStatusLabelType {
-  loading?: string;
-  uploaded?: string;
-}
+type AriaStatusLabelType = {
+  loading?: string,
+  uploaded?: string,
+};
 
 export type FileHandlerPropsType = $ReadOnly<{
   /**
@@ -147,6 +147,7 @@ const FileHandler = ({
   const buttonEventProps = {
     onClick: preventedOnClick,
     onKeyDown: e => {
+      // 32 - space, 13 - enter
       if (e.keyCode === 32 || e.keyCode === 13) {
         return preventedOnClick && preventedOnClick(e);
       }
@@ -166,7 +167,7 @@ const FileHandler = ({
     thumbnailSrc !== undefined ? (
       <img src={thumbnailSrc} alt="" className="cursor-pointer" />
     ) : (
-      <Icon type={iconType} size={24} color={ICON_COLOR['icon-black']} />
+      <Icon type={iconType} size={24} color="icon-black" />
     );
 
   const interactiveThumbnail = isActionProvided ? (
@@ -210,7 +211,7 @@ const FileHandler = ({
           onClick={onClose}
           aria-label={ariaCloseButtonLabel}
         >
-          <Icon type="close" size={16} color={ICON_COLOR['icon-black']} />
+          <Icon type="close" size={16} color="icon-black" />
         </button>
       )}
     </div>

--- a/src/components/file-handler/FileHandler.jsx
+++ b/src/components/file-handler/FileHandler.jsx
@@ -22,6 +22,11 @@ export const FILE_HANDLER_COLORS_SET = {
   WHITE: 'white',
 };
 
+export interface AriaStatusLabelType {
+  loading?: string;
+  uploaded?: string;
+}
+
 export type FileHandlerPropsType = $ReadOnly<{
   /**
    * Specify color of the background for FileHandler
@@ -93,6 +98,16 @@ export type FileHandlerPropsType = $ReadOnly<{
    *          </FileHandler>
    */
   children: React.Node,
+  /**
+   * An accessible, short-text description of `onClose` action,
+   * defaults to 'Close'
+   */
+  ariaCloseButtonLabel?: string,
+  /**
+   * An accessible, short-text description for loading
+   * and uploded status.
+   */
+  statusLabel?: AriaStatusLabelType,
   ...
 }>;
 
@@ -107,6 +122,8 @@ const FileHandler = ({
   onClick,
   textRef,
   className,
+  ariaCloseButtonLabel = 'Close',
+  statusLabel,
   ...props
 }: FileHandlerPropsType) => {
   const fileHandlerClass = classNames(
@@ -127,19 +144,17 @@ const FileHandler = ({
           rel: 'noopener noreferrer',
         };
 
-  const thumbnail =
-    thumbnailSrc !== undefined ? (
-      <img
-        {...clickProps}
-        src={thumbnailSrc}
-        alt=""
-        className="cursor-pointer"
-      />
-    ) : (
-      <a {...clickProps}>
+  const ThumbnailTag = clickProps.onClick ? 'button' : 'a';
+
+  const thumbnail = (
+    <ThumbnailTag {...clickProps} aria-hidden>
+      {thumbnailSrc !== undefined ? (
+        <img src={thumbnailSrc} alt="" className="cursor-pointer" />
+      ) : (
         <Icon type={iconType} size={24} color={ICON_COLOR['icon-black']} />
-      </a>
-    );
+      )}
+    </ThumbnailTag>
+  );
 
   return (
     <div {...props} className={fileHandlerClass}>
@@ -147,6 +162,11 @@ const FileHandler = ({
         {loading ? <Spinner size="xsmall" /> : thumbnail}
       </div>
       <span className="sg-file-handler__text" ref={textRef}>
+        <span className="sg-visually-hidden" aria-live="polite">
+          {loading
+            ? statusLabel?.loading || 'loading'
+            : statusLabel?.uploaded || 'uploaded'}
+        </span>
         {src !== undefined ? (
           <Link {...clickProps} size="small" color="text-black">
             {children}
@@ -158,7 +178,11 @@ const FileHandler = ({
         )}
       </span>
       {onClose && (
-        <button className="sg-file-handler__close-button" onClick={onClose}>
+        <button
+          className="sg-file-handler__close-button"
+          onClick={onClose}
+          aria-label={ariaCloseButtonLabel}
+        >
           <Icon type="close" size={16} color={ICON_COLOR['icon-black']} />
         </button>
       )}

--- a/src/components/file-handler/FileHandler.spec.jsx
+++ b/src/components/file-handler/FileHandler.spec.jsx
@@ -71,15 +71,4 @@ describe('FileHandler', () => {
     expect(fileHandler.find(Spinner)).toHaveLength(1);
     expect(fileHandler.find(Icon)).toHaveLength(0);
   });
-
-  test('passes onClick when onClick and thumbnailSrc', () => {
-    const fileHandler = shallow(
-      <FileHandler onClick={mockCallback} thumbnailSrc="thumbnailSrc">
-        example text
-      </FileHandler>
-    );
-
-    expect(fileHandler.find('img').prop('onClick')).toBe(mockCallback);
-    expect(fileHandler.find(Icon)).toHaveLength(0);
-  });
 });

--- a/src/components/file-handler/FileHandler.stories.jsx
+++ b/src/components/file-handler/FileHandler.stories.jsx
@@ -30,7 +30,9 @@ export default {
   },
 };
 
-const src = 'https://source.unsplash.com/240x240/?cat';
+const src =
+  // eslint-disable-next-line max-len
+  'https://images.unsplash.com/photo-1558349699-1e1c38c05eeb?ixlib=rb-1.2.1&ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8&auto=format&fit=crop&w=240&q=80';
 
 export const Default = args => <FileHandler {...args} />;
 

--- a/src/components/file-handler/FileHandler.stories.jsx
+++ b/src/components/file-handler/FileHandler.stories.jsx
@@ -29,8 +29,12 @@ export default {
     children: 'text',
   },
 };
+const src =
+  'https://m.natemat.pl/2f2a60ad79764b5466234d249d17adc8,800,450,1,0.jpg';
 
-export const Default = args => <FileHandler {...args} />;
+export const Default = args => (
+  <FileHandler {...args} src={src} thumbnailSrc={src} />
+);
 
 export const Colors = args => (
   <div>

--- a/src/components/file-handler/FileHandler.stories.jsx
+++ b/src/components/file-handler/FileHandler.stories.jsx
@@ -29,12 +29,10 @@ export default {
     children: 'text',
   },
 };
-const src =
-  'https://m.natemat.pl/2f2a60ad79764b5466234d249d17adc8,800,450,1,0.jpg';
 
-export const Default = args => (
-  <FileHandler {...args} src={src} thumbnailSrc={src} />
-);
+const src = 'https://source.unsplash.com/240x240/?cat';
+
+export const Default = args => <FileHandler {...args} />;
 
 export const Colors = args => (
   <div>
@@ -60,6 +58,10 @@ export const Icons = args => (
       </StoryVariant>
     ))}
   </Flex>
+);
+
+export const WithThumbnail = args => (
+  <FileHandler {...args} thumbnailSrc={src} />
 );
 
 export const Loading = args => <FileHandler {...args} loading />;

--- a/src/components/file-handler/_file-handler.scss
+++ b/src/components/file-handler/_file-handler.scss
@@ -12,7 +12,11 @@
     display: flex;
     margin-right: spacing(xs);
 
-    > img {
+    & a {
+      display: flex;
+    }
+
+    & img {
       width: 24px;
       max-height: 24px;
       border-radius: 4px;

--- a/src/docs/navigation.js
+++ b/src/docs/navigation.js
@@ -55,6 +55,7 @@ import accordion from '../components/accordion/pages/accordion';
 import Shadows from '../components/shadows/pages/shadows';
 import ShadowsUtils from '../sass/pages/utils/shadows';
 import UXMotion from '../sass/pages/utils/uxmotion';
+import VisuallyHidden from '../sass/pages/utils/visually-hidden';
 
 const navigation = [
   {
@@ -312,6 +313,10 @@ const navigation = [
       {
         name: 'Shadows',
         component: ShadowsUtils,
+      },
+      {
+        name: 'Visually Hidden',
+        component: VisuallyHidden,
       },
     ],
   },

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -73,3 +73,15 @@
     box-shadow: $shadowLarge;
   }
 }
+
+.sg-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border-width: 0;
+}

--- a/src/sass/pages/utils/visually-hidden.jsx
+++ b/src/sass/pages/utils/visually-hidden.jsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import CodeBlock from 'components/CodeBlock';
+import DocsBlock from 'components/DocsBlock';
+import DocsActiveBlock from 'components/DocsActiveBlock';
+
+const hiddenSettings = [
+  {
+    name: 'className',
+    values: {
+      'sg-visually-hidden': 'sg-visually-hidden',
+    },
+  },
+];
+
+const VisuallyHidden = () => (
+  <div>
+    <DocsBlock info="Screen readers only">
+      Use to hide element visually but leave it accessible
+      <CodeBlock type="css">.sg-visually-hidden</CodeBlock>
+      <DocsActiveBlock topSpace settings={hiddenSettings}>
+        <div>I am visible</div>
+      </DocsActiveBlock>
+    </DocsBlock>
+  </div>
+);
+
+export default VisuallyHidden;


### PR DESCRIPTION
* proper role on interactive element, depending on provided props
* uploaded / loading status hidden visually with `aria-live="polite"`
* a11y tests
* label for close button
* thumbnail/icon hidden from accessibility tree
* link is tabbable, when has `role="button"` and `href` is not provided

[Internal docs](https://brainly.atlassian.net/wiki/spaces/DesignSystem/pages/951517464/FileHandler)