### PR TITLE
update url to storybook preview

### DIFF
--- a/buildspec-branches.yml
+++ b/buildspec-branches.yml
@@ -14,7 +14,7 @@ phases:
       - export GIT_BRANCH=$(echo $GIT_BRANCH | sed "s|branch/||" | sed "s|/|-|g" | sed "s|refs-heads-||")
 
 artifacts:
-  name: 'branches/$GIT_BRANCH'
+  name: 'branch/$GIT_BRANCH'
   files:
     - '**/*'
   base-directory: '.storybook-static'


### PR DESCRIPTION
Codebuild is limited when it comes to generating link on status check when publishing storybook preview.

It can generate path: `/branch/{branch_name}` so the easiest way to align it with path from s3 is to change deploy destination from `/branches/` to `/branch/`. 

ℹ️ We still need to wait for automation infra team though, to extend terraform configuration to be able to change this path on status check. This was only tested using AWS console. It can work for know till we apply terraform again.