### PR TITLE
Change addons panel order to show contols addon first

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -18,9 +18,9 @@ module.exports = {
       ? ['../src/**/*.chromatic.stories.@(jsx|mdx)']
       : findStories(),
   addons: [
+    '@storybook/addon-essentials',
     '@storybook/addon-a11y',
     '@storybook/addon-docs',
-    '@storybook/addon-essentials',
     '@storybook/addon-links',
   ],
   staticDirs: ['./public'],


### PR DESCRIPTION
We would like to have controls addon show first and being opened by default.

**Before**
![CleanShot 2022-04-01 at 09 44 56](https://user-images.githubusercontent.com/8572321/161218644-8d0c322c-7aef-490d-94ea-8f4f16947e2e.png)

**After**
![CleanShot 2022-04-01 at 09 40 13](https://user-images.githubusercontent.com/8572321/161218215-0f93a0c4-d62d-44cf-8b20-8300349797b2.png)
