### PR TITLE
Label: rename iconHidden to iconAriaHidden

### DIFF
--- a/src/components/labels/Label.a11y.spec.jsx
+++ b/src/components/labels/Label.a11y.spec.jsx
@@ -38,7 +38,7 @@ describe('Label', () => {
 
   it('should have an icon which is hidden from accessibility tree', async () => {
     const label = render(
-      <Label iconType="attachment" iconHidden>
+      <Label iconType="attachment" iconAriaHidden>
         dog.jpg
       </Label>
     );
@@ -62,7 +62,7 @@ describe('Label a11y', () => {
 
   it('should have no a11y violations when icon is hidden from accessibility tree', async () => {
     await testA11y(
-      <Label iconType="attachment" iconHidden>
+      <Label iconType="attachment" iconAriaHidden>
         label
       </Label>
     );

--- a/src/components/labels/Label.jsx
+++ b/src/components/labels/Label.jsx
@@ -241,7 +241,7 @@ export type LabelPropsType = $ReadOnly<{
   /**
    * Hiding icon from accessibility tree
    */
-  iconHidden?: boolean,
+  iconAriaHidden?: boolean,
   ...
 }>;
 
@@ -252,14 +252,14 @@ const Label = ({
   onClose,
   color = 'achromatic',
   className,
-  closeButtonLabel = 'close',
+  closeButtonLabel,
   iconTitle,
-  iconHidden,
+  iconAriaHidden,
   ...props
 }: LabelPropsType) => {
   if (__DEV__) {
     invariant(
-      !(!iconType && (iconHidden || iconTitle)),
+      !(!iconType && (iconAriaHidden || iconTitle)),
       'You cannot hide an icon or name it, when `iconType` s not provided'
     );
 
@@ -313,7 +313,7 @@ const Label = ({
             type={iconType}
             color={iconColor}
             size={16}
-            aria-hidden={iconHidden}
+            aria-hidden={iconAriaHidden}
             title={iconTitle}
           />
         </div>
@@ -330,7 +330,7 @@ const Label = ({
         <button
           className="sg-label__close-button"
           onClick={onClose}
-          aria-label={closeButtonLabel}
+          aria-label={closeButtonLabel || 'close'}
         >
           <Icon type="close" color={closeIconColor} size={16} aria-hidden />
         </button>

--- a/src/components/labels/stories/Label.a11y.mdx
+++ b/src/components/labels/stories/Label.a11y.mdx
@@ -5,7 +5,7 @@
 | **Should** have 4.5:1 contrast ratio                                  |                                                                                                                                                     | Implementation: DONE<br />Tests: N/A  |
 | **Should** have an accessible name for a close button                 | Button can be named by `closeButtonLabel` prop, dafaults to `"close"`.                                                                              | Implementation: DONE<br />Tests: DONE |
 | **Should** have an accessible name for an icon                        | Icon can be named by `iconTitle` prop, defaults to icon type.                                                                                       | Implementation: DONE<br />Tests: DONE |
-| **Should** have a possibility to hide an icon from accessibility tree | Icon can be hidden by `iconHidden` prop.                                                                                                            | Implementation: DONE<br />Tests: DONE |
+| **Should** have a possibility to hide an icon from accessibility tree | Icon can be hidden by `iconAriaHidden` prop.                                                                                                        | Implementation: DONE<br />Tests: DONE |
 | **Can** have an accessible name                                       | Can be named by children, a label specified by `aria-label` prop or a value (`IDREF`) set for the `aria-labelledby` prop that refers to an element. | Implementation: DONE<br />Tests: DONE |
 
 ### Usage
@@ -36,7 +36,7 @@
 ```jsx
 <Label
   iconType={ICON_TYPE.VERIFIED}
-  iconHidden
+  iconAriaHidden
 >
   Answer Verified
 </Label>


### PR DESCRIPTION
`iconHidden` does not say clearly enough that it is related to the ARIA, so it is needed to rename it. 