### PR TITLE
Replace <mark> with InfoBox component in mdx

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,6 +11,7 @@ import hex from '../src/components/colors/hex';
 
 import {Primary} from 'blocks/Primary';
 import {Stories} from 'blocks/Stories';
+import {InfoBox} from 'blocks/InfoBox';
 
 // load all styles
 import '../src/main.scss';
@@ -54,6 +55,9 @@ export const parameters = {
   docs: {
     page: Page,
     theme,
+    components: {
+      InfoBox,
+    },
   },
   controls: {hideNoControlsWarning: true},
   options: {

--- a/src/_docs/blocks/InfoBox.jsx
+++ b/src/_docs/blocks/InfoBox.jsx
@@ -1,0 +1,64 @@
+// @flow strict
+
+import * as React from 'react';
+import Box from '../../components/box/Box';
+import Text from '../../components/text/Text';
+import Flex from '../../components/flex/Flex';
+import Icon from '../../components/icons/Icon';
+
+export type InfoBoxType = 'warning' | 'info' | 'error';
+
+interface InfoBoxProps {
+  type?: InfoBoxType;
+  children: React.Node;
+}
+
+export const COLORS_MAP: {
+  info: 'blue-20',
+  warning: 'yellow-20',
+  error: 'red-20',
+} = {
+  info: 'blue-20',
+  warning: 'yellow-20',
+  error: 'red-20',
+};
+
+export const ICON_COLORS_MAP: {
+  info: 'icon-blue-50',
+  warning: 'icon-yellow-50',
+  error: 'icon-red-50',
+} = {
+  info: 'icon-blue-50',
+  warning: 'icon-yellow-50',
+  error: 'icon-red-50',
+};
+
+export const ICONS_MAP: {
+  info: 'info',
+  warning: 'warning',
+  error: 'clear',
+} = {
+  info: 'info',
+  warning: 'warning',
+  error: 'clear',
+};
+
+export const InfoBox = ({children, type = 'info'}: InfoBoxProps) => {
+  return (
+    <Flex marginBottom="l">
+      <Box padding="s" color={COLORS_MAP[type]} role="alert">
+        <Flex>
+          <Icon
+            size={16}
+            type={ICONS_MAP[type]}
+            color={ICON_COLORS_MAP[type]}
+            className="sbdocs-info-box-icon"
+          />
+          <Text size="small" color="text-black">
+            {children}
+          </Text>
+        </Flex>
+      </Box>
+    </Flex>
+  );
+};

--- a/src/_docs/blocks/InfoBox.jsx
+++ b/src/_docs/blocks/InfoBox.jsx
@@ -6,14 +6,14 @@ import Text from '../../components/text/Text';
 import Flex from '../../components/flex/Flex';
 import Icon from '../../components/icons/Icon';
 
-export type InfoBoxType = 'warning' | 'info' | 'error';
+type InfoBoxType = 'warning' | 'info' | 'error';
 
 interface InfoBoxProps {
   type?: InfoBoxType;
   children: React.Node;
 }
 
-export const COLORS_MAP: {
+const COLORS_MAP: {
   info: 'blue-20',
   warning: 'yellow-20',
   error: 'red-20',
@@ -23,7 +23,7 @@ export const COLORS_MAP: {
   error: 'red-20',
 };
 
-export const ICON_COLORS_MAP: {
+const ICON_COLORS_MAP: {
   info: 'icon-blue-50',
   warning: 'icon-yellow-50',
   error: 'icon-red-50',
@@ -33,7 +33,7 @@ export const ICON_COLORS_MAP: {
   error: 'icon-red-50',
 };
 
-export const ICONS_MAP: {
+const ICONS_MAP: {
   info: 'info',
   warning: 'warning',
   error: 'clear',

--- a/src/_docs/blocks/index.js
+++ b/src/_docs/blocks/index.js
@@ -1,3 +1,4 @@
+export {InfoBox} from './InfoBox';
 export {Badge} from './Badge';
 export {Canvas} from './Canvas';
 export {DocsStory} from './DocsStory';

--- a/src/_docs/styles.scss
+++ b/src/_docs/styles.scss
@@ -218,3 +218,8 @@ pre.prismjs {
 .docblock-source .prismjs {
   font-size: 14px;
 }
+
+.sbdocs .sbdocs-info-box-icon {
+  margin-top: 1px;
+  margin-right: 8px;
+}

--- a/src/components/avatar/stories/Avatar.a11y.mdx
+++ b/src/components/avatar/stories/Avatar.a11y.mdx
@@ -7,9 +7,7 @@
 | **Should** have role `img`                                                               |                                                 | Implementation: DONE<br />Tests: DONE   |
 | **Can** have an accessible name                                                          | Can be named by setting a value for `alt` prop. | Implementation: DONE<br />Tests: DONE   |
 
-<p>
-  <mark>By default, `Avatar` is treated as a decorative image.</mark>
-</p>
+<InfoBox>By default, `Avatar` is treated as a decorative image.</InfoBox>
 
 ### With a `link`
 
@@ -18,12 +16,10 @@
 | **Should** have an accessible name                     | Link should be named by setting a value for `ariaLinkLabel` prop. | Implementation: DONE<br />Tests: DONE |
 | **Should** be focusable and have a visible focus style | Browser focus style is used                                       | Implementation: DONE<br />Tests: DONE |
 
-<p>
-  <mark>
-    If `ariaLinkLabel` is not set, `Avatar` is removed from accessibility tree
-    and link is not accessible.
-  </mark>
-</p>
+<InfoBox type="warning">
+  If `ariaLinkLabel` is not set, `Avatar` is removed from accessibility tree and
+  link is not accessible.
+</InfoBox>
 
 ### Usage
 

--- a/src/components/card/stories/Card.a11y.mdx
+++ b/src/components/card/stories/Card.a11y.mdx
@@ -1,3 +1,3 @@
-<p>
-  <mark>Card is a visual component, no accessibility rules apply to it.</mark>
-</p>
+<InfoBox>
+  Card is a visual component, no accessibility rules apply to it.
+</InfoBox>

--- a/src/components/flex/Flex.a11y.mdx
+++ b/src/components/flex/Flex.a11y.mdx
@@ -4,8 +4,6 @@
 | ------------------------------- | ------------------------------------------------------------------- | ----------------------------------- |
 | **Should** have a logical order | Reading order is determined by the order of the elements in the DOM | Implementation: N/A<br />Tests: N/A |
 
-<p>
-  <mark>
-    Flex should comply with the rules defined by the <code>htmlTag</code>.
-  </mark>
-</p>
+<InfoBox>
+  Flex should comply with the rules defined by the <code>htmlTag</code>.
+</InfoBox>

--- a/src/components/header/stories/Header.a11y.mdx
+++ b/src/components/header/stories/Header.a11y.mdx
@@ -1,6 +1,4 @@
-<p>
-  <mark>
-    Header is <strong>deprecated</strong> and does not have any accessibility
-    support.
-  </mark>
-</p>
+<InfoBox type="warning">
+  Header is <strong>deprecated</strong> and does not have any accessibility
+  support.
+</InfoBox>

--- a/src/components/rating/Rating.a11y.mdx
+++ b/src/components/rating/Rating.a11y.mdx
@@ -1,8 +1,6 @@
-# Rating accessibility
+### Rules
 
-<br/>
-
-## Rating
+#### Rating
 
 | Pattern                                                                             | Comment                                                                                                                                                                                             | Status                                |
 | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
@@ -11,12 +9,13 @@
 | **Should** have accessible label describing current rate value                      | `aria-label` defaults to `"current rate"`                                                                                                                                                           | Implementation: DONE<br />Tests: DONE |
 | **Should** have accessible label describing rate action with min and max rate value | `{activeText}, min: 1, max: {metricSize}`                                                                                                                                                           | Implementation: DONE<br />Tests: DONE |
 
-> <mark>Using `noLabel` option will affect different people with visual impairments.
-> <br/>Omitting `activeText` for an active `Rating` results in a non-labelled `onChange` action.</mark>
+<InfoBox type="warning">
+  Using `noLabel` option will affect different people with visual impairments.
+  Omitting `activeText` for an active `Rating` results in a non-labelled
+  `onChange` action.
+</InfoBox>
 
-<br/>
-
-## Star
+#### Star
 
 | Pattern                                                              | Comment                            | Status                                |
 | -------------------------------------------------------------------- | ---------------------------------- | ------------------------------------- |
@@ -26,14 +25,9 @@
 | **Should** have `radio` role                                         |                                    | Implementation: DONE<br />Tests: DONE |
 | **Should** fire `onChange` on click, space and arrows (left & right) | It is not possible to test arrows. | Implementation: DONE<br />Tests: DONE |
 
-<br/>
-<br/>
+### Usage
 
-## Usage
-
-<br/>
-
-### Code examples
+#### Code examples
 
 - basic
 

--- a/src/components/text/Link.a11y.mdx
+++ b/src/components/text/Link.a11y.mdx
@@ -17,14 +17,11 @@
 | **Can** have an accessible label (and/or icon) that indicates opening in new tab                       |                                                                                                                                                                                        | Implementation: DONE<br />Tests: DONE   |
 | **Can** have an accessible label with file size&format (and/or icon) that indicates downloading a file |                                                                                                                                                                                        | Implementation: TO DO<br />Tests: TO DO |
 
-<!-- prettier-ignore -->
-<p>
-  <mark>
+<InfoBox>
   Element, that looks like a link, but doesn't cause the user agent to navigate
   to a new resource but have onClick listener is a button and should meet the
   accessibility requirements for <a href="#link-asbutton">Link as="button"</a>.
-  </mark>
-</p>
+</InfoBox>
 
 More can be found in [Typography documentation](/docs/foundation-✨-typography--page#accessibility)
 


### PR DESCRIPTION
Default <mark> style doesn't match the new storybook style - it is needed to replace with a custom component InfoBox.

before:
<img width="877" alt="Screenshot 2022-07-05 at 19 03 54" src="https://user-images.githubusercontent.com/60467496/177534951-e3bccb13-7b80-4988-9c53-549e76226132.png">

after:
<img width="899" alt="Screenshot 2022-07-06 at 12 55 17" src="https://user-images.githubusercontent.com/60467496/177534855-fd227c12-b0f1-4b37-82b1-42f812202242.png">
