### PR TITLE
HomeButton a11y improvements

### DIFF
--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -23,7 +23,7 @@ export type AccordionItemPropsType = $ReadOnly<{
   padding?: PaddingType,
   tabIndex?: number,
   id?: string,
-  headingLevel?: number,
+  ariaHeadingLevel?: number,
 }>;
 
 function generateId() {
@@ -40,7 +40,7 @@ const AccordionItem = ({
   padding = 'm',
   tabIndex = 0,
   id: customId,
-  headingLevel = 2,
+  ariaHeadingLevel = 2,
 }: AccordionItemPropsType) => {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const {current: id} = useRef<string>(
@@ -172,7 +172,7 @@ const AccordionItem = ({
       )}
       padding={null}
     >
-      <div role="heading" aria-level={headingLevel} id={id}>
+      <div role="heading" aria-level={ariaHeadingLevel} id={id}>
         <Box
           padding={padding}
           className={cx('sg-accordion-item__button', {

--- a/src/components/dialog/Dialog.a11y.spec.jsx
+++ b/src/components/dialog/Dialog.a11y.spec.jsx
@@ -15,7 +15,7 @@ describe('Dialog a11y', () => {
     const onDismiss = jest.fn();
 
     await testA11y(
-      <Dialog open labelledBy={headerId}>
+      <Dialog open aria-labelledby={headerId}>
         <DialogCloseButton onClick={onDismiss} />
         <DialogHeader id={headerId}>Header</DialogHeader>
         <DialogBody>Information you provide to us directly.</DialogBody>
@@ -26,7 +26,7 @@ describe('Dialog a11y', () => {
   it('has "dialog" role and aria-modal', async () => {
     const label = 'Dialog label';
     const dialog = render(
-      <Dialog open label={label}>
+      <Dialog open aria-label={label}>
         content text
       </Dialog>
     );
@@ -39,7 +39,7 @@ describe('Dialog a11y', () => {
   it('is described by <DialogBody/> ', async () => {
     const descId = 'desc-id';
     const dialog = render(
-      <Dialog open describedBy={descId} label="Dialog label">
+      <Dialog open aria-describedby={descId} aria-label="Dialog label">
         <DialogBody id={descId}>
           Information you provide to us directly.
         </DialogBody>
@@ -56,7 +56,7 @@ describe('Dialog a11y', () => {
   it('moves focus to first tabbable element when opens', async () => {
     const buttonText = 'button';
     const dialog = render(
-      <Dialog open label="Dialog label">
+      <Dialog open aria-label="Dialog label">
         <button id="button">{buttonText}</button>
       </Dialog>
     );
@@ -66,7 +66,7 @@ describe('Dialog a11y', () => {
 
   it('has focus when it opens and there are no children', async () => {
     const dialog = render(
-      <Dialog open label="Dialog label">
+      <Dialog open aria-label="Dialog label">
         content text
       </Dialog>
     );

--- a/src/components/dialog/Dialog.jsx
+++ b/src/components/dialog/Dialog.jsx
@@ -13,9 +13,9 @@ export type DialogPropsType = $ReadOnly<{
   size?: 's' | 'm' | 'l' | 'xl',
   fullscreen?: boolean,
   reduceMotion?: boolean,
-  labelledBy?: string,
-  label?: string,
-  describedBy?: string,
+  'aria-labelledby'?: string,
+  'aria-label'?: string,
+  'aria-describedby'?: string,
   /**
    * Specify the dialog scrolling behavior when
    * the content is longer than the viewport.
@@ -54,9 +54,9 @@ function BaseDialog({
   fullscreen = false,
   reduceMotion = false,
   scroll = 'outside',
-  labelledBy,
-  label,
-  describedBy,
+  'aria-labelledby': ariaLabelledBy,
+  'aria-label': ariaLabel,
+  'aria-describedby': ariaDescribedBy,
   zIndex = 'auto',
   onDismiss,
   onEntryTransitionEnd,
@@ -152,9 +152,9 @@ function BaseDialog({
         className={containerClass}
         onTransitionEnd={handleTransitionEnd}
         aria-modal="true"
-        aria-labelledby={labelledBy}
-        aria-label={label}
-        aria-describedby={describedBy}
+        aria-labelledby={ariaLabelledBy}
+        aria-label={ariaLabel}
+        aria-describedby={ariaDescribedBy}
         tabIndex="-1"
       >
         {children}

--- a/src/components/home-button/HomeButton.a11y.spec.jsx
+++ b/src/components/home-button/HomeButton.a11y.spec.jsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import {render} from '@testing-library/react';
+import {testA11y} from '../../axe';
+import HomeButton from './HomeButton';
+
+describe('HomeButton', () => {
+  it('should have a label', () => {
+    const logo = render(<HomeButton />);
+
+    expect(logo.getByLabelText('brainly home')).toBeTruthy();
+  });
+});
+
+describe('HomeButton a11y', () => {
+  it('should have no a11y violations', async () => {
+    await testA11y(<HomeButton />);
+  });
+});

--- a/src/components/home-button/HomeButton.jsx
+++ b/src/components/home-button/HomeButton.jsx
@@ -18,7 +18,8 @@ export type HomeButtonPropsType = {
   type?: LogoTypeType,
   href?: string,
   className?: string,
-  altTag?: string,
+  alt?: string,
+  'aria-label'?: string,
   ...
 };
 
@@ -26,7 +27,8 @@ const HomeButton = ({
   type = TYPE.BRAINLY,
   href = '#',
   className,
-  altTag,
+  alt,
+  'aria-label': ariaLabel,
   ...props
 }: HomeButtonPropsType) => {
   const buttonClass = classnames(
@@ -40,14 +42,17 @@ const HomeButton = ({
   // $FlowFixMe - some icons are missing, we will investigate why
   const mobilePath = `${getLogoUrl(ICONS[type])}`;
 
+  const defaultAriaLabel = `${type.replace(/-/g, ' ')} home`;
+
   return (
-    <a {...props} href={href} className={buttonClass}>
-      <img
-        className="sg-home-button__logo-small"
-        src={mobilePath}
-        alt={altTag}
-      />
-      <img className="sg-home-button__logo-big" src={logoPath} alt={altTag} />
+    <a
+      {...props}
+      href={href}
+      className={buttonClass}
+      aria-label={ariaLabel || defaultAriaLabel}
+    >
+      <img className="sg-home-button__logo-small" src={mobilePath} alt={alt} />
+      <img className="sg-home-button__logo-big" src={logoPath} alt={alt} />
     </a>
   );
 };

--- a/src/components/home-button/HomeButton.jsx
+++ b/src/components/home-button/HomeButton.jsx
@@ -27,7 +27,7 @@ const HomeButton = ({
   type = TYPE.BRAINLY,
   href = '#',
   className,
-  alt,
+  alt = '',
   'aria-label': ariaLabel,
   ...props
 }: HomeButtonPropsType) => {


### PR DESCRIPTION
`HomeButton` a11y improvements: `aria-label` added for a link (defaults to type).
aria-* props renamed to use aria naming convention


[Internal documentation](https://brainly.atlassian.net/wiki/spaces/DesignSystem/pages/968098491/HomeButton+a11y)
