### PR TITLE
Dialog - Fix for nested dialogs

### DIFF
--- a/src/components/dialog/Dialog.jsx
+++ b/src/components/dialog/Dialog.jsx
@@ -118,6 +118,7 @@ function BaseDialog({
     event => {
       if (onDismiss && event.key === 'Escape') {
         onDismiss();
+        event.stopPropagation();
       }
     },
     [onDismiss]


### PR DESCRIPTION
it's a follow up to [the fullscreen related changes of Dialog component](https://github.com/brainly/style-guide/pull/2277)

**case:**

two dialogs are rendered on the page and one is nested in another

**issue:**
when `Escape` key was pressed both dialogs were being closed

**after fix:**
when `Escape` key is pressed, only the most nested Dialog is being closed
