### PR TITLE
redirect to story when no version is in url

### DIFF
--- a/src/root-redirect.html
+++ b/src/root-redirect.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta http-equiv="refresh" content="1;url=/#LATEST_VERSION#/docs/" />
     <script type="text/javascript">
-      window.location.href = '/#LATEST_VERSION#/docs/';
+      window.location.href = '/#LATEST_VERSION#/docs/' + window.location.search;
     </script>
     <title>Page Redirection</title>
   </head>


### PR DESCRIPTION
This redirect allows someone to use links to stories without version, e.g:
`https://styleguide.brainly.com?path=/story/components-button--default` (it is invalid url)
will redirect to
`https://styleguide.brainly.com/{latest_version}/docs?path=/story/components-button--default`
