### PR TITLE
Fix chromatic story for SkipLink

### DIFF
--- a/src/components/skip-link/SkipLink.chromatic.stories.jsx
+++ b/src/components/skip-link/SkipLink.chromatic.stories.jsx
@@ -1,7 +1,11 @@
 import * as SkipLink from './SkipLink.stories.mdx';
 import {mergeStories} from '../../chromatic/utils';
 
-export const Default = mergeStories(SkipLink);
+const {play, ...SkipLinkStories} = SkipLink;
+
+export const Default = mergeStories(SkipLinkStories);
+
+Default.play = play;
 
 const {includeStories, ...meta} = SkipLink.default;
 

--- a/src/components/skip-link/SkipLink.stories.mdx
+++ b/src/components/skip-link/SkipLink.stories.mdx
@@ -1,11 +1,12 @@
 import {ArgsTable, Meta, Story, Canvas} from '@storybook/addon-docs';
-import {screen, userEvent} from '@storybook/testing-library';
+import {within} from '@storybook/testing-library';
 
 import SkipLink from './SkipLink';
 import SkipLinkA11y from './stories/SkipLink.a11y.mdx';
 
-export const play = async () => {
-  const link = await screen.getByRole('link', {
+export const play = async ({canvasElement}) => {
+  const canvas = within(canvasElement);
+  const link = canvas.getByRole('link', {
     name: /skip to main content/i,
   });
   link.focus();

--- a/src/components/skip-link/SkipLink.stories.mdx
+++ b/src/components/skip-link/SkipLink.stories.mdx
@@ -4,6 +4,13 @@ import {screen, userEvent} from '@storybook/testing-library';
 import SkipLink from './SkipLink';
 import SkipLinkA11y from './stories/SkipLink.a11y.mdx';
 
+export const play = async () => {
+  const link = await screen.getByRole('link', {
+    name: /skip to main content/i,
+  });
+  link.focus();
+};
+
 <Meta title="Components/SkipLink" component={SkipLink} />
 
 # Skiplink
@@ -13,13 +20,7 @@ import SkipLinkA11y from './stories/SkipLink.a11y.mdx';
 ## Overview
 
 <Canvas>
-  <Story
-    name="default"
-    play={() => {
-      const link = screen.getByRole('link', {name: /skip to main content/i});
-      link.focus();
-    }}
-  >
+  <Story name="default" play={play}>
     {args => {
       return (
         <div>


### PR DESCRIPTION
Reuse play function within chromatic story to make `SkipLink` component shown up when chromatic screenshot is taken.  

![CleanShot 2022-06-30 at 20 30 46](https://user-images.githubusercontent.com/8572321/176752043-cd5f8645-8c1a-4eed-90fc-aba183424553.png)

![CleanShot 2022-06-30 at 20 40 36](https://user-images.githubusercontent.com/8572321/176753785-ac4de031-4211-4c8d-8395-5380f0e2626b.png)

