### PR TITLE
Deprecate Footer

### DIFF
--- a/deprecated.json
+++ b/deprecated.json
@@ -4,6 +4,8 @@
     { "componentName": "ContentBox", "className": "sg-content-box" },
     { "componentName": "ActionList", "className": "sg-actions-list" },
     { "componentName": "MenuList", "className": "sg-menu-list" },
-    { "componentName": "PopupMenu", "className": "sg-popup-menu" }
+    { "componentName": "PopupMenu", "className": "sg-popup-menu" },
+    { "componentName": "Footer", "className": "sg-footer"},
+    { "componentName": "FooterLine", "className": "sg-footer__line"}
   ]
 }

--- a/src/components/action-list/pages/action-list-interactive.jsx
+++ b/src/components/action-list/pages/action-list-interactive.jsx
@@ -6,6 +6,7 @@ import Text, {TEXT_TYPE} from 'text/Text';
 
 import ActionListHole from '../ActionListHole';
 import DocsActiveBlock from 'components/DocsActiveBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 
 const ActionLists = () => {
   const settings = [
@@ -29,6 +30,7 @@ const ActionLists = () => {
 
   return (
     <div>
+      <DeprecatedNote />
       <DocsActiveBlock settings={settings}>
         <ActionList>
           <ActionListHole>

--- a/src/components/action-list/pages/action-list.jsx
+++ b/src/components/action-list/pages/action-list.jsx
@@ -8,6 +8,7 @@ import Text, {TEXT_TYPE, TEXT_SIZE, TEXT_WEIGHT} from 'text/Text';
 
 import ContrastBox from 'components/ContrastBox';
 import DocsBlock from 'components/DocsBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 import ActionListHole, {ACTION_LIST_HOLE_SPACING} from '../ActionListHole';
 import SeparatorVertical, {
   SIZE as SEPARATOR_VERTICAL_SIZE,
@@ -17,17 +18,12 @@ import ContentBoxContent, {
   ALIGNMENT as CB_ALIGNMENT,
 } from 'content-box/ContentBoxContent';
 import Radio from 'form-elements/Radio';
-import Link from 'text/Link';
-import Flex from 'flex/Flex';
 
 const ActionLists = () => (
   <div>
-    <Flex marginBottom="m">
-      <Text color="text-red-60">
-        This component is deprecated, please use{' '}
-        <Link href="./containers.html#flexbox">Flex</Link> instead
-      </Text>
-    </Flex>
+    <DeprecatedNote
+      replacement={{componentName: 'Flex', href: './containers.html#flexbox'}}
+    />
     <DocsBlock info="Default">
       <ContrastBox fullWidth>
         <ActionList>

--- a/src/components/content-box/pages/content-box-interactive.jsx
+++ b/src/components/content-box/pages/content-box-interactive.jsx
@@ -9,6 +9,7 @@ import Text from 'text/Text';
 import Headline, {HEADLINE_TYPE} from 'text/Headline';
 import SeparatorVertical from 'separators/SeparatorVertical';
 import DocsActiveBlock from 'components/DocsActiveBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 
 const ContentBoxes = () => {
   const settings = [
@@ -28,6 +29,7 @@ const ContentBoxes = () => {
 
   return (
     <div>
+      <DeprecatedNote />
       <DocsActiveBlock settings={settings}>
         <ContentBox>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam vel dui

--- a/src/components/content-box/pages/content-box.jsx
+++ b/src/components/content-box/pages/content-box.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import DocsBlock from 'components/DocsBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 import ContentBox from '../ContentBox';
 import ContentBoxActions, {SIZE, ALIGNMENT} from '../ContentBoxActions';
 import ContentBoxTitle from '../ContentBoxTitle';
@@ -14,7 +15,6 @@ import Icon, {ICON_COLOR} from 'icons/Icon';
 import Link from 'text/Link';
 import Headline, {HEADLINE_TYPE, HEADLINE_SIZE} from 'text/Headline';
 import SeparatorVertical from 'separators/SeparatorVertical';
-import Flex from 'flex/Flex';
 
 const link1 = (
   <Link href="#" color="text-gray-70">
@@ -145,12 +145,9 @@ const examplePart2 = (
 
 const ContentBoxes = () => (
   <div>
-    <Flex marginBottom="m">
-      <Text color="text-red-60">
-        This component is deprecated, please use{' '}
-        <Link href="./containers.html#flexbox">Flex</Link> instead
-      </Text>
-    </Flex>
+    <DeprecatedNote
+      replacement={{componentsName: 'Flex', href: './containers.html#flexbox'}}
+    />
     <DocsBlock info="Simple with header">
       <ContentBox>
         <ContentBoxHeader>

--- a/src/components/footer/Footer.a11y.spec.jsx
+++ b/src/components/footer/Footer.a11y.spec.jsx
@@ -1,0 +1,9 @@
+import * as React from 'react';
+import {testA11y} from '../../axe';
+import Footer from './Footer';
+
+describe('Footer a11y', () => {
+  it('should have no a11y violations', async () => {
+    await testA11y(<Footer>item</Footer>);
+  });
+});

--- a/src/components/footer/Footer.jsx
+++ b/src/components/footer/Footer.jsx
@@ -9,6 +9,8 @@ export type FooterPropsType = {
   ...
 };
 
+// This component is deprecated
+
 const Footer = ({children, className, ...props}: FooterPropsType) => {
   const footerClass = classNames('sg-footer', className);
 

--- a/src/components/footer/Footer.stories.mdx
+++ b/src/components/footer/Footer.stories.mdx
@@ -1,6 +1,7 @@
 import {ArgsTable, Meta, Story, Canvas} from '@storybook/addon-docs';
 import Footer from './Footer';
 import FooterLine from './FooterLine';
+import FooterA11y from './stories/Footer.a11y.mdx';
 
 <Meta
   title="Components/Footer"
@@ -24,6 +25,7 @@ import FooterLine from './FooterLine';
 # Footer
 
 - [Stories](#stories)
+- [Accessibility](#accessibility)
 
 ## Overview
 
@@ -50,3 +52,7 @@ import FooterLine from './FooterLine';
     )}
   </Story>
 </Canvas>
+
+## Accessibility
+
+<FooterA11y />

--- a/src/components/footer/FooterLine.jsx
+++ b/src/components/footer/FooterLine.jsx
@@ -9,6 +9,8 @@ export type FooterLinePropsType = {
   ...
 };
 
+// This component is deprecated
+
 const FooterLine = ({children, className, ...props}: FooterLinePropsType) => {
   const footerClass = classNames('sg-footer__line', className);
 

--- a/src/components/footer/pages/footer-interactive.jsx
+++ b/src/components/footer/pages/footer-interactive.jsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import DocsActiveBlock from 'components/DocsActiveBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 import Footer from '../Footer';
 import FooterLine from '../FooterLine';
 import Text, {TEXT_TYPE, TEXT_SIZE, TEXT_WEIGHT} from 'text/Text';
@@ -12,6 +13,7 @@ const Footers = () => {
 
   return (
     <div>
+      <DeprecatedNote />
       <DocsActiveBlock settings={settings}>
         <Footer>
           <FooterLine>line</FooterLine>

--- a/src/components/footer/pages/footer.jsx
+++ b/src/components/footer/pages/footer.jsx
@@ -3,12 +3,16 @@ import DocsBlock from 'components/DocsBlock';
 import Footer from '../Footer';
 import FooterLine from '../FooterLine';
 import Text, {TEXT_TYPE, TEXT_SIZE, TEXT_WEIGHT} from 'text/Text';
+import Flex from '../../flex/Flex';
 
 import Link from 'text/Link';
 import Breadcrumb from 'breadcrumb/Breadcrumb';
 
 const Footers = () => (
   <div>
+    <Flex marginBottom="m">
+      <Text color="text-red-60">This component is deprecated</Text>
+    </Flex>
     <DocsBlock info="Standard">
       <Footer>
         <FooterLine>line</FooterLine>

--- a/src/components/footer/pages/footer.jsx
+++ b/src/components/footer/pages/footer.jsx
@@ -1,18 +1,16 @@
 import * as React from 'react';
 import DocsBlock from 'components/DocsBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 import Footer from '../Footer';
 import FooterLine from '../FooterLine';
 import Text, {TEXT_TYPE, TEXT_SIZE, TEXT_WEIGHT} from 'text/Text';
-import Flex from '../../flex/Flex';
 
 import Link from 'text/Link';
 import Breadcrumb from 'breadcrumb/Breadcrumb';
 
 const Footers = () => (
   <div>
-    <Flex marginBottom="m">
-      <Text color="text-red-60">This component is deprecated</Text>
-    </Flex>
+    <DeprecatedNote />
     <DocsBlock info="Standard">
       <Footer>
         <FooterLine>line</FooterLine>

--- a/src/components/footer/stories/Footer.a11y.mdx
+++ b/src/components/footer/stories/Footer.a11y.mdx
@@ -1,0 +1,6 @@
+<p>
+  <mark>
+    Footer is <strong>deprecated</strong> and does not have any accessibility
+    support.
+  </mark>
+</p>

--- a/src/components/icon-as-button/pages/icon-as-button-interactive.jsx
+++ b/src/components/icon-as-button/pages/icon-as-button-interactive.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import IconAsButton, {TYPE, ICON_COLOR, SIZE} from '../IconAsButton';
 import Counter from 'counters/Counter';
 import DocsActiveBlock from 'components/DocsActiveBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 import Avatar, {SIZE as AVATAR_SIZE} from 'avatar/Avatar';
 
 const IconsAsButtons = () => {
@@ -42,6 +43,7 @@ const IconsAsButtons = () => {
 
   return (
     <div>
+      <DeprecatedNote />
       <DocsActiveBlock settings={settings}>
         <IconAsButton
           color={ICON_COLOR['icon-gray-70']}

--- a/src/components/icon-as-button/pages/icon-as-button.jsx
+++ b/src/components/icon-as-button/pages/icon-as-button.jsx
@@ -1,22 +1,17 @@
 import * as React from 'react';
 import DocsBlock from 'components/DocsBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 import {TYPE, ICON_COLOR, SIZE} from '../IconAsButton';
-import Text from '../../text/Text';
-import Link from '../../text/Link';
-import Flex from '../../flex/Flex';
 import DrawHelper from './DrawHelper';
 
 const icons = () => (
   <div>
-    <Flex marginBottom="m">
-      <Text color="text-red-60">
-        This component is deprecated, please use{' '}
-        <Link href="./components.html#buttons">
-          Buttons with iconOnly option
-        </Link>{' '}
-        instead
-      </Text>
-    </Flex>
+    <DeprecatedNote
+      replacement={{
+        componentName: 'Button with iconOnly option',
+        href: './components.html#buttons',
+      }}
+    />
     <DocsBlock info="Normal">
       <ul className="icons-list">
         {Object.values(ICON_COLOR).map(color => (

--- a/src/components/list/pages/list.jsx
+++ b/src/components/list/pages/list.jsx
@@ -8,7 +8,6 @@ import ListItem from '../ListItem';
 import ListItemIcon from '../ListItemIcon';
 import Icon, {TYPE as ICON_TYPE, ICON_COLOR} from '../../icons/Icon';
 import Text, {TEXT_SIZE} from 'text/Text';
-import Flex from '../../flex/Flex';
 
 import MenuList, {SIZE} from '../MenuList';
 

--- a/src/components/list/pages/list.jsx
+++ b/src/components/list/pages/list.jsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import DocsBlock from 'components/DocsBlock';
 import ContentBox from 'content-box/ContentBox';
 import ContrastBox from 'components/ContrastBox';
+import DeprecatedNote from 'components/DeprecatedNote';
 import List from '../List';
 import ListItem from '../ListItem';
 import ListItemIcon from '../ListItemIcon';
@@ -28,14 +29,6 @@ const menuItem1 = {text: firstString, href: '#'};
 const menuItem2 = {text: secondString, href: '#'};
 const menuItem3 = {text: thirdString, href: '#'};
 const menuItems = [menuItem1, menuItem2, menuItem3];
-
-const componentIsDeprecated = (
-  <Flex marginBottom="m">
-    <Text color="text-red-60" size="small">
-      This component is deprecated
-    </Text>
-  </Flex>
-);
 
 const ListItems = () => (
   <div>
@@ -133,7 +126,7 @@ const ListItems = () => (
     <div>
       <DocsBlock
         info="Menu list (deprecated)"
-        additionalInfo={componentIsDeprecated}
+        additionalInfo={<DeprecatedNote />}
       >
         <ContentBox>
           <MenuList items={menuItems} />
@@ -141,7 +134,7 @@ const ListItems = () => (
       </DocsBlock>
       <DocsBlock
         info="Menu list - small (deprecated)"
-        additionalInfo={componentIsDeprecated}
+        additionalInfo={<DeprecatedNote />}
       >
         <ContentBox>
           <MenuList items={menuItems} size={SIZE.SMALL} />
@@ -149,7 +142,7 @@ const ListItems = () => (
       </DocsBlock>
       <DocsBlock
         info="Menu list - large (deprecated)"
-        additionalInfo={componentIsDeprecated}
+        additionalInfo={<DeprecatedNote />}
       >
         <ContentBox>
           <MenuList items={menuItems} size={SIZE.LARGE} />

--- a/src/components/popup-menu/pages/popup-menu-interactive.jsx
+++ b/src/components/popup-menu/pages/popup-menu-interactive.jsx
@@ -4,6 +4,7 @@ import IconAsButton, {ICON_COLOR, TYPE} from 'icon-as-button/IconAsButton';
 import Button from 'buttons/Button';
 import Avatar from 'avatar/Avatar';
 import DocsActiveBlock from 'components/DocsActiveBlock';
+import DeprecatedNote from 'components/DeprecatedNote';
 
 const PopupMenus = () => {
   const settings = [
@@ -15,6 +16,7 @@ const PopupMenus = () => {
 
   return (
     <div>
+      <DeprecatedNote />
       <DocsActiveBlock settings={settings}>
         <PopupMenu
           items={[

--- a/src/components/popup-menu/pages/popup-menu.jsx
+++ b/src/components/popup-menu/pages/popup-menu.jsx
@@ -4,17 +4,14 @@ import IconAsButton, {ICON_COLOR, TYPE} from 'icon-as-button/IconAsButton';
 import Button from 'buttons/Button';
 import DocsBlock from 'components/DocsBlock';
 import ContrastBox from 'components/ContrastBox';
+import DeprecatedNote from 'components/DeprecatedNote';
 import Avatar from 'avatar/Avatar';
-import Text from '../../text/Text';
-import Flex from '../../flex/Flex';
 
 const items = ['one', 'two', 'three'];
 
 const PopupsMenus = () => (
   <div>
-    <Flex marginBottom="m">
-      <Text color="text-red-60">This component is deprecated</Text>
-    </Flex>
+    <DeprecatedNote />
     <DocsBlock info="Default">
       <PopupMenu items={items} />
     </DocsBlock>

--- a/src/docs/components/DeprecatedNote.jsx
+++ b/src/docs/components/DeprecatedNote.jsx
@@ -1,0 +1,30 @@
+// @flow
+
+import * as React from 'react';
+import Text from 'text/Text';
+import Link from 'text/Link';
+import Flex from 'flex/Flex';
+
+type PropsType = {
+  replacement?: {
+    componentName: string,
+    href: string,
+  },
+};
+
+const DeprecatedNote = ({replacement}: PropsType) => (
+  <Flex marginBottom="m">
+    <Text color="text-red-60">
+      This component is deprecated
+      {replacement && (
+        <span>
+          , please use{' '}
+          <Link href={replacement.href}>{replacement.componentName}</Link>{' '}
+          instead
+        </span>
+      )}
+    </Text>
+  </Flex>
+);
+
+export default DeprecatedNote;

--- a/src/docs/components/DeprecatedNote.jsx
+++ b/src/docs/components/DeprecatedNote.jsx
@@ -14,12 +14,14 @@ type PropsType = {
 
 const DeprecatedNote = ({replacement}: PropsType) => (
   <Flex marginBottom="m">
-    <Text color="text-red-60">
+    <Text color="text-red-60" size="small">
       This component is deprecated
       {replacement && (
         <span>
           , please use{' '}
-          <Link href={replacement.href}>{replacement.componentName}</Link>{' '}
+          <Link href={replacement.href} weight="bold" inherited>
+            {replacement.componentName}
+          </Link>{' '}
           instead
         </span>
       )}

--- a/src/docs/navigation.js
+++ b/src/docs/navigation.js
@@ -267,7 +267,7 @@ const navigation = [
         component: header,
       },
       {
-        name: 'Footer',
+        name: 'Footer (deprecated)',
         component: footer,
       },
       {


### PR DESCRIPTION
The Brainly web app does not use Footer so we decided to deprecate it. 

- Footer deprecated:
    - notes in old docs added
    - a short note in accessibility documentation added
    - axe test for Footer added
    - Footer to `deprecated.json` added
 - better information in the old documentation about the component being deprecated:
     - new component `<DeprecatedNote/>` 
     - info on the interactive subpage


<img width="912" alt="Screenshot 2022-05-31 at 13 15 51" src="https://user-images.githubusercontent.com/60467496/171161226-68bce74a-c20a-4004-a6ef-cc54a84c8f28.png">

<img width="704" alt="Screenshot 2022-05-31 at 13 19 05" src="https://user-images.githubusercontent.com/60467496/171161727-2de8f933-d1c1-431c-9e81-8542cfad54f4.png">

