### PR TITLE
fix regex to not remove any styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "215.0.1",
+  "version": "215.1.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -177,7 +177,7 @@ let finalTypes = fs
   .readFileSync(path.resolve(TYPES_DIR, 'brainly-style-guide.d.ts'))
   .toString();
 
-finalTypes = finalTypes.replace(/React_\d/g, 'React');
+finalTypes = finalTypes.replace(/React_\d\./g, 'React.');
 
 fs.writeFileSync(
   path.resolve(TYPES_DIR, 'brainly-style-guide.d.ts'),

--- a/scripts/build-types.js
+++ b/scripts/build-types.js
@@ -177,7 +177,7 @@ let finalTypes = fs
   .readFileSync(path.resolve(TYPES_DIR, 'brainly-style-guide.d.ts'))
   .toString();
 
-finalTypes = finalTypes.replace(/(?<=React).*(?=\.)/g, '');
+finalTypes = finalTypes.replace(/React_\d/g, 'React');
 
 fs.writeFileSync(
   path.resolve(TYPES_DIR, 'brainly-style-guide.d.ts'),


### PR DESCRIPTION
This is fix to other fix https://github.com/brainly/style-guide/pull/2451.

Due to bad regexp some styles are being removed when generating typescript types. I'm narrowing it to only remove React_2 or with other digit.