### PR TITLE
Darken colors in Counter

### DIFF
--- a/src/components/counters/Counter.jsx
+++ b/src/components/counters/Counter.jsx
@@ -9,11 +9,11 @@ import type {IconTypeType} from '../icons/Icon';
 
 type CounterSizeType = 'xs' | 'xxs';
 
-type ColorType = 'red-60' | 'blue-60';
+type ColorType = 'red-50' | 'blue-50';
 
 export const COUNTER_COLOR = {
-  'red-60': 'red-60',
-  'blue-60': 'blue-60',
+  'red-50': 'red-50',
+  'blue-50': 'blue-50',
 };
 
 export const COUNTER_SIZE: {
@@ -50,7 +50,7 @@ export type CounterPropsType = {
   size?: ?CounterSizeType,
   /**
    * Counter background color
-   * @example <Counter color="blue-60">1</Counter>
+   * @example <Counter color="blue-50">1</Counter>
    */
   color?: ?ColorType,
   /**
@@ -76,7 +76,7 @@ const Counter = ({
   children,
   className,
   size,
-  color = 'red-60',
+  color = 'red-50',
   withAnimation,
   'aria-label': ariaLabel,
   ...props

--- a/src/components/counters/Counter.jsx
+++ b/src/components/counters/Counter.jsx
@@ -9,11 +9,11 @@ import type {IconTypeType} from '../icons/Icon';
 
 type CounterSizeType = 'xs' | 'xxs';
 
-type ColorType = 'red-50' | 'blue-50';
+type ColorType = 'red-60' | 'blue-60';
 
 export const COUNTER_COLOR = {
-  'red-50': 'red-50',
-  'blue-50': 'blue-50',
+  'red-60': 'red-60',
+  'blue-60': 'blue-60',
 };
 
 export const COUNTER_SIZE: {
@@ -50,7 +50,7 @@ export type CounterPropsType = {
   size?: ?CounterSizeType,
   /**
    * Counter background color
-   * @example <Counter color="blue-50">1</Counter>
+   * @example <Counter color="blue-60">1</Counter>
    */
   color?: ?ColorType,
   /**
@@ -76,7 +76,7 @@ const Counter = ({
   children,
   className,
   size,
-  color = 'red-50',
+  color = 'red-60',
   withAnimation,
   'aria-label': ariaLabel,
   ...props

--- a/src/components/counters/Counters.stories.mdx
+++ b/src/components/counters/Counters.stories.mdx
@@ -106,7 +106,7 @@ import CounterA11y from './stories/Counter.a11y.mdx';
                 </td>
                 <td>
                   <Flex justifyContent="center">
-                    <Counter key={size} {...args} size={size} color="blue-50">
+                    <Counter key={size} {...args} size={size} color="blue-60">
                       2
                     </Counter>
                   </Flex>

--- a/src/components/counters/Counters.stories.mdx
+++ b/src/components/counters/Counters.stories.mdx
@@ -106,7 +106,7 @@ import CounterA11y from './stories/Counter.a11y.mdx';
                 </td>
                 <td>
                   <Flex justifyContent="center">
-                    <Counter key={size} {...args} size={size} color="blue-60">
+                    <Counter key={size} {...args} size={size} color="blue-50">
                       2
                     </Counter>
                   </Flex>

--- a/src/components/counters/_counters.scss
+++ b/src/components/counters/_counters.scss
@@ -13,7 +13,7 @@ $counterSizeXS: componentSize(xs);
     justify-content: center;
     align-content: center;
     flex-shrink: 0;
-    background-color: $red-50;
+    background-color: $red-60;
     cursor: default;
 
     &__text {
@@ -26,12 +26,12 @@ $counterSizeXS: componentSize(xs);
       top: 3px;
     }
 
-    &--red-50 {
-      background-color: $red-50;
+    &--red-60 {
+      background-color: $red-60;
     }
 
-    &--blue-50 {
-      background-color: $blue-50;
+    &--blue-60 {
+      background-color: $blue-60;
     }
 
     &--with-icon {

--- a/src/components/counters/_counters.scss
+++ b/src/components/counters/_counters.scss
@@ -13,7 +13,7 @@ $counterSizeXS: componentSize(xs);
     justify-content: center;
     align-content: center;
     flex-shrink: 0;
-    background-color: $red-60;
+    background-color: $red-50;
     cursor: default;
 
     &__text {
@@ -26,12 +26,12 @@ $counterSizeXS: componentSize(xs);
       top: 3px;
     }
 
-    &--red-60 {
-      background-color: $red-60;
+    &--red-50 {
+      background-color: $red-50;
     }
 
-    &--blue-60 {
-      background-color: $blue-60;
+    &--blue-50 {
+      background-color: $blue-50;
     }
 
     &--with-icon {

--- a/src/components/counters/stories/Counter.a11y.mdx
+++ b/src/components/counters/stories/Counter.a11y.mdx
@@ -2,7 +2,7 @@
 
 | Pattern                              | Comment                                                                                                                                               | Status                                |
 | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| **Should** have 4.5:1 contrast ratio |                                                                                                                                                       | Implementation: TO DO<br />Tests: N/A |
+| **Should** have 4.5:1 contrast ratio | `red-60` against white 5.48:1, `blue-60` against white 9.11:1, `gray-20` against black 18.57:1                                                        | Implementation: DONE<br />Tests: N/A  |
 | **Should** have an accessible name   | Can be named by a label specified by `aria-label` prop or a value (`IDREF`) set for the `aria-labelledby` prop that refers to a visible dialog title. | Implementation: DONE<br />Tests: DONE |
 
 ### Usage


### PR DESCRIPTION
Darken colors of counter to meet accessibile contrast:
- `blue-50` -> `blue-60`
- `red-50` -> `red-60`

<img width="507" alt="Screenshot 2022-05-20 at 15 25 17" src="https://user-images.githubusercontent.com/60467496/170286637-0abb125c-4f36-40ba-9489-62707d86db52.png">
