### PR TITLE
Add feature to hide new tab indicator (arrow) in Link

### DIFF
--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -62,6 +62,7 @@ export type LinkPropsType = {
   'aria-label'?: string,
   target?: TargetType,
   newTabLabel?: string,
+  hideNewTabIndicator?: boolean,
   onClick?: (
     SyntheticMouseEvent<HTMLButtonElement | HTMLAnchorElement>
   ) => mixed,
@@ -92,6 +93,7 @@ const Link = (props: LinkPropsType) => {
     target,
     onClick,
     newTabLabel = '(opens in a new tab)',
+    hideNewTabIndicator = false,
     ...additionalProps
   } = props;
   const {current: labelId} = React.useRef(generateId());
@@ -193,7 +195,9 @@ const Link = (props: LinkPropsType) => {
       {children}
       {target === '_blank' && (
         <>
-          <span aria-hidden> ⬈</span>
+          <span aria-hidden hidden={hideNewTabIndicator}>
+            ⬈
+          </span>
           <span className="sg-visually-hidden">{newTabLabel}</span>
         </>
       )}

--- a/src/components/text/Link.stories.mdx
+++ b/src/components/text/Link.stories.mdx
@@ -109,7 +109,7 @@ import LinkA11y from './Link.a11y.mdx';
     {args => (
       <Text type="h2" color={TEXT_COLOR['text-red-60']}>
         Outer text-
-        <Link as="button" inherited>
+        <Link as="button" inherited {...args}>
           nested Link with inherited styles
         </Link>
       </Text>
@@ -122,7 +122,11 @@ import LinkA11y from './Link.a11y.mdx';
 <Canvas>
   <Story name="Open in a new tab">
     {args => (
-      <Link href="https://en.wikipedia.org/wiki/Red_panda" target="_blank">
+      <Link
+        href="https://en.wikipedia.org/wiki/Red_panda"
+        target="_blank"
+        {...args}
+      >
         Read more about red pandas
       </Link>
     )}


### PR DESCRIPTION
- `hideNewTabIndicator` prop
- remove space between link content and indicator

closes #2395 