### PR TITLE
fix missing assets links on storybook introduction page

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -2,6 +2,8 @@ const path = require('path');
 const glob = require('glob');
 const webpackConfigFn = require('../webpack.config');
 const webpackConfig = webpackConfigFn();
+const pkg = require('../package.json');
+const fs = require('fs');
 
 process.env.STORYBOOK_ENV = process.env.STORYBOOK_ENV || 'dev';
 
@@ -40,6 +42,37 @@ module.exports = {
 
     // support for aliases
     config.resolve.modules.push(...webpackConfig.resolve.modules);
+
+    let revManifestPath;
+
+    const pathToVersionedManifest = path.resolve(
+      __dirname,
+      '../',
+      'dist',
+      pkg.version,
+      'rev-manifest.json'
+    );
+    const pathToDevManifest = path.resolve(
+      __dirname,
+      '../',
+      'dist',
+      'dev',
+      'rev-manifest.json'
+    );
+
+    revManifestPath = [pathToVersionedManifest, pathToDevManifest].find(path =>
+      fs.existsSync(path)
+    );
+
+    if (!revManifestPath) {
+      throw new Error(`rev-manifest.json not found in paths:
+      ${pathToVersionedManifest}
+      ${pathToDevManifest}.
+      Run 'yarn build'.`);
+    }
+
+    // alias for finger printed asset urls
+    config.resolve.alias.RevManifest = revManifestPath;
 
     return config;
   },

--- a/src/_docs/stories/introduction.stories.mdx
+++ b/src/_docs/stories/introduction.stories.mdx
@@ -9,6 +9,7 @@ import Logo from 'logo/Logo';
 import Flex from 'flex/Flex';
 import OverlayedBox from 'overlayed-box/OverlayedBox';
 import {Source} from '@storybook/components';
+import revManifest from 'RevManifest';
 
 <Meta title="Introduction ✏️/Getting Started" />
 
@@ -111,35 +112,35 @@ For our icons include this scripts before the closing `</body>` tag:
 
 <Source
   type="html"
-  code={`<link href='https://styleguide.brainly.com/%%images/icons.js%%' rel='stylesheet'/>`}
+  code={`<link href='https://styleguide.brainly.com/${revManifest['images/icons.js']}' rel='stylesheet'/>`}
 />
 
 **Subject Icons**
 
 <Source
   type="html"
-  code={`<link href='https://styleguide.brainly.com/%%images/subject-icons.js%%' rel='stylesheet'/>`}
+  code={`<link href='https://styleguide.brainly.com/${revManifest['images/subjects-icons.js']}' rel='stylesheet'/>`}
 />
 
 **Subject Mono Icons**
 
 <Source
   type="html"
-  code={`<link href='https://styleguide.brainly.com/%%images/subject-mono-icons.js%%' rel='stylesheet'/>`}
+  code={`<link href='https://styleguide.brainly.com/${revManifest['images/subjects-mono-icons.js']}' rel='stylesheet'/>`}
 />
 
 **Math Symbols**
 
 <Source
   type="html"
-  code={`<link href='https://styleguide.brainly.com/%%images/math-symbols-icons.js%%' rel='stylesheet'/>`}
+  code={`<link href='https://styleguide.brainly.com/${revManifest['images/math-symbols-icons.js']}' rel='stylesheet'/>`}
 />
 
 **Mobile Icons**
 
 <Source
   type="html"
-  code={`<link href='https://styleguide.brainly.com/%%images/mobile-icons.js%%' rel='stylesheet'/>`}
+  code={`<link href='https://styleguide.brainly.com/${revManifest['images/mobile-icons.js']}' rel='stylesheet'/>`}
 />
 
 ## More


### PR DESCRIPTION
This change is fixing links on storybook introduction page. Now before running storybook, we have to first build project to generate manifest file with all hashed asset paths. If not, error is thrown and appropriate message is displayed.

<img width="1033" alt="Screenshot 2022-06-28 at 15 44 59" src="https://user-images.githubusercontent.com/25419830/176194431-a1b2d9c5-2ede-4300-8ef2-faa2f55091ee.png">
