### PR TITLE
Texts - Fix for styles of transform prop

### DIFF
--- a/src/components/text/_text.scss
+++ b/src/components/text/_text.scss
@@ -126,7 +126,7 @@ $bodyTextSizeRules: (
       }
 
       @each $transform in $bodyTextTransforms {
-        @include makeResponsive($variant, 'sg-text--#{transform}') {
+        @include makeResponsive($variant, 'sg-text--#{$transform}') {
           text-transform: $transform;
         }
       }


### PR DESCRIPTION
## before

<img width="575" alt="Screenshot 2022-02-15 at 12 04 02" src="https://user-images.githubusercontent.com/1231144/154049781-8f1023de-5bcf-436b-a488-f44d4075dcb1.png">

<img width="338" alt="Screenshot 2022-02-15 at 12 05 36" src="https://user-images.githubusercontent.com/1231144/154049783-3416ba14-a9b7-45f1-a000-1ca364aab76c.png">


## after

<img width="550" alt="Screenshot 2022-02-15 at 12 03 50" src="https://user-images.githubusercontent.com/1231144/154049770-e334353c-c050-4a5c-8c73-f57738ca84d1.png">

<img width="239" alt="Screenshot 2022-02-15 at 12 06 06" src="https://user-images.githubusercontent.com/1231144/154049876-9f856861-9207-4b5d-9aa0-ee479e784b56.png">
