### PR TITLE
fix unwanted deploys

### DIFF
--- a/.temp
+++ b/.temp
@@ -1,1 +1,0 @@
-/Users/bartoszadamczyk/Projects/style-guide/scripts/dist

--- a/.temp
+++ b/.temp
@@ -1,0 +1,1 @@
+/Users/bartoszadamczyk/Projects/style-guide/scripts/dist

--- a/scripts/build-s3.js
+++ b/scripts/build-s3.js
@@ -27,18 +27,18 @@ client.s3.getObject(
     Bucket: `styleguide-${env}.brainly.com`,
     Key: `${version}/style-guide.css`,
   },
-  function (err, data) {
+  function (err) {
     if (err) {
-      if (err.name === 'AccessDenied' || err.name === 'NoSuchKey') {
+      // NoSuchKey - we can list bucket files but file is not found
+      if (err.name === 'NoSuchKey') {
+        console.log(`${version}/style-guide.css is not found. Building files.`);
         buildFiles();
       } else {
-        console.log(err, err.stack);
+        console.error(err, err.stack);
       }
-    } else if (!data || (data && data.toString('utf-8') !== version)) {
-      buildFiles();
     } else {
       console.log(
-        'No version change detected in package.json, skipping storybook build.'
+        'No version change detected in package.json, skipping build.'
       );
     }
   }

--- a/scripts/build-s3.js
+++ b/scripts/build-s3.js
@@ -2,6 +2,8 @@ const {version} = require('../package.json');
 const s3 = require('@brainly/s3');
 const {execSync} = require('child_process');
 const argv = require('yargs').argv;
+const path = require('path');
+const fs = require('fs');
 
 if (argv.env && argv.env !== 'dev' && argv.env !== 'prod') {
   throw new Error(`Invalid env: ${argv.env}`);
@@ -40,6 +42,10 @@ client.s3.getObject(
       console.log(
         'No version change detected in package.json, skipping build.'
       );
+
+      // CodeBuild deploy project requires 'dist' folder to not be empty, so we create mock file.
+      fs.mkdirSync(path.resolve(__dirname, '..', 'dist'));
+      fs.writeFileSync(path.resolve(__dirname, '..', 'dist', '.temp'), '');
     }
   }
 );


### PR DESCRIPTION
When version was not changed we were deploying new files from master to latest tagged version. This cause version mismatch and potential bugs when new master has breaking change.
Now version check condition is simplified and build files only when NoSuchKey error is thrown.