### PR TITLE
Remove "layout" group in storybook

### DIFF
--- a/src/components/accordion/Accordion.stories.mdx
+++ b/src/components/accordion/Accordion.stories.mdx
@@ -26,7 +26,7 @@ const storyItems = [
 ];
 
 <Meta
-  title="Layout/Accordion"
+  title="Components/Accordion"
   component={Accordion}
   argTypes={{
     children: {

--- a/src/components/box/Box.stories.mdx
+++ b/src/components/box/Box.stories.mdx
@@ -10,7 +10,7 @@ import Headline from '../text/Headline';
 import Icon from '../icons/Icon';
 
 <Meta
-  title="Layout/Box"
+  title="Components/Box"
   component={Box}
   argTypes={{
     children: {

--- a/src/components/bubble/Bubble.stories.mdx
+++ b/src/components/bubble/Bubble.stories.mdx
@@ -6,7 +6,7 @@ import Bubble, {DIRECTION, ALIGNMENT, BUBBLE_COLOR} from './Bubble';
 import BubbleA11y from './stories/Bubble.a11y.mdx';
 
 <Meta
-  title="Layout/Bubble"
+  title="Components/Bubble"
   component={Bubble}
   argTypes={{
     direction: {control: {type: 'select', options: DIRECTION}},


### PR DESCRIPTION
## Removing ambiguous "layout" group from storybook. 
The purpose of this group was different and I have deviated from the original concept. However, I believe there will still be room for this group in the future.

![CleanShot 2022-04-12 at 15 29 42](https://user-images.githubusercontent.com/8572321/162973792-07ede2ca-245a-4524-843c-9e3e415130c8.png)

