### PR TITLE
Logo a11y improvements

### DIFF
--- a/src/components/logo/Logo.a11y.spec.jsx
+++ b/src/components/logo/Logo.a11y.spec.jsx
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import {render} from '@testing-library/react';
+import {testA11y} from '../../axe';
+import Logo from './Logo';
+
+describe('Logo', () => {
+  it('should have an alt', () => {
+    const logo = render(<Logo />);
+
+    expect(logo.getByAltText('brainly')).toBeTruthy();
+  });
+
+  it('should not have an alt', () => {
+    const logo = render(<Logo alt="" />);
+
+    expect(logo.queryByAltText('brainly')).toBeFalsy();
+  });
+});
+
+describe('Logo a11y', () => {
+  it('should have no a11y violations', async () => {
+    await testA11y(<Logo />);
+  });
+});

--- a/src/components/logo/Logo.jsx
+++ b/src/components/logo/Logo.jsx
@@ -82,6 +82,22 @@ export const TYPE: {
   BRAINLY_LOGOTYPE_TEXTBOOK_DETECTIVE: 'brainly-logotype-textbook-detective',
 };
 
+function getDefaultAlt(type: LogoTypeType) {
+  const replacers = [
+    {regexp: /-mobile/g, newSubstr: ''},
+    {regexp: /-inverse/g, newSubstr: ''},
+    {regexp: /-small/g, newSubstr: ''},
+    {regexp: /-logotype-/g, newSubstr: ' '},
+    {regexp: /logo-/g, newSubstr: ''},
+    {regexp: /-/g, newSubstr: ' '},
+  ];
+
+  return replacers.reduce(
+    (alt, {regexp, newSubstr}) => alt.replace(regexp, newSubstr),
+    type
+  );
+}
+
 export type LogoPropsType = {
   className?: string,
   type?: LogoTypeType,
@@ -104,9 +120,11 @@ const Logo = ({
   );
   const logoPath = `${getLogoUrl(type)}`;
 
+  const defaultAlt = getDefaultAlt(type);
+
   return (
     <div {...props} className={logoClass}>
-      <img className="sg-logo__image" src={logoPath} alt={alt} />
+      <img className="sg-logo__image" src={logoPath} alt={alt ?? defaultAlt} />
     </div>
   );
 };

--- a/src/components/logo/Logo.spec.jsx
+++ b/src/components/logo/Logo.spec.jsx
@@ -14,15 +14,3 @@ test('type', () => {
 
   expect(logo.hasClass('sg-logo--znanija')).toEqual(true);
 });
-
-test('alt', () => {
-  const logo = shallow(<Logo alt="test alt attr" />);
-
-  expect(logo.find('img').prop('alt')).toEqual('test alt attr');
-});
-
-test('alt undefined', () => {
-  const logo = shallow(<Logo />);
-
-  expect(logo.find('img').prop('alt')).toBeUndefined();
-});


### PR DESCRIPTION
`Logo` a11y improvements - logo has an alt text by default.

[Internal documentation](https://brainly.atlassian.net/wiki/spaces/DesignSystem/pages/968589401/Logo+a11y)