### PR TITLE
Fix text related mixins

### DIFF
--- a/src/components/text/_headlines.scss
+++ b/src/components/text/_headlines.scss
@@ -1,10 +1,10 @@
 @import './text-colors-mixin';
 
 $includeHtml: false !default;
-$sizes: (xxsmall xsmall small medium large xlarge xxlarge xxxlarge);
-$transforms: (uppercase lowercase capitalize);
+$headlineSizes: (xxsmall xsmall small medium large xlarge xxlarge xxxlarge);
+$headlineTransforms: (uppercase lowercase capitalize);
 
-$sizeRules: (
+$headlineSizeRules: (
   xxxlarge: (
     fontSize: 78px,
     lineHeight: 88px,
@@ -47,8 +47,8 @@ $sizeRules: (
 }
 
 @mixin headlineTypeSizeVariant($size) {
-  font-size: getHeadLineSizeFromMap($sizeRules, $size, 'fontSize');
-  line-height: getHeadLineSizeFromMap($sizeRules, $size, 'lineHeight');
+  font-size: getHeadLineSizeFromMap($headlineSizeRules, $size, 'fontSize');
+  line-height: getHeadLineSizeFromMap($headlineSizeRules, $size, 'lineHeight');
 }
 
 @if ($includeHtml) {
@@ -72,13 +72,13 @@ $sizeRules: (
 
   @each $breakpoint, $variant in $responsiveVariants {
     @include sgResponsive($breakpoint) {
-      @each $size in $sizes {
+      @each $size in $headlineSizes {
         @include makeResponsive($variant, 'sg-headline--#{$size}') {
           @include headlineTypeSizeVariant($size);
         }
       }
 
-      @each $transform in $transforms {
+      @each $transform in $headlineTransforms {
         @include makeResponsive($variant, 'sg-headline--#{$transform}') {
           text-transform: $transform;
         }

--- a/src/components/text/_subheadlines.scss
+++ b/src/components/text/_subheadlines.scss
@@ -1,10 +1,10 @@
 @import './text-colors-mixin';
 
 $includeHtml: false !default;
-$sizes: (xsmall small medium large xlarge xxlarge xxxlarge);
-$transforms: (uppercase lowercase capitalize);
+$subheadlineSizes: (xsmall small medium large xlarge xxlarge xxxlarge);
+$subheadlineTransforms: (uppercase lowercase capitalize);
 
-$sizeRules: (
+$subheadlineSizeRules: (
   xxxlarge: (
     fontSize: 78px,
     lineHeight: 88px,
@@ -43,8 +43,16 @@ $sizeRules: (
 }
 
 @mixin subheadlineTypeSizeVariant($size) {
-  font-size: getSubheadlineSizeFromMap($sizeRules, $size, 'fontSize');
-  line-height: getSubheadlineSizeFromMap($sizeRules, $size, 'lineHeight');
+  font-size: getSubheadlineSizeFromMap(
+    $subheadlineSizeRules,
+    $size,
+    'fontSize'
+  );
+  line-height: getSubheadlineSizeFromMap(
+    $subheadlineSizeRules,
+    $size,
+    'lineHeight'
+  );
 }
 
 @if ($includeHtml) {
@@ -69,13 +77,13 @@ $sizeRules: (
 
   @each $breakpoint, $variant in $responsiveVariants {
     @include sgResponsive($breakpoint) {
-      @each $size in $sizes {
+      @each $size in $subheadlineSizes {
         @include makeResponsive($variant, 'sg-subheadline--#{$size}') {
           @include subheadlineTypeSizeVariant($size);
         }
       }
 
-      @each $transform in $transforms {
+      @each $transform in $subheadlineTransforms {
         @include makeResponsive($variant, 'sg-subheadline--#{$transform}') {
           text-transform: $transform;
         }

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -1,10 +1,10 @@
 @import './text-colors-mixin';
 
 $includeHtml: false !default;
-$sizes: (xxsmall xsmall small medium large xlarge xxlarge xxxlarge);
-$transforms: (uppercase lowercase capitalize);
+$bodyTextSizes: (xxsmall xsmall small medium large xlarge xxlarge xxxlarge);
+$bodyTextTransforms: (uppercase lowercase capitalize);
 
-$sizeRules: (
+$bodyTextSizeRules: (
   xxxlarge: (
     fontSize: 66px,
     lineHeight: 88px,
@@ -47,8 +47,8 @@ $sizeRules: (
 }
 
 @mixin bodyTextTypeSizeVariant($size) {
-  font-size: getBodyTextSizeFromMap($sizeRules, $size, 'fontSize');
-  line-height: getBodyTextSizeFromMap($sizeRules, $size, 'lineHeight');
+  font-size: getBodyTextSizeFromMap($bodyTextSizeRules, $size, 'fontSize');
+  line-height: getBodyTextSizeFromMap($bodyTextSizeRules, $size, 'lineHeight');
 }
 
 @if ($includeHtml) {
@@ -111,7 +111,7 @@ $sizeRules: (
 
   @each $breakpoint, $variant in $responsiveVariants {
     @include sgResponsive($breakpoint) {
-      @each $size in $sizes {
+      @each $size in $bodyTextSizes {
         @include makeResponsive($variant, 'sg-text--#{$size}') {
           @include bodyTextTypeSizeVariant($size);
         }
@@ -125,7 +125,7 @@ $sizeRules: (
         font-weight: $fontWeightNormal;
       }
 
-      @each $transform in $transforms {
+      @each $transform in $bodyTextTransforms {
         @include makeResponsive($variant, 'sg-text--#{transform}') {
           text-transform: $transform;
         }


### PR DESCRIPTION
**Note**:

This changes do not affect style-guide itself from visual perspective and are related only to the specific case: importing exposed mixins to style custom elements.

It's partially related to the reported production bug: https://brainly.atlassian.net/browse/PBUGS-1444

**Case:**

when more than 1 text-related mixin was directly imported in a project:
```
@import '~brainly-style-guide/src/components/text/text';
@import '~brainly-style-guide/src/components/text/headlines';
```
due to usage of the same variable names, they were overriding each other and the values were taken from the one that was imported later.

as a result some body texts received the sizes of headlines:

## before

<img width="663" alt="Screenshot 2022-02-08 at 07 51 50" src="https://user-images.githubusercontent.com/1231144/152933766-2c7daa18-67be-4c07-b1e4-45680b31ea8d.png">
<img width="703" alt="Screenshot 2022-02-08 at 07 51 57" src="https://user-images.githubusercontent.com/1231144/152933773-fda931a1-d050-4f76-8569-f28d2f2d8fdc.png">


## after

<img width="697" alt="Screenshot 2022-02-08 at 07 38 55" src="https://user-images.githubusercontent.com/1231144/152933610-5a05a1ec-7a43-4a13-bdc7-096a1dd29bc8.png">
<img width="725" alt="Screenshot 2022-02-08 at 07 38 59" src="https://user-images.githubusercontent.com/1231144/152933617-d99face8-6721-4cf3-8843-3074fb668e8c.png">