### PR TITLE
Blue 60 color added as a variant to Spinner component

### DIFF
--- a/src/components/spinner/Spinner.jsx
+++ b/src/components/spinner/Spinner.jsx
@@ -14,6 +14,7 @@ export type SpinnerColorType =
   | 'red-50'
   | 'yellow-40'
   | 'blue-40'
+  | 'blue-60'
   | 'indigo-50';
 
 export type AriaLiveType = 'off' | 'polite' | 'assertive';
@@ -34,6 +35,7 @@ export const SPINNER_COLOR = {
   'red-50': 'red-50',
   'yellow-40': 'yellow-40',
   'blue-40': 'blue-40',
+  'blue-60': 'blue-60',
 };
 
 export type SpinnerPropsType = {

--- a/src/components/spinner/_spinner.scss
+++ b/src/components/spinner/_spinner.scss
@@ -67,6 +67,11 @@
     border-left-color: $blue-40;
   }
 
+  &--blue-60 {
+    border-bottom-color: $blue-60;
+    border-left-color: $blue-60;
+  }
+
   &--indigo-50 {
     border-bottom-color: $indigo-50;
     border-left-color: $indigo-50;

--- a/src/components/spinner/stories/Spinner.a11y.mdx
+++ b/src/components/spinner/stories/Spinner.a11y.mdx
@@ -1,11 +1,11 @@
 ### Rules
 
-| Pattern                                                                     | Comment                                                                                                                                                       | Status                                |
-| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------- |
-| **Should** have an accessible information about the status that is annouced | Use `aria-label` to set custom information, `aria-label` defaults to `"loading"`                                                                              | Implementation: DONE<br />Tests: DONE |
-| **Should** have role `status`                                               |                                                                                                                                                               | Implementation: DONE<br />Tests: DONE |
-| **Should** have 3:1 contrast ratio against the background                   | For white background use: `black`, `gray-70`, `gray-50`, `red-50`, `indigo-50`, against black: `white`, `gray-50`, `red-50`, `red-40`, `blue-40`, `yellow-40` | Implementation: DONE<br />Tests: N/A  |
-| **Should** respect Windows High Contrast theme                              |                                                                                                                                                               | Implementation: DONE<br />Tests: N/A  |
+| Pattern                                                                     | Comment                                                                                                                                                                  | Status                                |
+| --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------- |
+| **Should** have an accessible information about the status that is annouced | Use `aria-label` to set custom information, `aria-label` defaults to `"loading"`                                                                                         | Implementation: DONE<br />Tests: DONE |
+| **Should** have role `status`                                               |                                                                                                                                                                          | Implementation: DONE<br />Tests: DONE |
+| **Should** have 3:1 contrast ratio against the background                   | For white background use: `black`, `gray-70`, `gray-50`, `red-50`, `indigo-50`, `blue-60`, against black: `white`, `gray-50`, `red-50`, `red-40`, `blue-40`, `yellow-40` | Implementation: DONE<br />Tests: N/A  |
+| **Should** respect Windows High Contrast theme                              |                                                                                                                                                                          | Implementation: DONE<br />Tests: N/A  |
 
 <InfoBox>
   Use <code>aria-busy</code> to indicate which element is being loaded/updated.


### PR DESCRIPTION
added $blue-60 as a varian to spinner component, because we are going to use it as a placeholder for $blue-60 counter

![Screenshot 2022-08-04 at 16 52 00](https://user-images.githubusercontent.com/53941885/182877986-6049dd12-07b5-4707-8ac4-10bc3930b20e.png)
