### PR TITLE
Link a11y improvements

### DIFF
--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -4,6 +4,7 @@
 import * as React from 'react';
 // eslint-disable-next-line import/no-duplicates
 import {useContext, useEffect, useRef, useState} from 'react';
+import {generateId} from '../utils';
 
 import cx from 'classnames';
 import Box from '../box/Box';
@@ -25,10 +26,6 @@ export type AccordionItemPropsType = $ReadOnly<{
   id?: string,
   ariaHeadingLevel?: number,
 }>;
-
-function generateId() {
-  return Math.random().toString(36).substring(7);
-}
 
 const AccordionItem = ({
   title,

--- a/src/components/accordion/AccordionItem.jsx
+++ b/src/components/accordion/AccordionItem.jsx
@@ -194,6 +194,7 @@ const AccordionItem = ({
                 color="text-black"
                 weight="bold"
                 underlined={isHighlighted}
+                disabled
               >
                 {title}
               </Link>

--- a/src/components/accordion/_accordion.scss
+++ b/src/components/accordion/_accordion.scss
@@ -26,6 +26,11 @@
           outline: none;
         }
       }
+
+      &:hover,
+      &:active {
+        text-decoration: underline;
+      }
     }
 
     &__title {

--- a/src/components/bubble/pages/bubble-interactive.jsx
+++ b/src/components/bubble/pages/bubble-interactive.jsx
@@ -60,10 +60,10 @@ const Bubbles = () => {
                 <ActionListHole>
                   <Breadcrumb
                     elements={[
-                      <Link key={1} color="text-gray-70">
+                      <Link key={1} href="#" color="text-gray-70">
                         Katie
                       </Link>,
-                      <Link key={2} color="text-gray-70">
+                      <Link key={2} href="#" color="text-gray-70">
                         a few seconds ago
                       </Link>,
                     ]}

--- a/src/components/content-box/pages/content-box.jsx
+++ b/src/components/content-box/pages/content-box.jsx
@@ -33,7 +33,7 @@ const link3 = (
 );
 const breadcrumbs = [link1, link2, link3];
 const breadcrumbsSpaced = [
-  <Link key={1} color="text-gray-70">
+  <Link key={1} href="#" color="text-gray-70">
     Katie
   </Link>,
   <Link key={2} href="#" color="text-gray-70">
@@ -41,7 +41,9 @@ const breadcrumbsSpaced = [
   </Link>,
 ];
 const breadcrumbsSpaced2 = [
-  <Link key={1}>Comments (9)</Link>,
+  <Link key={1} as="button">
+    Comments (9)
+  </Link>,
   <Link key={2} href="#">
     Report
   </Link>,

--- a/src/components/file-handler/FileHandler.a11y.spec.jsx
+++ b/src/components/file-handler/FileHandler.a11y.spec.jsx
@@ -12,9 +12,11 @@ describe('FileHandler', () => {
       <FileHandler onClick={handleOnClick}>{fileName}</FileHandler>
     );
 
-    userEvent.click(fileHandler.getByText(fileName));
+    userEvent.click(fileHandler.getByRole('button', {name: fileName}));
+    expect(handleOnClick).toHaveBeenCalledTimes(1);
     fileHandler.getByText(fileName).focus();
     userEvent.keyboard('{space}');
+    expect(handleOnClick).toHaveBeenCalledTimes(2);
     userEvent.keyboard('{enter}');
 
     expect(handleOnClick).toHaveBeenCalledTimes(3);

--- a/src/components/file-handler/FileHandler.jsx
+++ b/src/components/file-handler/FileHandler.jsx
@@ -77,7 +77,7 @@ export type FileHandlerPropsType = $ReadOnly<{
    *            text
    *          </FileHandler>
    */
-  onClick?: () => mixed,
+  onClick?: (e: KeyboardEvent | MouseEvent) => mixed,
   /**
    * Additional function to set ref for text
    */
@@ -130,12 +130,13 @@ const FileHandler = ({
     className
   );
 
-  const preventedOnClick =
-    onClick &&
-    (e => {
-      e.preventDefault();
-      return onClick();
-    });
+  const preventedOnClick = (e: KeyboardEvent | MouseEvent) => {
+    if (!onClick) {
+      return;
+    }
+    e.preventDefault();
+    return onClick(e);
+  };
 
   const isActionProvided = src !== undefined || preventedOnClick;
 

--- a/src/components/file-handler/FileHandler.jsx
+++ b/src/components/file-handler/FileHandler.jsx
@@ -130,28 +130,10 @@ const FileHandler = ({
     className
   );
 
-  const preventedOnClick = (e: KeyboardEvent | MouseEvent) => {
-    if (!onClick) {
-      return;
-    }
-    e.preventDefault();
-    return onClick(e);
-  };
+  const isActionProvided = src !== undefined || onClick;
 
-  const isActionProvided = src !== undefined || preventedOnClick;
-
-  const buttonEventProps = {
-    onClick: preventedOnClick,
-    onKeyDown: e => {
-      // 32 - space, 13 - enter
-      if (e.keyCode === 32 || e.keyCode === 13) {
-        return preventedOnClick && preventedOnClick(e);
-      }
-    },
-  };
-
-  const clickProps = preventedOnClick
-    ? buttonEventProps
+  const clickProps = onClick
+    ? {onClick}
     : {
         href: src,
         target: '_blank',
@@ -159,6 +141,8 @@ const FileHandler = ({
       };
 
   const role = clickProps.onClick && 'button';
+  const asLink = clickProps.onClick ? 'button' : 'a';
+
   const thumbnail =
     thumbnailSrc !== undefined ? (
       <img src={thumbnailSrc} alt="" className="cursor-pointer" />
@@ -186,13 +170,7 @@ const FileHandler = ({
             : statusLabel?.uploaded || 'uploaded'}
         </span>
         {isActionProvided ? (
-          <Link
-            {...clickProps}
-            size="small"
-            color="text-black"
-            role={role}
-            tabIndex="0"
-          >
+          <Link {...clickProps} size="small" color="text-black" as={asLink}>
             {children}
           </Link>
         ) : (

--- a/src/components/footer/pages/footer-interactive.jsx
+++ b/src/components/footer/pages/footer-interactive.jsx
@@ -48,16 +48,28 @@ const Footers = () => {
                 adaptive
                 elements={[
                   <Text key={1} type={TEXT_TYPE.SPAN} size={TEXT_SIZE.SMALL}>
-                    United States: <Link target="_blank">brainly.com</Link>
+                    United States:{' '}
+                    <Link href="#" target="_blank">
+                      brainly.com
+                    </Link>
                   </Text>,
                   <Text key={2} type={TEXT_TYPE.SPAN} size={TEXT_SIZE.SMALL}>
-                    Poland: <Link target="_blank">brainly.pl</Link>
+                    Poland:{' '}
+                    <Link href="#" target="_blank">
+                      brainly.pl
+                    </Link>
                   </Text>,
                   <Text key={3} type={TEXT_TYPE.SPAN} size={TEXT_SIZE.SMALL}>
-                    Russia/Ukraine: <Link target="_blank">znanija.com</Link>
+                    Russia/Ukraine:{' '}
+                    <Link href="#" target="_blank">
+                      znanija.com
+                    </Link>
                   </Text>,
                   <Text key={4} type={TEXT_TYPE.SPAN} size={TEXT_SIZE.SMALL}>
-                    Latam: <Link target="_blank">brainly.lat</Link>
+                    Latam:{' '}
+                    <Link href="#" target="_blank">
+                      brainly.lat
+                    </Link>
                   </Text>,
                 ]}
               />
@@ -71,7 +83,7 @@ const Footers = () => {
               weight={TEXT_WEIGHT.BOLD}
             >
               Strona korzysta z plików cookie w celu realizacji usług zgodnie z{' '}
-              <Link>polityką cookie</Link>. Możesz określić warunki
+              <Link href="#">polityką cookie</Link>. Możesz określić warunki
               przechowywania lub dostępu do cookie w Twojej przeglądarce.
             </Text>
           </FooterLine>

--- a/src/components/footer/pages/footer.jsx
+++ b/src/components/footer/pages/footer.jsx
@@ -45,16 +45,28 @@ const Footers = () => (
               adaptive
               elements={[
                 <Text key={1} type={TEXT_TYPE.SPAN} size={TEXT_SIZE.SMALL}>
-                  United States: <Link target="_blank">brainly.com</Link>
+                  United States:{' '}
+                  <Link href="#" target="_blank">
+                    brainly.com
+                  </Link>
                 </Text>,
                 <Text key={2} type={TEXT_TYPE.SPAN} size={TEXT_SIZE.SMALL}>
-                  Poland: <Link target="_blank">brainly.pl</Link>
+                  Poland:{' '}
+                  <Link href="#" target="_blank">
+                    brainly.pl
+                  </Link>
                 </Text>,
                 <Text key={3} type={TEXT_TYPE.SPAN} size={TEXT_SIZE.SMALL}>
-                  Russia/Ukraine: <Link target="_blank">znanija.com</Link>
+                  Russia/Ukraine:{' '}
+                  <Link href="#" target="_blank">
+                    znanija.com
+                  </Link>
                 </Text>,
                 <Text key={4} type={TEXT_TYPE.SPAN} size={TEXT_SIZE.SMALL}>
-                  Latam: <Link target="_blank">brainly.lat</Link>
+                  Latam:{' '}
+                  <Link href="#" target="_blank">
+                    brainly.lat
+                  </Link>
                 </Text>,
               ]}
             />
@@ -68,8 +80,8 @@ const Footers = () => (
             weight={TEXT_WEIGHT.BOLD}
           >
             Strona korzysta z plików cookie w celu realizacji usług zgodnie z{' '}
-            <Link>polityką cookie</Link>. Możesz określić warunki przechowywania
-            lub dostępu do cookie w Twojej przeglądarce.
+            <Link href="#">polityką cookie</Link>. Możesz określić warunki
+            przechowywania lub dostępu do cookie w Twojej przeglądarce.
           </Text>
         </FooterLine>
       </Footer>

--- a/src/components/form-elements/pages/formElements.jsx
+++ b/src/components/form-elements/pages/formElements.jsx
@@ -28,7 +28,10 @@ const formElements = () => (
             </Flex>
             <Flex marginBottom="m">
               <Text size="small">
-                Already have an account? <Link size="small">Log in here</Link>
+                Already have an account?{' '}
+                <Link href="#" size="small">
+                  Log in here
+                </Link>
               </Text>
             </Flex>
 
@@ -115,7 +118,10 @@ const formElements = () => (
           </Flex>
           <Flex marginBottom="m">
             <Text size="small">
-              Already have an account? <Link size="small">Log in here</Link>
+              Already have an account?{' '}
+              <Link href="#" size="small">
+                Log in here
+              </Link>
             </Text>
           </Flex>
 

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
+import {generateId} from '../utils';
 
 export type IconTypeType =
   | 'academic_cap'
@@ -552,9 +553,7 @@ export type IconPropsType =
     };
 
 function generateIdSuffix(type: string) {
-  const randomIndex = Math.random().toString(36).substring(7);
-
-  return `${type}-${randomIndex}`;
+  return `${type}-${generateId()}`;
 }
 
 const Icon = ({

--- a/src/components/media/pages/media-interactive.jsx
+++ b/src/components/media/pages/media-interactive.jsx
@@ -7,7 +7,7 @@ import Link from 'text/Link';
 const MediaExamples = () => {
   const defaultProps = {
     contentArray: [
-      <Link key={1} color="text-gray-70">
+      <Link href="#" key={1} color="text-gray-70">
         The Goat
       </Link>,
       <span key={2}>Master </span>,

--- a/src/components/media/pages/media.jsx
+++ b/src/components/media/pages/media.jsx
@@ -7,7 +7,7 @@ import Link from 'text/Link';
 
 const defaultProps = {
   contentArray: [
-    <Link key={1} color="text-gray-70">
+    <Link href="#" key={1} color="text-gray-70">
       The Goat
     </Link>,
     <span key={2}>Master </span>,

--- a/src/components/rating/Rating.spec.jsx
+++ b/src/components/rating/Rating.spec.jsx
@@ -59,7 +59,7 @@ describe('rating', () => {
     console.error = jest.fn();
 
     const rate = 3;
-    const rating = mount(<Rating rate={rate} active />);
+    const rating = mount(<Rating rate={rate} />);
     const stars = rating.find(Star);
 
     stars.at(0).simulate('click');

--- a/src/components/separators/pages/separators.jsx
+++ b/src/components/separators/pages/separators.jsx
@@ -58,9 +58,9 @@ const Separators = () => (
     ))}
 
     <DocsBlock info="Small" centered>
-      <Link>previous</Link>
+      <Link href="#">previous</Link>
       <SeparatorVertical size={SIZE.SMALL} />
-      <Link>next</Link>
+      <Link href="#">next</Link>
     </DocsBlock>
     <DocsBlock info="Large" centered>
       <div>

--- a/src/components/text/Link.a11y.md
+++ b/src/components/text/Link.a11y.md
@@ -4,44 +4,39 @@
 
 ## Link `as="a"`
 
-| Pattern                         | Comment | Status                                  |
-| ------------------------------- | ------- | --------------------------------------- |
-| **Should** have an accessible name | Name should be meaningful (ex. “Read more about vitamin C“ instead of “Read more“). `aria-label` can be used to provide a name. | Implementation: DONE<br />Tests: TO DO |
-| **Should** have a role `link` | | Implementation: DONE<br />Tests: TO DO |
-| **Should** cause the user agent to navigate to a new resource | | Implementation: DONE<br />Tests: TO DO |
-| **Should** be focusable and tabable | `href` can’t be empty. | Implementation: DONE<br />Tests: TO DO |
-| **Should** have visible focus style | Browser focus style is used | Implementation: DONE<br />Tests: TO DO |
-| **Should** have a non-color indicator | Ex. underline, bold (italic is not accessible). Default `Link` weight is `bold`. `underlined`, `emphasised` or `weight` props can also be provided.| Implementation: DONE<br />Tests: TO DO |
-| **Should** have a color indicator with 4.5:1 contrast ratio to the background | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement| Implementation: DONE<br />Tests: TO DO |
-| **Should** have a color indicator with 3:1 contrast ratio to the surrounding text | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement| Implementation: DONE<br />Tests: TO DO |
-| **Should** have `cursor: pointer` | | Implementation: DONE<br />Tests: TO DO |
-| **Should** be activated by pressing `Enter` and mouse click | | Implementation: DONE<br />Tests: DONE |
-| **Can** have an accessible label (and/or icon) that indicates opening in new tab| | Implementation: IN PROGRESS<br />Tests: TO DO |
-| **Can** have an accessible label with file size&format (and/or icon) that indicates downloading a file| | Implementation: TODO<br />Tests: TO DO |
+| Pattern                                                                                                | Comment                                                                                                                                             | Status                                        |
+| ------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| **Should** have an accessible name                                                                     | Name should be meaningful (ex. “Read more about vitamin C“ instead of “Read more“). `aria-label` can be used to provide a name.                     | Implementation: DONE<br />Tests: DONE         |
+| **Should** have a role `link`                                                                          |                                                                                                                                                     | Implementation: DONE<br />Tests: DONE         |
+| **Should** cause the user agent to navigate to a new resource                                          |                                                                                                                                                     | Implementation: DONE<br />Tests: BLOCKED      |
+| **Should** be focusable and tabable                                                                    | `href` can’t be empty.                                                                                                                              | Implementation: DONE<br />Tests: DONE         |
+| **Should** have visible focus style                                                                    | Browser focus style is used                                                                                                                         | Implementation: DONE<br />Tests: BLOCKED      |
+| **Should** have a non-color indicator                                                                  | Ex. underline, bold (italic is not accessible). Default `Link` weight is `bold`. `underlined`, `emphasised` or `weight` props can also be provided. | Implementation: DONE<br />Tests: BLOCKED      |
+| **Should** have a color indicator with 4.5:1 contrast ratio to the background                          | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement                                         | Implementation: DONE<br />Tests: BLOCKED      |
+| **Should** have a color indicator with 3:1 contrast ratio to the surrounding text                      | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement                                         | Implementation: DONE<br />Tests: BLOCKED      |
+| **Should** have `cursor: pointer`                                                                      |                                                                                                                                                     | Implementation: DONE<br />Tests: BLOCKED      |
+| **Should** be activated by pressing `Enter` and mouse click                                            |                                                                                                                                                     | Implementation: DONE<br />Tests: BLOCKED      |
+| **Can** have an accessible label (and/or icon) that indicates opening in new tab                       |                                                                                                                                                     | Implementation: IN PROGRESS<br />Tests: TO DO |
+| **Can** have an accessible label with file size&format (and/or icon) that indicates downloading a file |                                                                                                                                                     | Implementation: TO DO<br />Tests: TO DO       |
 
 > <mark>Element, that looks like a link, but doesn't cause the user agent to navigate to a new resource but have onClick listener is a button and should meet the accessibility requirements for [Link `as="button"`](#link-asbutton).</mark>
-
-
 
 <br/>
 
 ## Link `as="button"`
 
-| Pattern                         | Comment | Status                                  |
-| ------------------------------- | ------- | --------------------------------------- |
-| **Should** have an accessible name | Name should be meaningful (ex. “Read more about vitamin C“ instead of “Read more“). `aria-label` can be used to provide a name. | Implementation: DONE<br />Tests: TO DO |
-| **Should** have a role `button` | | Implementation: DONE<br />Tests: TO DO |
-| **Should** be focusable and tabable | | Implementation: DONE<br />Tests: TO DO |
-| **Should** have visible focus style | Browser focus style is used | Implementation: DONE<br />Tests: TO DO |
-| **Should** have a non-color indicator | Ex. underline, bold (italic is not accessible). Default `Link` weight is `bold`. `underlined`, `emphasised` or `weight` props can also be provided.| Implementation: DONE<br />Tests: TO DO |
-| **Should** have a color indicator with 4.5:1 contrast ratio to the background | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement| Implementation: DONE<br />Tests: TO DO |
-| **Should** have a color indicator with 3:1 contrast ratio to the surrounding text | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement| Implementation: DONE<br />Tests: TO DO |
-| **Should** have `cursor: pointer` | | Implementation: DONE<br />Tests: TO DO |
-| **Should** fire `onClick` on `Space`/`Enter` press and mouse click | | Implementation: DONE<br />Tests: DONE |
-| **Should** have a visible `disabled` state | | Implementation: DONE<br />Tests: DONE |
-
-
-
+| Pattern                                                                           | Comment                                                                                                                                             | Status                                   |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------- |
+| **Should** have an accessible name                                                | Name should be meaningful (ex. “Read more about vitamin C“ instead of “Read more“). `aria-label` can be used to provide a name.                     | Implementation: DONE<br />Tests: DONE    |
+| **Should** have a role `button`                                                   |                                                                                                                                                     | Implementation: DONE<br />Tests: DONE    |
+| **Should** be focusable and tabable                                               |                                                                                                                                                     | Implementation: DONE<br />Tests: DONE    |
+| **Should** have visible focus style                                               | Browser focus style is used                                                                                                                         | Implementation: DONE<br />Tests: BLOCKED |
+| **Should** have a non-color indicator                                             | Ex. underline, bold (italic is not accessible). Default `Link` weight is `bold`. `underlined`, `emphasised` or `weight` props can also be provided. | Implementation: DONE<br />Tests: BLOCKED |
+| **Should** have a color indicator with 4.5:1 contrast ratio to the background     | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement                                         | Implementation: DONE<br />Tests: BLOCKED |
+| **Should** have a color indicator with 3:1 contrast ratio to the surrounding text | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement                                         | Implementation: DONE<br />Tests: BLOCKED |
+| **Should** have `cursor: pointer`                                                 |                                                                                                                                                     | Implementation: DONE<br />Tests: BLOCKED |
+| **Should** fire `onClick` on `Space`/`Enter` press and mouse click                |                                                                                                                                                     | Implementation: DONE<br />Tests: DONE    |
+| **Should** have a visible `disabled` state                                        |                                                                                                                                                     | Implementation: DONE<br />Tests: BLOCKED |
 
 <br/>
 <br/>
@@ -120,4 +115,3 @@
 - <https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html>
 - <https://www.scottohara.me/blog/2018/10/03/unbutton-buttons.html>
 - <https://medium.com/@svinkle/why-let-someone-know-when-a-link-opens-a-new-window-8699d20ed3b1#:~:text=Specifically%2C%20check%20out%20the%20target,new%20tab%20or%20window%20automatically.>
-

--- a/src/components/text/Link.a11y.md
+++ b/src/components/text/Link.a11y.md
@@ -1,0 +1,123 @@
+# Link accessibility
+
+<br/>
+
+## Link `as="a"`
+
+| Pattern                         | Comment | Status                                  |
+| ------------------------------- | ------- | --------------------------------------- |
+| **Should** have an accessible name | Name should be meaningful (ex. “Read more about vitamin C“ instead of “Read more“). `aria-label` can be used to provide a name. | Implementation: DONE<br />Tests: TO DO |
+| **Should** have a role `link` | | Implementation: DONE<br />Tests: TO DO |
+| **Should** cause the user agent to navigate to a new resource | | Implementation: DONE<br />Tests: TO DO |
+| **Should** be focusable and tabable | `href` can’t be empty. | Implementation: DONE<br />Tests: TO DO |
+| **Should** have visible focus style | Browser focus style is used | Implementation: DONE<br />Tests: TO DO |
+| **Should** have a non-color indicator | Ex. underline, bold (italic is not accessible). Default `Link` weight is `bold`. `underlined`, `emphasised` or `weight` props can also be provided.| Implementation: DONE<br />Tests: TO DO |
+| **Should** have a color indicator with 4.5:1 contrast ratio to the background | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement| Implementation: DONE<br />Tests: TO DO |
+| **Should** have a color indicator with 3:1 contrast ratio to the surrounding text | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement| Implementation: DONE<br />Tests: TO DO |
+| **Should** have `cursor: pointer` | | Implementation: DONE<br />Tests: TO DO |
+| **Should** be activated by pressing `Enter` and mouse click | | Implementation: DONE<br />Tests: DONE |
+| **Can** have an accessible label (and/or icon) that indicates opening in new tab| | Implementation: IN PROGRESS<br />Tests: TO DO |
+| **Can** have an accessible label with file size&format (and/or icon) that indicates downloading a file| | Implementation: TODO<br />Tests: TO DO |
+
+> <mark>Element, that looks like a link, but doesn't cause the user agent to navigate to a new resource but have onClick listener is a button and should meet the accessibility requirements for [Link `as="button"`](#link-asbutton).</mark>
+
+
+
+<br/>
+
+## Link `as="button"`
+
+| Pattern                         | Comment | Status                                  |
+| ------------------------------- | ------- | --------------------------------------- |
+| **Should** have an accessible name | Name should be meaningful (ex. “Read more about vitamin C“ instead of “Read more“). `aria-label` can be used to provide a name. | Implementation: DONE<br />Tests: TO DO |
+| **Should** have a role `button` | | Implementation: DONE<br />Tests: TO DO |
+| **Should** be focusable and tabable | | Implementation: DONE<br />Tests: TO DO |
+| **Should** have visible focus style | Browser focus style is used | Implementation: DONE<br />Tests: TO DO |
+| **Should** have a non-color indicator | Ex. underline, bold (italic is not accessible). Default `Link` weight is `bold`. `underlined`, `emphasised` or `weight` props can also be provided.| Implementation: DONE<br />Tests: TO DO |
+| **Should** have a color indicator with 4.5:1 contrast ratio to the background | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement| Implementation: DONE<br />Tests: TO DO |
+| **Should** have a color indicator with 3:1 contrast ratio to the surrounding text | Default `Link` color is `text-blue-60`. Another `text-color` may also be specified to meet this requirement| Implementation: DONE<br />Tests: TO DO |
+| **Should** have `cursor: pointer` | | Implementation: DONE<br />Tests: TO DO |
+| **Should** fire `onClick` on `Space`/`Enter` press and mouse click | | Implementation: DONE<br />Tests: DONE |
+| **Should** have a visible `disabled` state | | Implementation: DONE<br />Tests: DONE |
+
+
+
+
+<br/>
+<br/>
+
+## Usage
+
+<br/>
+
+### Code examples
+
+- `as="a"`
+
+<!-- prettier-ignore -->
+```jsx
+<Link
+  href="https://example.com/"
+>
+  Read more about our products
+</Link>
+```
+
+- `as="button"`
+
+<!-- prettier-ignore -->
+```jsx
+<Link
+  as="button"
+  onClick={onClick}
+>
+  Check our offer
+</Link>
+```
+
+- with a meaningful label
+
+<!-- prettier-ignore -->
+```jsx
+<Link
+  href="https://example.com"
+  aria-label="Read more about our products"
+>
+  Read more
+</Link>
+```
+
+- with an underline to indicate it's a link
+
+<!-- prettier-ignore -->
+```jsx
+<Link
+  href="https://example.com"
+  underlined
+>
+  Privacy policy
+</Link>
+```
+
+- disabled
+
+<!-- prettier-ignore -->
+```jsx
+<Link
+  as="button"
+  onClick={onClick}
+  disabled
+>
+  Check our offer
+</Link>
+```
+
+### Resources
+
+- <https://www.a11y-collective.com/blog/the-perfect-link/>
+- <https://www.levelaccess.com/methods-of-indicating-the-purpose-of-a-link/>
+- <https://www.w3.org/WAI/WCAG21/Techniques/aria/ARIA8.html>
+- <https://www.w3.org/WAI/WCAG21/Understanding/link-purpose-in-context.html>
+- <https://www.scottohara.me/blog/2018/10/03/unbutton-buttons.html>
+- <https://medium.com/@svinkle/why-let-someone-know-when-a-link-opens-a-new-window-8699d20ed3b1#:~:text=Specifically%2C%20check%20out%20the%20target,new%20tab%20or%20window%20automatically.>
+

--- a/src/components/text/Link.a11y.spec.jsx
+++ b/src/components/text/Link.a11y.spec.jsx
@@ -1,0 +1,142 @@
+import * as React from 'react';
+import {render} from '@testing-library/react';
+import {testA11y} from '../../axe';
+import Link from './Link';
+import userEvent from '@testing-library/user-event';
+
+describe('Link', () => {
+  describe('as anchor', () => {
+    it('has a link role and an accessible label', () => {
+      const label = 'read more about products';
+      const link = render(
+        <Link href="https://example.com/" aria-label={label}>
+          Read more
+        </Link>
+      );
+
+      expect(link.getByRole('link', {name: label})).toBeTruthy();
+    });
+
+    it('is focusable', () => {
+      const link = render(<Link href="https://example.com/">Read more</Link>);
+
+      link.getByRole('link').focus();
+
+      expect(link.getByRole('link')).toBe(document.activeElement);
+    });
+
+    it('is not focusable when disabled', () => {
+      const label = 'read more';
+      const link = render(
+        <Link href="https://example.com/" disabled>
+          {label}
+        </Link>
+      );
+
+      link.getByText(label).focus();
+
+      expect(link.getByText(label)).not.toBe(document.activeElement);
+    });
+  });
+
+  describe('as button', () => {
+    it('has a button role and an accessible label', () => {
+      const label = 'read more about products';
+      const link = render(
+        <Link as="button" aria-label={label}>
+          Read more
+        </Link>
+      );
+
+      expect(link.getByRole('button', {name: label})).toBeTruthy();
+    });
+
+    it('is focusable', () => {
+      const link = render(<Link as="button">Read more</Link>);
+
+      link.getByRole('button').focus();
+
+      expect(link.getByRole('button')).toBe(document.activeElement);
+    });
+
+    it('is not focusable when disabled', () => {
+      const label = 'read more';
+      const link = render(
+        <Link as="button" disabled>
+          {label}
+        </Link>
+      );
+
+      link.getByText(label).focus();
+
+      expect(link.getByText(label)).not.toBe(document.activeElement);
+    });
+
+    it('fires onClick on click, space and enter', () => {
+      const handleOnClick = jest.fn();
+      const label = 'read more';
+      const link = render(
+        <Link as="button" onClick={handleOnClick}>
+          {label}
+        </Link>
+      );
+
+      userEvent.click(link.getByRole('button', {name: label}));
+      expect(handleOnClick).toHaveBeenCalledTimes(1);
+
+      link.getByText(label).focus();
+
+      userEvent.keyboard('{space}');
+      expect(handleOnClick).toHaveBeenCalledTimes(2);
+
+      userEvent.keyboard('{enter}');
+      expect(handleOnClick).toHaveBeenCalledTimes(3);
+    });
+  });
+});
+
+describe('Link a11y', () => {
+  describe('as anchor', () => {
+    it('should have no a11y violations', async () => {
+      await testA11y(<Link href="https://example.com/">Read more</Link>);
+    });
+
+    it('should have no a11y violations when aria-label is provided', async () => {
+      await testA11y(
+        <Link href="https://example.com/" aria-label="read more about us">
+          Read more
+        </Link>
+      );
+    });
+
+    it('should have no a11y violations when disabled', async () => {
+      await testA11y(
+        <Link href="https://example.com/" disabled>
+          Read more
+        </Link>
+      );
+    });
+  });
+
+  describe('as button', () => {
+    it('should have no a11y violations', async () => {
+      await testA11y(<Link as="button">Read more about us</Link>);
+    });
+
+    it('should have no a11y violations when aria-label is provided', async () => {
+      await testA11y(
+        <Link as="button" aria-label="read more about us">
+          Read more
+        </Link>
+      );
+    });
+
+    it('should have no a11y violations when disabled', async () => {
+      await testA11y(
+        <Link as="button" disabled>
+          Read more about us
+        </Link>
+      );
+    });
+  });
+});

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -108,7 +108,7 @@ const Link = (props: LinkPropsType) => {
 
   if (__DEV__) {
     invariant(
-      !(as === 'a' && (href === null || href === undefined)),
+      !(as === 'a' && !disabled && (href === null || href === undefined)),
       'An anchor element without a href will be accessible only for users with a pointing device.'
     );
 

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import {__DEV__, invariant} from '../utils';
+import {__DEV__, invariant, generateId} from '../utils';
 import Text from './Text';
 import type {TextColorType, TextSizeType} from './Text';
 import {
@@ -58,7 +58,7 @@ export type LinkPropsType = {
   disabled?: boolean,
   className?: ?string,
   inherited?: boolean,
-  ariaNewTabLabel?: string,
+  'aria-label'?: string,
   onClick?: () => mixed,
   ...
 };
@@ -83,9 +83,11 @@ const Link = (props: LinkPropsType) => {
     className,
     inherited = false,
     size,
+    'aria-label': ariaLabel,
     onClick,
     ...additionalProps
   } = props;
+  const {current: labelId} = React.useRef(generateId());
 
   let textSize: ResponsivePropType<TextSizeType>;
 
@@ -111,12 +113,16 @@ const Link = (props: LinkPropsType) => {
     );
 
     invariant(
-      !(as === 'button' &&
+      !(
+        as === 'button' &&
         (href ||
           Object.keys(additionalProps).some(p =>
             anchorRelatedProps.includes(p)
-          )),
-      'An anchor-related prop is not working for a button.')
+          ))
+      ),
+      `An anchor-related prop is not working for as="button": ${Object.keys(
+        additionalProps
+      )}`
     );
   }
 
@@ -144,12 +150,15 @@ const Link = (props: LinkPropsType) => {
         className={linkClass}
         size={textSize}
       >
-        {children}
+        <span id={labelId} aria-label={ariaLabel} aria-hidden>
+          {children}
+        </span>
         <button
           className="sg-visually-hidden"
           onClick={onClick}
           disabled={disabled}
           type="button"
+          aria-labelledby={labelId}
         />
       </Text>
     );
@@ -164,6 +173,7 @@ const Link = (props: LinkPropsType) => {
       href={href}
       className={linkClass}
       size={textSize}
+      aria-label={ariaLabel}
     >
       {children}
     </Text>

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -6,7 +6,6 @@ import {__DEV__, invariant} from '../utils';
 import Text from './Text';
 import type {TextColorType, TextSizeType} from './Text';
 import {
-  TEXT_TYPE,
   TEXT_SIZE,
   TEXT_WEIGHT,
   TEXT_TRANSFORM,
@@ -16,17 +15,14 @@ import {
 import {generateResponsiveClassNames} from '../utils/responsive-props';
 import type {ResponsivePropType} from '../utils/responsive-props';
 
-type TextTypeType =
-  | 'span'
-  | 'p'
-  | 'h1'
-  | 'h2'
-  | 'h3'
-  | 'h4'
-  | 'h5'
-  | 'h6'
-  | 'div'
-  | 'label';
+const anchorRelatedProps = [
+  'download',
+  'hreflang',
+  'ping',
+  'referrerpolicy',
+  'rel',
+  'target',
+];
 
 type LinkSizeType =
   | 'xsmall'
@@ -50,7 +46,6 @@ export type LinkPropsType = {
   as?: ?ElementType,
   href?: ?string,
   size?: ResponsivePropType<LinkSizeType>,
-  type?: TextTypeType,
   color?: ?TextColorType,
   weight?: ResponsivePropType<TextWeightType>,
   transform?: ResponsivePropType<?TextTransformType>,
@@ -63,19 +58,12 @@ export type LinkPropsType = {
   disabled?: boolean,
   className?: ?string,
   inherited?: boolean,
-  'aria-label'?: string,
-  download?: string,
-  hreflang?: string,
-  ping?: string,
-  referrerpolicy?: string,
-  rel?: string,
-  target?: string,
+  ariaNewTabLabel?: string,
   onClick?: () => mixed,
   ...
 };
 
 export {TEXT_COLOR};
-export const LINK_TYPE = TEXT_TYPE;
 export const LINK_SIZE = TEXT_SIZE;
 export const LINK_WEIGHT = TEXT_WEIGHT;
 export const LINK_TRANSFORM = TEXT_TRANSFORM;
@@ -95,15 +83,7 @@ const Link = (props: LinkPropsType) => {
     className,
     inherited = false,
     size,
-    type,
     onClick,
-    'aria-label': ariaLabel,
-    download,
-    hreflang,
-    ping,
-    referrerpolicy,
-    rel,
-    target,
     ...additionalProps
   } = props;
 
@@ -131,17 +111,12 @@ const Link = (props: LinkPropsType) => {
     );
 
     invariant(
-      !(
-        as === 'button' &&
+      !(as === 'button' &&
         (href ||
-          hreflang ||
-          download ||
-          ping ||
-          referrerpolicy ||
-          rel ||
-          target)
-      ),
-      'An anchor-related prop is not working for a button.'
+          Object.keys(additionalProps).some(p =>
+            anchorRelatedProps.includes(p)
+          )),
+      'An anchor-related prop is not working for a button.')
     );
   }
 
@@ -154,6 +129,8 @@ const Link = (props: LinkPropsType) => {
       'sg-text--bold': emphasised && !inherited,
       'sg-text--link-disabled': disabled,
       [`sg-text--${String(color)}`]: color && !unstyled,
+      [`sg-text--${String(weight)}`]: weight,
+      'sg-text--link-label': as === 'button',
     },
     ...generateResponsiveClassNames(weight => `sg-text--${weight}`, weight),
     className
@@ -162,50 +139,33 @@ const Link = (props: LinkPropsType) => {
   if (as === 'button') {
     return (
       <Text
-        type={type || 'span'}
+        type="label"
         {...additionalProps}
         className={linkClass}
         size={textSize}
       >
-        <label className="sg-text--link-label" aria-label={ariaLabel}>
-          {children}
-          <button
-            className="sg-visually-hidden"
-            onClick={onClick}
-            disabled={disabled}
-            type="button"
-          />
-        </label>
+        {children}
+        <button
+          className="sg-visually-hidden"
+          onClick={onClick}
+          disabled={disabled}
+          type="button"
+        />
       </Text>
     );
   }
 
-  if (disabled) {
-    return (
-      <Text
-        type={type || 'span'}
-        {...additionalProps}
-        className={linkClass}
-        aria-label={ariaLabel}
-      >
-        {children}
-      </Text>
-    );
-  }
+  const linkType = disabled ? 'span' : 'a';
 
   return (
-    <Text type={type}>
-      <Text
-        type="a"
-        {...additionalProps}
-        className={linkClass}
-        href={href}
-        inherited
-        aria-label={ariaLabel}
-        size={textSize}
-      >
-        {children}
-      </Text>
+    <Text
+      type={linkType}
+      {...additionalProps}
+      href={href}
+      className={linkClass}
+      size={textSize}
+    >
+      {children}
     </Text>
   );
 };

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -59,7 +59,7 @@ export type LinkPropsType = {
   className?: ?string,
   inherited?: boolean,
   'aria-label'?: string,
-  onClick?: () => mixed,
+  onClick?: (e: KeyboardEvent | MouseEvent) => mixed,
   ...
 };
 
@@ -120,6 +120,7 @@ const Link = (props: LinkPropsType) => {
             anchorRelatedProps.includes(p)
           ))
       ),
+      // $FlowFixMe
       `An anchor-related prop is not working for as="button": ${Object.keys(
         additionalProps
       )}`
@@ -145,8 +146,8 @@ const Link = (props: LinkPropsType) => {
   if (as === 'button') {
     return (
       <Text
-        type="label"
         {...additionalProps}
+        type="label"
         className={linkClass}
         size={textSize}
       >
@@ -168,9 +169,9 @@ const Link = (props: LinkPropsType) => {
 
   return (
     <Text
-      type={linkType}
       {...additionalProps}
-      href={href}
+      type={linkType}
+      href={href || ''}
       className={linkClass}
       size={textSize}
       aria-label={ariaLabel}

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -25,8 +25,7 @@ type TextTypeType =
   | 'h5'
   | 'h6'
   | 'div'
-  | 'label'
-  | 'a';
+  | 'label';
 
 type LinkSizeType =
   | 'xsmall'
@@ -43,8 +42,11 @@ type TextTransformType = 'uppercase' | 'lowercase' | 'capitalize';
 
 type TextAlignType = 'to-left' | 'to-center' | 'to-right' | 'justify';
 
+type ElementType = 'a' | 'button';
+
 export type LinkPropsType = {
   children?: ?React.Node,
+  as?: ?ElementType,
   href?: ?string,
   size?: ResponsivePropType<LinkSizeType>,
   type?: TextTypeType,
@@ -60,6 +62,8 @@ export type LinkPropsType = {
   disabled?: boolean,
   className?: ?string,
   inherited?: boolean,
+  'aria-label'?: string,
+  onClick?: () => mixed,
   ...
 };
 
@@ -73,6 +77,7 @@ export const LINK_ALIGN = TEXT_ALIGN;
 const Link = (props: LinkPropsType) => {
   const {
     children,
+    as = 'a',
     href,
     color,
     underlined = false,
@@ -83,6 +88,9 @@ const Link = (props: LinkPropsType) => {
     className,
     inherited = false,
     size,
+    type,
+    onClick,
+    'aria-label': ariaLabel,
     ...additionalProps
   } = props;
 
@@ -117,13 +125,33 @@ const Link = (props: LinkPropsType) => {
     className
   );
 
-  if (href === undefined || href === '' || href === null) {
+  if (as === 'button') {
     return (
       <Text
-        type="span"
+        type={type || 'span'}
         {...additionalProps}
         className={linkClass}
         size={textSize}
+      >
+        <label className="sg-text--link-label" aria-label={ariaLabel}>
+          {children}
+          <button
+            className="sg-visually-hidden"
+            onClick={onClick}
+            disabled={disabled}
+          />
+        </label>
+      </Text>
+    );
+  }
+
+  if (disabled) {
+    return (
+      <Text
+        type={type || 'span'}
+        {...additionalProps}
+        className={linkClass}
+        aria-label={ariaLabel}
       >
         {children}
       </Text>
@@ -131,14 +159,18 @@ const Link = (props: LinkPropsType) => {
   }
 
   return (
-    <Text
-      type="a"
-      {...additionalProps}
-      className={linkClass}
-      href={href}
-      size={textSize}
-    >
-      {children}
+    <Text type={type}>
+      <Text
+        type="a"
+        {...additionalProps}
+        className={linkClass}
+        href={href}
+        inherited
+        aria-label={ariaLabel}
+        size={textSize}
+      >
+        {children}
+      </Text>
     </Text>
   );
 };

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
+import {__DEV__, invariant} from '../utils';
 import Text from './Text';
 import type {TextColorType, TextSizeType} from './Text';
 import {
@@ -63,6 +64,12 @@ export type LinkPropsType = {
   className?: ?string,
   inherited?: boolean,
   'aria-label'?: string,
+  download?: string,
+  hreflang?: string,
+  ping?: string,
+  referrerpolicy?: string,
+  rel?: string,
+  target?: string,
   onClick?: () => mixed,
   ...
 };
@@ -91,6 +98,12 @@ const Link = (props: LinkPropsType) => {
     type,
     onClick,
     'aria-label': ariaLabel,
+    download,
+    hreflang,
+    ping,
+    referrerpolicy,
+    rel,
+    target,
     ...additionalProps
   } = props;
 
@@ -109,6 +122,27 @@ const Link = (props: LinkPropsType) => {
     }
   } else if (size) {
     textSize = size;
+  }
+
+  if (__DEV__) {
+    invariant(
+      !(as === 'a' && (href === null || href === undefined)),
+      'An anchor element without a href will be accessible only for users with a pointing device.'
+    );
+
+    invariant(
+      !(
+        as === 'button' &&
+        (href ||
+          hreflang ||
+          download ||
+          ping ||
+          referrerpolicy ||
+          rel ||
+          target)
+      ),
+      'An anchor-related prop is not working for a button.'
+    );
   }
 
   const linkClass = classNames(
@@ -139,6 +173,7 @@ const Link = (props: LinkPropsType) => {
             className="sg-visually-hidden"
             onClick={onClick}
             disabled={disabled}
+            type="button"
           />
         </label>
       </Text>

--- a/src/components/text/Link.spec.jsx
+++ b/src/components/text/Link.spec.jsx
@@ -17,14 +17,12 @@ test('render Text', () => {
   expect(link.find(Text)).toBeTruthy();
 });
 
-test('empty href', () => {
-  const link = shallow(<Link>Test</Link>).dive();
-
-  expect(link.find('span')).toHaveLength(1);
-});
-
 test('size', () => {
-  const link = shallow(<Link size={LINK_SIZE.SMALL}>Test</Link>).dive();
+  const link = shallow(
+    <Link href="#" size={LINK_SIZE.SMALL}>
+      Test
+    </Link>
+  ).dive();
   const responsiveSizeLink = shallow(
     <Link size={['xsmall', 'small', null, 'large']}>Test</Link>
   ).dive();
@@ -39,26 +37,42 @@ test('size', () => {
 
 it('size is responsive prop', () => {
   const size = [LINK_SIZE.SMALL, LINK_SIZE.XXLARGE, null, LINK_SIZE.XXXLARGE];
-  const component = shallow(<Link size={size}>Test</Link>);
+  const component = shallow(
+    <Link href="#" size={size}>
+      Test
+    </Link>
+  );
 
   expect(component.prop('size')).toEqual(size);
 });
 
 test('color', () => {
-  const link = shallow(<Link color="text-white">Test</Link>).dive();
+  const link = shallow(
+    <Link href="#" color="text-white">
+      Test
+    </Link>
+  ).dive();
 
   expect(link.hasClass('sg-text--text-white')).toBeTruthy();
 });
 
 test('unstyled', () => {
-  const link = shallow(<Link unstyled>Test</Link>);
+  const link = shallow(
+    <Link href="#" unstyled>
+      Test
+    </Link>
+  );
 
   expect(link.hasClass('sg-text--link-unstyled')).toBeTruthy();
   expect(link.hasClass('sg-text--link')).toBeFalsy();
 });
 
 test('underlined', () => {
-  const link = shallow(<Link underlined>Test</Link>);
+  const link = shallow(
+    <Link href="#" underlined>
+      Test
+    </Link>
+  );
 
   expect(link.hasClass('sg-text--link-underlined')).toBeTruthy();
   expect(link.hasClass('sg-text--link-unstyled')).toBeFalsy();
@@ -69,6 +83,7 @@ it('weight is responsive prop', () => {
   const component = shallow(
     <Link
       weight={[TEXT_WEIGHT.BOLD, TEXT_WEIGHT.REGULAR, null, TEXT_WEIGHT.BOLD]}
+      href="#"
     >
       Test
     </Link>
@@ -81,28 +96,44 @@ it('weight is responsive prop', () => {
 
 it('transform is responsive prop', () => {
   const transform = [LINK_TRANSFORM.CAPITALIZE, LINK_TRANSFORM.LOWERCASE];
-  const component = shallow(<Link transform={transform}>Test</Link>);
+  const component = shallow(
+    <Link href="#" transform={transform}>
+      Test
+    </Link>
+  );
 
   expect(component.prop('transform')).toEqual(transform);
 });
 
 it('align is responsive prop', () => {
   const align = [LINK_ALIGN.CENTER, LINK_ALIGN.CENTER];
-  const component = shallow(<Link align={align}>Test</Link>);
+  const component = shallow(
+    <Link href="#" align={align}>
+      Test
+    </Link>
+  );
 
   expect(component.prop('align')).toEqual(align);
 });
 
 it('noWrap is responsive prop', () => {
   const noWrap = [true];
-  const component = shallow(<Link noWrap={noWrap}>Test</Link>);
+  const component = shallow(
+    <Link href="#" noWrap={noWrap}>
+      Test
+    </Link>
+  );
 
   expect(component.prop('noWrap')).toEqual(noWrap);
 });
 
 it('breakWords is responsive prop', () => {
   const breakWords = [true];
-  const component = shallow(<Link breakWords={breakWords}>Test</Link>);
+  const component = shallow(
+    <Link href="#" breakWords={breakWords}>
+      Test
+    </Link>
+  );
 
   expect(component.prop('breakWords')).toEqual(breakWords);
 });

--- a/src/components/text/Link.stories.jsx
+++ b/src/components/text/Link.stories.jsx
@@ -22,7 +22,7 @@ Default.argTypes = {
 
 export const Nested = args => (
   <Text type="h2" color={TEXT_COLOR['text-red-60']}>
-    Outer link-
+    Outer text-
     <Link {...args} />
   </Text>
 );

--- a/src/components/text/Link.stories.jsx
+++ b/src/components/text/Link.stories.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import Link from './Link';
+import Text from './Text';
 import {TEXT_COLOR} from './textConsts';
 
 export default {
@@ -19,19 +20,17 @@ Default.argTypes = {
   href: '#',
 };
 
-export const Nested = args => <Link {...args} />;
+export const Nested = args => (
+  <Text type="h2" color={TEXT_COLOR['text-red-60']}>
+    Outer link-
+    <Link {...args} />
+  </Text>
+);
 
 Nested.args = {
-  type: 'h2',
-  color: TEXT_COLOR['text-red-60'],
-  children: (
-    <>
-      Outer Link{' '}
-      <Link inherited as="button">
-        nested Link with inherited styles
-      </Link>
-    </>
-  ),
+  inherited: true,
+  as: 'button',
+  children: 'nested Link with inherited styles',
 };
 
 Nested.argTypes = {

--- a/src/components/text/Link.stories.jsx
+++ b/src/components/text/Link.stories.jsx
@@ -11,10 +11,12 @@ export const Default = args => <Link {...args} />;
 
 Default.args = {
   children: 'Some text',
+  href: '#',
 };
 
 Default.argTypes = {
   children: 'string',
+  href: '#',
 };
 
 export const Nested = args => <Link {...args} />;
@@ -25,7 +27,7 @@ Nested.args = {
   children: (
     <>
       Outer Link{' '}
-      <Link inherited type="span">
+      <Link inherited as="button">
         nested Link with inherited styles
       </Link>
     </>

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -82,7 +82,7 @@ $bodyTextSizeRules: (
     }
 
     &--link-label {
-      cursor: inherit;
+      cursor: pointer;
 
       &:focus-within {
         outline: 5px auto Highlight;

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -81,6 +81,15 @@ $bodyTextSizeRules: (
       }
     }
 
+    &--link-label{
+      cursor: inherit;
+    
+    &:focus-within {
+      outline: 5px auto Highlight;
+      outline: 5px auto -webkit-focus-ring-color;
+    }
+  }
+
     &--link-disabled {
       cursor: default;
 

--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -81,14 +81,14 @@ $bodyTextSizeRules: (
       }
     }
 
-    &--link-label{
+    &--link-label {
       cursor: inherit;
-    
-    &:focus-within {
-      outline: 5px auto Highlight;
-      outline: 5px auto -webkit-focus-ring-color;
+
+      &:focus-within {
+        outline: 5px auto Highlight;
+        outline: 5px auto -webkit-focus-ring-color;
+      }
     }
-  }
 
     &--link-disabled {
       cursor: default;

--- a/src/components/text/pages/links-interactive.jsx
+++ b/src/components/text/pages/links-interactive.jsx
@@ -34,7 +34,7 @@ const Links = () => {
   return (
     <div>
       <DocsActiveBlock settings={settings}>
-        <Link>Comments (9)</Link>
+        <Link as="button">Comments (9)</Link>
       </DocsActiveBlock>
       <DocsActiveBlock settings={settings}>
         <Link
@@ -47,9 +47,9 @@ const Links = () => {
         </Link>
       </DocsActiveBlock>
       <DocsActiveBlock settings={settings}>
-        <Link>
+        <Link as="button">
           Parent Link component{' '}
-          <Link inherited type="span" color="text-green-60">
+          <Link href="#" inherited type="span" color="text-green-60">
             nested Link inheriting styles from parent Link
           </Link>
         </Link>

--- a/src/components/utils/generateId.js
+++ b/src/components/utils/generateId.js
@@ -1,0 +1,3 @@
+export default function generateId() {
+  return Math.random().toString(36).substring(7);
+}

--- a/src/components/utils/generateId.js
+++ b/src/components/utils/generateId.js
@@ -1,3 +1,5 @@
+// @flow strict
+
 export default function generateId() {
   return Math.random().toString(36).substring(7);
 }

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -3,3 +3,4 @@
 export {__DEV__} from './consts';
 export {default as invariant} from './invariant';
 export {default as useReducedMotion} from './useReducedMotion';
+export {default as generateId} from './generateId';

--- a/src/sass/_utils.scss
+++ b/src/sass/_utils.scss
@@ -87,9 +87,10 @@
   width: 1px;
   height: 1px;
   padding: 0;
-  margin: -1px;
+  margin: 0;
   overflow: hidden;
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border-width: 0;
+  clip-path: inset(50%);
 }


### PR DESCRIPTION
Accessibility improvements in `Link` component: 
- `Link` can work both as button and anchor (`as` prop) with corresponding behaviour pattern:
    - `as="a"` (default), when `href` provided: activates on click and enter, is focusable and tabbable, can be disabled (acts like `span`), has focus styles
    - `as="button"`: activates on click, enter and space, is focusable and tabbable, can be disabled, has focus styles
- has accessible name (can be overwritten by `aria-label`)
- accessibility documentation
- accessibility tests

More in [documentation](https://github.com/brainly/style-guide/blob/256f28ed4ba541525b240a266d586fc469a078ea/src/components/text/Link.a11y.md)


