### PR TITLE
Transition Component - Fire Callbacks After Instant Animation

### DIFF
--- a/src/components/transition/CSSTransitionAnimator.js
+++ b/src/components/transition/CSSTransitionAnimator.js
@@ -51,7 +51,7 @@ export function createCSSTransitionAnimator(
   let remainingPropsToChange: number = 0;
   let finishCallbackRef = null;
 
-  function executeTransition(
+  function addTransitionStyles(
     element: HTMLElement,
     from?: PropertyObjectType,
     to?: PropertyObjectType,
@@ -250,7 +250,7 @@ export function createCSSTransitionAnimator(
       to?: PropertyObjectType,
       speed?: number
     ) => {
-      const {instant} = executeTransition(element, from, to, speed);
+      const {instant} = addTransitionStyles(element, from, to, speed);
 
       if (instant) {
         remainingPropsToChange = 0;
@@ -261,7 +261,8 @@ export function createCSSTransitionAnimator(
       }
     },
     apply: (element: HTMLElement, props?: PropertyObjectType) => {
-      executeTransition(element, props, undefined, undefined);
+      addTransitionStyles(element, props, undefined, undefined);
+      remainingPropsToChange = 0; // to not fire any callback
     },
     cleanup: (element: HTMLElement) => {
       pushState(DEFAULT_PARSED_PROPS);

--- a/src/components/transition/CSSTransitionAnimator.js
+++ b/src/components/transition/CSSTransitionAnimator.js
@@ -207,19 +207,10 @@ export function createCSSTransitionAnimator(
        */
       const willChangeProps = getWillChangeProps();
 
-      /**
-       * Only the optional "to" props are "transitioned" and
-       * defined can try to execute an animation with a zero
-       * duration that won't trigger a transitionEnd event.
-       */
-      const instant = isInstantTransition(toParsedProps, willChangeProps);
-
-      if (!instant) {
-        remainingPropsToChange = Object.keys(willChangeProps).reduce(
-          (sum, prop) => sum + Number(willChangeProps[prop]),
-          0
-        );
-      }
+      remainingPropsToChange = Object.keys(willChangeProps).reduce(
+        (sum, prop) => sum + Number(willChangeProps[prop]),
+        0
+      );
 
       if (fromParsedProps !== undefined) {
         addElementStyles({
@@ -243,8 +234,17 @@ export function createCSSTransitionAnimator(
         });
       }
 
-      if (instant && finishCallbackRef) {
-        finishCallbackRef();
+      /**
+       * Only the optional "to" props are "transitioned" and
+       * defined can try to execute an animation with a zero
+       * duration that won't trigger a transitionEnd event.
+       */
+      if (isInstantTransition(toParsedProps, willChangeProps)) {
+        remainingPropsToChange = 0;
+
+        if (finishCallbackRef) {
+          finishCallbackRef();
+        }
       }
     },
 

--- a/src/components/transition/CSSTransitionAnimator.js
+++ b/src/components/transition/CSSTransitionAnimator.js
@@ -163,6 +163,11 @@ export function createCSSTransitionAnimator(
     return value / speed + units;
   }
 
+  /**
+   * The instant transition is that defined
+   * with a zero duration that won't trigger
+   * a native transitionEnd event.
+   */
   function isInstantTransition(
     parsedProps?: ParsedPropertyObjectType,
     willChangeProps: CSSTransitionedPropsType

--- a/src/components/transition/CSSTransitionAnimator.js
+++ b/src/components/transition/CSSTransitionAnimator.js
@@ -172,16 +172,12 @@ export function createCSSTransitionAnimator(
     parsedProps?: ParsedPropertyObjectType,
     willChangeProps: CSSTransitionedPropsType
   ) {
-    if (parsedProps === undefined) {
-      return true;
-    }
+    if (parsedProps !== undefined) {
+      const someDuration = Object.keys(willChangeProps).some(
+        prop => parsedProps[prop].duration !== '0ms'
+      );
 
-    const props = Object.keys(willChangeProps);
-
-    for (let i = 0; i < props.length; i++) {
-      if (parsedProps[props[i]].duration !== '0ms') {
-        return false;
-      }
+      return someDuration === false;
     }
 
     return true;

--- a/src/components/transition/CSSTransitionAnimator.js
+++ b/src/components/transition/CSSTransitionAnimator.js
@@ -173,11 +173,9 @@ export function createCSSTransitionAnimator(
     willChangeProps: CSSTransitionedPropsType
   ) {
     if (parsedProps !== undefined) {
-      const someDuration = Object.keys(willChangeProps).some(
+      return !Object.keys(willChangeProps).some(
         prop => parsedProps[prop].duration !== '0ms'
       );
-
-      return someDuration === false;
     }
 
     return true;

--- a/src/components/transition/CSSTransitionAnimator.spec.js
+++ b/src/components/transition/CSSTransitionAnimator.spec.js
@@ -244,4 +244,27 @@ describe('createCSSTransitionAnimator()', () => {
     animator.propertyTransitionEnd();
     expect(callback).toHaveBeenCalledTimes(1);
   });
+
+  it('calls onFinish callback after instant animation', () => {
+    const callback = jest.fn();
+    const animator = createCSSTransitionAnimator(classNamesRegistry);
+    const element = document.createElement('div');
+
+    animator.onFinish(callback);
+    animator.animate(
+      element,
+      {
+        transform: {translateY: 24},
+        opacity: 0,
+      },
+      {
+        transform: {translateY: 0},
+        opacity: {value: 1},
+        duration: 'instant',
+      }
+    );
+
+    // the propertyTransitionEnd callback shouldn't be fired
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/components/transition/CSSTransitionAnimator.spec.js
+++ b/src/components/transition/CSSTransitionAnimator.spec.js
@@ -267,4 +267,32 @@ describe('createCSSTransitionAnimator()', () => {
     // the propertyTransitionEnd callback shouldn't be fired
     expect(callback).toHaveBeenCalledTimes(1);
   });
+
+  it('does not fire onFinish callback after many apply methods', () => {
+    const callback = jest.fn();
+    const animator = createCSSTransitionAnimator(classNamesRegistry);
+    const element = document.createElement('div');
+
+    animator.onFinish(callback);
+    animator.apply(element, {
+      opacity: 0,
+      duration: 'quick2',
+    });
+
+    animator.apply(element, {
+      opacity: 0.5,
+      duration: 'quick2',
+    });
+
+    animator.apply(element, {
+      opacity: 1,
+      duration: 'quick2',
+    });
+
+    animator.propertyTransitionEnd();
+    animator.propertyTransitionEnd();
+    animator.propertyTransitionEnd();
+    animator.propertyTransitionEnd();
+    expect(callback).toHaveBeenCalledTimes(0);
+  });
 });

--- a/src/components/transition/Transition.jsx
+++ b/src/components/transition/Transition.jsx
@@ -258,7 +258,7 @@ function BaseTransition({
     }
 
     if (supportsTransitions() && isFillModeBackwards(fillMode)) {
-      animator.animate(container, rules.from);
+      animator.apply(container, rules.from);
     }
 
     const performTransitionEffect = () => {

--- a/src/components/transition/Transition.spec.jsx
+++ b/src/components/transition/Transition.spec.jsx
@@ -130,7 +130,7 @@ describe('<Transition />', () => {
     expect(effectFunction).toHaveBeenCalledWith(false);
   });
 
-  fit('fires onTransitionEnd after instant transition', () => {
+  it('fires onTransitionEnd after instant transition', () => {
     const onTransitionEnd = jest.fn();
 
     mount(

--- a/src/components/transition/Transition.spec.jsx
+++ b/src/components/transition/Transition.spec.jsx
@@ -21,8 +21,14 @@ const EXIT_OPACITY = '0.3';
 
 const testEffect = {
   initial: {opacity: INITIAL_OPACITY},
-  animate: {opacity: ANIMATE_OPACITY},
-  exit: {opacity: EXIT_OPACITY},
+  animate: {opacity: ANIMATE_OPACITY, duration: 'quick2'},
+  exit: {opacity: EXIT_OPACITY, duration: 'quick2'},
+};
+
+const instantEffect = {
+  initial: {opacity: INITIAL_OPACITY},
+  animate: {opacity: ANIMATE_OPACITY, duration: 'instant'},
+  exit: {opacity: EXIT_OPACITY, duration: 'instant'},
 };
 
 describe('<Transition />', () => {
@@ -62,7 +68,7 @@ describe('<Transition />', () => {
       />
     );
 
-    expect(onTransitionStart).toHaveBeenCalled();
+    expect(onTransitionStart).toHaveBeenCalledTimes(1);
   });
 
   it('fires onTransitionEnd as a fallback when not support transition', () => {
@@ -77,7 +83,7 @@ describe('<Transition />', () => {
       />
     );
 
-    expect(onTransitionEnd).toHaveBeenCalled();
+    expect(onTransitionEnd).toHaveBeenCalledTimes(1);
   });
 
   it.each`
@@ -122,5 +128,20 @@ describe('<Transition />', () => {
 
     expect(wrapper.getDOMNode().style.opacity).toBe(ANIMATE_OPACITY);
     expect(effectFunction).toHaveBeenCalledWith(false);
+  });
+
+  fit('fires onTransitionEnd after instant transition', () => {
+    const onTransitionEnd = jest.fn();
+
+    mount(
+      <Transition
+        effect={instantEffect}
+        onTransitionEnd={onTransitionEnd}
+        fillMode="both"
+        active
+      />
+    );
+
+    expect(onTransitionEnd).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/transition/propertyObjectAnimator.js
+++ b/src/components/transition/propertyObjectAnimator.js
@@ -9,6 +9,7 @@ export interface PropertyObjectAnimatorType {
     to?: PropertyObjectType,
     speed?: number
   ): void;
+  apply(element: HTMLElement, props?: PropertyObjectType): void;
   cleanup(element: HTMLElement): void;
   propertyTransitionEnd(): void;
   onFinish(callback: () => void): void;

--- a/src/components/transition/stories/OffsetBehavior.jsx
+++ b/src/components/transition/stories/OffsetBehavior.jsx
@@ -47,6 +47,11 @@ const contentCounterSlideEffect = {
     transform: {scaleY: 1, duration: 'gentle1', origin: 'left top'},
     easing: 'entry',
   },
+  exit: {
+    opacity: 0,
+    duration: 'quick2',
+    easing: 'exit',
+  },
 };
 
 export const OffsetBehavior = () => {


### PR DESCRIPTION
When `effect` does not define one of the optional phases like `initial`, `animate`, or `exit`, they become "instant" via default values. This is correct behavior for a CSS Transition. For example, when a user doesn't care about the exit transition they skip it but the `onTransitionEnd` callback should be called anyway. The current implementation relies on CSS Transition that doesn't trigger events for transition with a zero duration. It produces a bug when skipped phases won't trigger proper callbacks.

### before

https://user-images.githubusercontent.com/13873576/177271413-fcee004a-b023-40c8-b387-9ab00a7357be.mp4

### after

https://user-images.githubusercontent.com/13873576/177271445-0bd8c1a1-6363-45b2-b6b6-71e6d92eb9a4.mp4

