### PR TITLE
Dialog - Fix Unimplemented TransitionEnd Event

### DIFF
--- a/src/components/dialog/Dialog.jsx
+++ b/src/components/dialog/Dialog.jsx
@@ -6,6 +6,9 @@ import cx from 'classnames';
 import {useBodyNoScroll} from './useBodyNoScroll';
 import {useFocusTrap} from './useFocusTrap';
 
+// https://github.com/jsdom/jsdom/issues/1781
+const supportsTransitions = window.TransitionEvent !== undefined;
+
 export type DialogPropsType = $ReadOnly<{
   open: boolean,
   children: React.Node,
@@ -78,12 +81,41 @@ function BaseDialog({
    */
   const [deferredOpen, setDeferredOpen] = React.useState<boolean>(false);
 
+  const fireTransitionEndCallbacks = React.useCallback(() => {
+    if (open) {
+      if (onEntryTransitionEnd) {
+        onEntryTransitionEnd();
+      }
+    } else if (onExitTransitionEnd) {
+      onExitTransitionEnd();
+    }
+  }, [open, onEntryTransitionEnd, onExitTransitionEnd]);
+
   React.useEffect(() => {
     setDeferredOpen(open);
-  }, [open]);
+
+    if (!supportsTransitions) {
+      fireTransitionEndCallbacks();
+    }
+  }, [open, fireTransitionEndCallbacks]);
 
   useBodyNoScroll();
-  useFocusTrap({dialogRef: containerRef, overlayRef});
+  useFocusTrap({
+    dialogRef: containerRef,
+    overlayRef,
+  });
+
+  const handleTransitionEnd = React.useCallback(
+    (event: TransitionEvent) => {
+      if (
+        event.target === event.currentTarget &&
+        event.propertyName === lastTransitionName
+      ) {
+        fireTransitionEndCallbacks();
+      }
+    },
+    [fireTransitionEndCallbacks, lastTransitionName]
+  );
 
   const handleOverlayClick = React.useCallback(
     (event: SyntheticMouseEvent<HTMLDivElement>) => {
@@ -94,28 +126,8 @@ function BaseDialog({
     [onDismiss]
   );
 
-  const handleTransitionEnd = React.useCallback(
-    (event: TransitionEvent) => {
-      if (
-        event.target !== event.currentTarget ||
-        event.propertyName !== lastTransitionName
-      ) {
-        return;
-      }
-
-      if (open) {
-        if (onEntryTransitionEnd) {
-          onEntryTransitionEnd();
-        }
-      } else if (onExitTransitionEnd) {
-        onExitTransitionEnd();
-      }
-    },
-    [open, lastTransitionName, onEntryTransitionEnd, onExitTransitionEnd]
-  );
-
   const handleKeyUp = React.useCallback(
-    event => {
+    (event: SyntheticKeyboardEvent<HTMLDivElement>) => {
       if (onDismiss && event.key === 'Escape') {
         onDismiss();
         event.stopPropagation();
@@ -158,7 +170,7 @@ function BaseDialog({
         role="dialog"
         ref={containerRef}
         className={containerClass}
-        onTransitionEnd={handleTransitionEnd}
+        onTransitionEnd={supportsTransitions ? handleTransitionEnd : undefined}
         aria-modal="true"
         aria-labelledby={ariaLabelledBy}
         aria-label={ariaLabel}

--- a/src/components/dialog/Dialog.spec.jsx
+++ b/src/components/dialog/Dialog.spec.jsx
@@ -43,7 +43,6 @@ describe('<Dialog>', () => {
 
   it('fires onDismiss callback on Escape key', () => {
     const onDismiss = jest.fn();
-
     const wrapper = mount(
       <Dialog onDismiss={onDismiss} open>
         content text
@@ -68,15 +67,12 @@ describe('<Dialog>', () => {
 
   it('fires onEntryTransitionEnd callback on entry', () => {
     const onEntryTransitionEnd = jest.fn();
-    const wrapper = mount(
+
+    mount(
       <Dialog onEntryTransitionEnd={onEntryTransitionEnd} open>
         content text
       </Dialog>
     );
-
-    wrapper.find('[role="dialog"]').simulate('transitionEnd', {
-      propertyName: 'transform',
-    });
 
     expect(onEntryTransitionEnd).toHaveBeenCalledTimes(1);
   });
@@ -90,10 +86,6 @@ describe('<Dialog>', () => {
     );
 
     wrapper.setProps({open: false});
-    wrapper.find('[role="dialog"]').simulate('transitionEnd', {
-      propertyName: 'opacity',
-    });
-
     expect(onExitTransitionEnd).toHaveBeenCalledTimes(1);
   });
 
@@ -103,9 +95,7 @@ describe('<Dialog>', () => {
     expect(wrapper.isEmptyRender()).toBe(false);
 
     wrapper.setProps({open: false});
-    wrapper.find('[role="dialog"]').simulate('transitionEnd', {
-      propertyName: 'opacity',
-    });
+    wrapper.update();
 
     expect(wrapper.isEmptyRender()).toBe(true);
   });

--- a/src/components/dialog/Dialog.spec.jsx
+++ b/src/components/dialog/Dialog.spec.jsx
@@ -89,6 +89,30 @@ describe('<Dialog>', () => {
     expect(onExitTransitionEnd).toHaveBeenCalledTimes(1);
   });
 
+  it('does not fire onEntryTransitionEnd callback before mount', () => {
+    const onEntryTransitionEnd = jest.fn();
+
+    mount(
+      <Dialog onEntryTransitionEnd={onEntryTransitionEnd} open={false}>
+        content text
+      </Dialog>
+    );
+
+    expect(onEntryTransitionEnd).toHaveBeenCalledTimes(0);
+  });
+
+  it('does not fire onExitTransitionEnd callback before mount', () => {
+    const onExitTransitionEnd = jest.fn();
+
+    mount(
+      <Dialog onExitTransitionEnd={onExitTransitionEnd} open={false}>
+        content text
+      </Dialog>
+    );
+
+    expect(onExitTransitionEnd).toHaveBeenCalledTimes(0);
+  });
+
   it('returns null after exit transition', () => {
     const wrapper = mount(<Dialog open>content text</Dialog>);
 

--- a/src/components/dialog/Dialog.spec.jsx
+++ b/src/components/dialog/Dialog.spec.jsx
@@ -89,7 +89,7 @@ describe('<Dialog>', () => {
     expect(onExitTransitionEnd).toHaveBeenCalledTimes(1);
   });
 
-  it('does not fire onEntryTransitionEnd callback before mount', () => {
+  it('does not fire onEntryTransitionEnd callback before open', () => {
     const onEntryTransitionEnd = jest.fn();
 
     mount(
@@ -101,7 +101,7 @@ describe('<Dialog>', () => {
     expect(onEntryTransitionEnd).toHaveBeenCalledTimes(0);
   });
 
-  it('does not fire onExitTransitionEnd callback before mount', () => {
+  it('does not fire onExitTransitionEnd callback before open', () => {
     const onExitTransitionEnd = jest.fn();
 
     mount(


### PR DESCRIPTION
Currently both `onEntryTransitionEnd` and `onExitTransitionEnd` callbacks aren't fired when environment doesn't support transition events, e.g. the JSDOM. It requires additional mocking in every test which is not obvious. Furthermore, it doesn't work in older browsers (minor).

- https://github.com/jsdom/jsdom/issues/1781
- https://github.com/testing-library/dom-testing-library/pull/865