### PR TITLE
add z-index for close button to be on top of dialog body

### DIFF
--- a/src/components/dialog/Dialog.stories.mdx
+++ b/src/components/dialog/Dialog.stories.mdx
@@ -193,6 +193,57 @@ import PageHeader from 'blocks/PageHeader';
   </Story>
 </Canvas>
 
+<Canvas>
+  <Story name="Without header">
+    {args => {
+      const [open, setOpen] = React.useState(false);
+      const handleDismiss = () => setOpen(false);
+      const headerId = 'dialog-header';
+      const anotherHeaderId = 'another-dialog-header';
+      return (
+        <div>
+          <Button type="solid-indigo" onClick={() => setOpen(true)}>
+            open dialog
+          </Button>
+          <Dialog
+            {...args}
+            open={open}
+            onDismiss={handleDismiss}
+            labelledBy={headerId}
+          >
+            <DialogCloseButton onClick={handleDismiss} />
+            <DialogBody>
+              <Flex marginBottom="m">
+                Information you provide to us directly. We may collect personal
+                information, such as your name, address, telephone number, date
+                of birth, payment information, and e-mail address when you when
+                you register for our Service, sign up for our mailing list,
+                enter a contest or sweepstakes, or otherwise communicate with
+                us. We may also collect any communications between you and
+                Brainly and any other information you provide to Brainly
+                Information you provide to us directly. We may collect personal
+                information, such as your name, address, telephone number, date
+                of birth, payment information, and e-mail address when you when
+                you register for our Service, sign up for our mailing list,
+                enter a contest or sweepstakes, or otherwise communicate with
+                us. We may also collect any communications between you and
+                Brainly and any other information you provide to Brainly
+                Information you provide to us directly.
+              </Flex>
+              <Flex justifyContent="flex-end" className="sg-space-x-s">
+                <Button type="outline" onClick={handleDismiss}>
+                  cancel
+                </Button>
+                <Button type="solid">proceed</Button>
+              </Flex>
+            </DialogBody>
+          </Dialog>
+        </div>
+      );
+    }}
+  </Story>
+</Canvas>
+
 <ArgsTable story="Default" />
 
 ## Accessibility

--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -139,5 +139,6 @@ $dialogMaxWidthMap: (
     position: absolute;
     top: 0;
     right: 0;
+    z-index: 1;
   }
 }


### PR DESCRIPTION
Dialog close button is overlapped by DialogBody causing close button impossible to click.
Adding `z-index` is fixing issue positioning button in proper stacking context