### PR TITLE
Counter - Prevent from shrinking

### DIFF
--- a/src/components/counters/_counters.scss
+++ b/src/components/counters/_counters.scss
@@ -12,6 +12,7 @@ $counterSizeXS: componentSize(xs);
     display: inline-flex;
     justify-content: center;
     align-content: center;
+    flex-shrink: 0;
     background-color: $red-50;
     cursor: default;
 


### PR DESCRIPTION
it prevents `Counter` component from shrinking

example from the website (where the counter is shrunken):

<img width="374" alt="Screenshot 2022-01-13 at 12 58 23" src="https://user-images.githubusercontent.com/1231144/149326964-813c76f4-05cd-4b37-b1a6-f9eab86a7f35.png">

(too long button copy is another issue)

after fixing it:

<img width="394" alt="Screenshot 2022-01-13 at 13 07 58" src="https://user-images.githubusercontent.com/1231144/149327668-d8361b88-e454-4866-b1e6-71a21a953ae2.png">

no visually change for default usage of `Counter`:
<img width="559" alt="Screenshot 2022-01-13 at 13 02 04" src="https://user-images.githubusercontent.com/1231144/149327373-06f76c74-50ef-48a9-9b61-51d27aafec48.png">


