### PR TITLE
[WIP] Dialog decoposition PoC

### DIFF
--- a/src/components/dialog/Dialog.jsx
+++ b/src/components/dialog/Dialog.jsx
@@ -52,10 +52,9 @@ const DialogContext = React.createContext<DialogContextType>({});
 
 export function DialogContextProvider({
   children,
-  size,
-  scroll,
-  zIndex,
-  reduceMotion,
+  size = 'm',
+  scroll = 'outside',
+  zIndex = 'auto',
   ...otherProps
 }: DialogPropsType) {
   const overlayRef = React.useRef(null);
@@ -67,36 +66,22 @@ export function DialogContextProvider({
   const [isDialogHigherThanOverlay, setIsDialogHigherThanOverlay] =
     React.useState<boolean>(false);
 
-  const contextData = React.useMemo<DialogContextType>(
-    () => ({
-      size: size || 'm',
-      scroll: scroll || 'outside',
-      zIndex: zIndex || 'auto',
-      reduceMotion: reduceMotion || false,
-      ...otherProps,
+  const contextData: DialogContextType = {
+    ...otherProps,
+    size,
+    scroll,
+    zIndex,
 
-      overlayRef,
-      containerRef,
+    overlayRef,
+    containerRef,
 
-      deferredOpen,
-      setDeferredOpen,
-      hasFinishedTransition,
-      setHasFinishedTransition,
-      isDialogHigherThanOverlay,
-      setIsDialogHigherThanOverlay,
-    }),
-    [
-      size,
-      scroll,
-      zIndex,
-      reduceMotion,
-      // should otherProps be here?
-      otherProps,
-      deferredOpen,
-      hasFinishedTransition,
-      isDialogHigherThanOverlay,
-    ]
-  );
+    deferredOpen,
+    setDeferredOpen,
+    hasFinishedTransition,
+    setHasFinishedTransition,
+    isDialogHigherThanOverlay,
+    setIsDialogHigherThanOverlay,
+  };
 
   return (
     <DialogContext.Provider value={contextData}>
@@ -144,6 +129,7 @@ function BaseDialogOverlay({children}: {children: React.Node}) {
     [onDismiss]
   );
 
+  // move to BaseDialogContainer?
   const handleKeyUp = React.useCallback(
     (event: SyntheticKeyboardEvent<HTMLDivElement>) => {
       if (onDismiss && event.key === 'Escape') {
@@ -294,6 +280,7 @@ function BaseDialogContainer({
       the focus event when the dialog is the first or last node,
       bracket the dialog with two invisible, focusable nodes. */}
       <div tabIndex="0" />
+      {/*  Role dialog - container or just content? */}
       <div
         role="dialog"
         ref={containerRef}

--- a/src/components/dialog/Dialog.jsx
+++ b/src/components/dialog/Dialog.jsx
@@ -123,7 +123,7 @@ Dialog.defaultProps = ({
   scroll: 'outside',
 }: $Shape<DialogPropsType>);
 
-function BaseDialogOverlay({children}: {children: React.Node}) {
+export function BaseDialogOverlay({children}: {children: React.Node}) {
   const {
     size,
     overlayRef,
@@ -175,7 +175,7 @@ function BaseDialogOverlay({children}: {children: React.Node}) {
   );
 }
 
-function BaseDialogContent({children}: {children: React.Node}) {
+export function BaseDialogContent({children}: {children: React.Node}) {
   return <div className="sg-dialog__content">{children}</div>;
 }
 
@@ -183,7 +183,7 @@ function BaseDialogContent({children}: {children: React.Node}) {
  * The Dialog component controls mounting
  * when BaseDialog controls its own states.
  */
-function BaseDialogContainer({children}: {children: React.Node}) {
+export function BaseDialogContainer({children}: {children: React.Node}) {
   const [exiting, setExiting] = React.useState<boolean>(false);
 
   const {

--- a/src/components/dialog/Dialog.jsx
+++ b/src/components/dialog/Dialog.jsx
@@ -104,11 +104,15 @@ function BaseDialogOverlay({
   );
 }
 
+function BaseDialogContent({children}) {
+  return <div className="sg-dialog__content">{children}</div>;
+}
+
 /**
  * The Dialog component controls mounting
  * when BaseDialog controls its own states.
  */
-function BaseDialog({
+function BaseDialogContainer({
   open,
   children,
   size = 'm',
@@ -272,7 +276,6 @@ function Dialog({open, onExitTransitionEnd, ...otherProps}: DialogPropsType) {
 
   const [isDialogHigherThanOverlay, setIsDialogHigherThanOverlay] =
     React.useState<boolean>(false);
-
   /* END COMMON */
 
   if (open && !mounted) {
@@ -296,7 +299,17 @@ function Dialog({open, onExitTransitionEnd, ...otherProps}: DialogPropsType) {
       isDialogHigherThanOverlay={isDialogHigherThanOverlay}
       hasFinishedTransition={hasFinishedTransition}
     >
-      <BaseDialog
+      {/*<div*/}
+      {/*  style={{*/}
+      {/*    position: 'absolute',*/}
+      {/*    height: '100%',*/}
+      {/*    width: '100%',*/}
+      {/*    backgroundImage:*/}
+      {/*      "url('https://i.picsum.photos/id/350/1000/1000.jpg?hmac=K8UpYK9kXINCijZuHxZF1DIV9JVWMf7fCfuDL3Gtddc')",*/}
+      {/*    backgroundSize: 'cover',*/}
+      {/*  }}*/}
+      {/*/>*/}
+      <BaseDialogContainer
         {...otherProps}
         overlayRef={overlayRef}
         containerRef={containerRef}
@@ -307,7 +320,13 @@ function Dialog({open, onExitTransitionEnd, ...otherProps}: DialogPropsType) {
         isDialogHigherThanOverlay={isDialogHigherThanOverlay}
         setIsDialogHigherThanOverlay={setIsDialogHigherThanOverlay}
         setHasFinishedTransition={setHasFinishedTransition}
-      />
+      >
+        <BaseDialogContent>{otherProps.children}</BaseDialogContent>
+
+        {/*<div style={{height: '100px', width: '900px', background: 'green'}}>*/}
+        {/*  <p>helloł</p>*/}
+        {/*</div>*/}
+      </BaseDialogContainer>
     </BaseDialogOverlay>
   ) : null;
 }

--- a/src/components/dialog/Dialog.stories.mdx
+++ b/src/components/dialog/Dialog.stories.mdx
@@ -1,7 +1,7 @@
 import {ArgsTable, Meta, Story, Canvas} from '@storybook/addon-docs';
 
 import DialogA11y from './stories/Dialog.a11y.mdx';
-import Dialog from './Dialog';
+import Dialog, {BaseDialogContainer, BaseDialogContent, BaseDialogOverlay, DialogContextProvider} from './Dialog';
 import Button from '../buttons/Button';
 import Flex from '../flex/Flex';
 import Headline from '../text/Headline';
@@ -150,8 +150,67 @@ import DialogCloseButton from './DialogCloseButton';
   </Story>
 </Canvas>
 
-<ArgsTable story="Default" />
+<ArgsTable story="Default"/>
 
 ## Accessibility
 
 <DialogA11y />
+
+## Stories
+
+### With custom element before overlay
+
+<Canvas>
+    <Story name="WithCustomElementBeforeOverlay">
+        {args => {
+            const [open, setOpen] = React.useState(false);
+            const handleDismiss = () => setOpen(false);
+            const headerId = 'dialog-header';
+            return (
+                <div>
+                    <Button type="solid-mint" onClick={() => setOpen(true)}>
+                        open dialog
+                    </Button>
+
+                    <DialogContextProvider
+                        {...args}
+                        open={open}
+                        onDismiss={handleDismiss}
+                        labelledBy={headerId}>
+                        <BaseDialogOverlay>
+                            <BaseDialogContainer>
+                                <BaseDialogContent>
+                                    <DialogCloseButton onClick={handleDismiss}/>
+                                    <DialogHeader id={headerId}>
+                                        <Flex marginBottom="m">
+                                            <Headline>
+                                                Are you sure you want to stop asking this question?
+                                            </Headline>
+                                        </Flex>
+                                    </DialogHeader>
+                                    <DialogBody>
+                                        <Flex marginBottom="m">
+                                            Information you provide to us directly. We may collect personal
+                                            information, such as your name, address, telephone number, date
+                                            of birth, payment information, and e-mail address when you when
+                                            you register for our Service, sign up for our mailing list,
+                                            enter a contest or sweepstakes, or otherwise communicate with
+                                            us. We may also collect any communications between you and
+                                            Brainly and any other information you provide to Brainly
+                                        </Flex>
+                                        <Flex justifyContent="flex-end" className="sg-space-x-s">
+                                            <Button type="outline" onClick={handleDismiss}>
+                                                cancel
+                                            </Button>
+                                            <Button type="solid">proceed</Button>
+                                        </Flex>
+                                    </DialogBody>
+                                </BaseDialogContent>
+                            </BaseDialogContainer>
+                        </BaseDialogOverlay>
+                    </DialogContextProvider>
+                </div>
+            );
+        }}
+    </Story>
+</Canvas>

--- a/src/components/dialog/Dialog.stories.mdx
+++ b/src/components/dialog/Dialog.stories.mdx
@@ -171,7 +171,72 @@ import DialogCloseButton from './DialogCloseButton';
                     <Button type="solid-mint" onClick={() => setOpen(true)}>
                         open dialog
                     </Button>
+                    <DialogContextProvider
+                        {...args}
+                        open={open}
+                        onDismiss={handleDismiss}
+                        labelledBy={headerId}>
+                        <BaseDialogOverlay>
+                            <div
+                                style={{
+                                    position: 'absolute',
+                                    height: '100%',
+                                    width: '100%',
+                                    backgroundImage:
+                                        "url('https://i.picsum.photos/id/350/1000/1000.jpg?hmac=K8UpYK9kXINCijZuHxZF1DIV9JVWMf7fCfuDL3Gtddc')",
+                                    backgroundSize: 'cover',
+                                }}
+                            />
+                            <BaseDialogContainer>
+                                <BaseDialogContent>
+                                    <DialogCloseButton onClick={handleDismiss}/>
+                                    <DialogHeader id={headerId}>
+                                        <Flex marginBottom="m">
+                                            <Headline>
+                                                Are you sure you want to stop asking this question?
+                                            </Headline>
+                                        </Flex>
+                                    </DialogHeader>
+                                    <DialogBody>
+                                        <Flex marginBottom="m">
+                                            Information you provide to us directly. We may collect personal
+                                            information, such as your name, address, telephone number, date
+                                            of birth, payment information, and e-mail address when you when
+                                            you register for our Service, sign up for our mailing list,
+                                            enter a contest or sweepstakes, or otherwise communicate with
+                                            us. We may also collect any communications between you and
+                                            Brainly and any other information you provide to Brainly
+                                        </Flex>
+                                        <Flex justifyContent="flex-end" className="sg-space-x-s">
+                                            <Button type="outline" onClick={handleDismiss}>
+                                                cancel
+                                            </Button>
+                                            <Button type="solid">proceed</Button>
+                                        </Flex>
+                                    </DialogBody>
+                                </BaseDialogContent>
+                            </BaseDialogContainer>
+                        </BaseDialogOverlay>
+                    </DialogContextProvider>
+                </div>
+            );
+        }}
+    </Story>
+</Canvas>
 
+### With custom element below dialog
+
+<Canvas>
+    <Story name="WithCustomElementBelowDialog">
+        {args => {
+            const [open, setOpen] = React.useState(false);
+            const handleDismiss = () => setOpen(false);
+            const headerId = 'dialog-header';
+            return (
+                <div>
+                    <Button type="solid-mint" onClick={() => setOpen(true)}>
+                        open dialog
+                    </Button>
                     <DialogContextProvider
                         {...args}
                         open={open}
@@ -206,6 +271,11 @@ import DialogCloseButton from './DialogCloseButton';
                                         </Flex>
                                     </DialogBody>
                                 </BaseDialogContent>
+                                <div style={{
+                                    height: '250px', width: '970px', marginTop: '1rem', background: 'green', backgroundImage:
+                                        "url('https://i.picsum.photos/id/473/970/250.jpg?hmac=qercOFBheyXUfKsZztEkkL06_o3_Ld-u7Xw4AGMd2wo')",
+                                    backgroundSize: 'cover',
+                                }}/>
                             </BaseDialogContainer>
                         </BaseDialogOverlay>
                     </DialogContextProvider>

--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -59,13 +59,23 @@ $dialogMaxWidthMap: (
     }
   }
 
+  &__content {
+    background-color: $white;
+    border-radius: $borderRadiusDefault $borderRadiusDefault 0 0;
+    box-shadow: $dialogBoxShadow;
+
+    @include sgResponsive(md) {
+      border-radius: $borderRadiusDefault;
+    }
+  }
+
   &__container {
     display: flex;
     flex-direction: column;
     position: relative;
-    background-color: $white;
-    border-radius: $borderRadiusDefault $borderRadiusDefault 0 0;
-    box-shadow: $dialogBoxShadow;
+    //background-color: $white;
+    //border-radius: $borderRadiusDefault $borderRadiusDefault 0 0;
+    //box-shadow: $dialogBoxShadow;
     width: 100%;
     margin-top: auto;
     margin-bottom: 0;
@@ -75,8 +85,10 @@ $dialogMaxWidthMap: (
     transform: translate3d(0, $dialogSlideWindowDistance, 0);
     opacity: 0;
 
+    align-items: center;
+
     @include sgResponsive(md) {
-      border-radius: $borderRadiusDefault;
+      //border-radius: $borderRadiusDefault;
       margin-bottom: auto;
 
       @each $sizeName, $maxWidth in $dialogMaxWidthMap {

--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -59,6 +59,7 @@ $dialogMaxWidthMap: (
     }
   }
 
+  // TODO: handle full screen
   &__content {
     background-color: $white;
     border-radius: $borderRadiusDefault $borderRadiusDefault 0 0;


### PR DESCRIPTION
The purpose of this PR is to split a `Dialog` component into multiple parts in order to be able to add custom elements to it without adding new props and still have all a11y improvements from the original dialog.

The default usage with just a `Dialog` component shouldn't change at all but in the case of more advanced cases, it will be a possibility to compose your own "dialog" fully compliant with the "Style Guide" dialog.

![image](https://user-images.githubusercontent.com/32246156/163545751-1d379761-f409-438b-a1b5-6e8d1ca6664a.png)

![image](https://user-images.githubusercontent.com/32246156/163545820-19cb076f-9be2-4f97-afee-dd9dc236eb0e.png)

