### PR TITLE
fix Dialog.Overlay typescript types

### DIFF
--- a/src/components/dialog/DialogOverlay.jsx
+++ b/src/components/dialog/DialogOverlay.jsx
@@ -35,9 +35,10 @@ export const SLOTS = [
 
 export type DialogOverlayPropsType = {
   children: React.Node,
+  // eslint-disable-next-line react/no-unused-prop-types
   slot: SlotType,
 };
 
-const DialogOverlay = ({children}: DialogOverlayPropsType) => children;
+const DialogOverlay = ({children}: DialogOverlayPropsType) => <>{children}</>;
 
 export default DialogOverlay;


### PR DESCRIPTION
Wrap Dialog returned element <> to generate proper type () => JSX.Element