### PR TITLE
Rename Button type to variant

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,13 +105,13 @@ When importing dependencies, we are using global imports instead of relative one
 Bad:
 
 ```
-import Button, {types as buttonTypes} from '../../buttons/Button';
+import Button, {variants as buttonVariants} from '../../buttons/Button';
 ```
 
 Good:
 
 ```
-import Button, {BUTTON_TYPE} from 'components/buttons/Button';
+import Button, {BUTTON_VARIANT} from 'components/buttons/Button';
 ```
 
 or just:
@@ -119,7 +119,7 @@ or just:
 ```
 import Button from 'components/buttons/Button';
 
-<Button type="solid">Button</Button>
+<Button variant="solid">Button</Button>
 ```
 
 #### Components options

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "219.1.2-beta.0",
+  "version": "219.1.2-beta-button-naming.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "219.1.2",
+  "version": "219.1.2-beta.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "219.1.2-beta-button-naming.0",
+  "version": "219.1.2-button-naming-beta.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "219.1.2-button-naming-beta.0",
+  "version": "219.1.2",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/action-list/ActionList.spec.jsx
+++ b/src/components/action-list/ActionList.spec.jsx
@@ -9,10 +9,10 @@ describe('ActionList', () => {
     const actionList = shallow(
       <ActionList>
         <ActionListHole>
-          <Button type="solid">accept</Button>
+          <Button variant="solid">accept</Button>
         </ActionListHole>
         <ActionListHole>
-          <Button type="solid-inverse">accept</Button>
+          <Button variant="solid-inverse">accept</Button>
         </ActionListHole>
       </ActionList>
     );

--- a/src/components/action-list/ActionListHole.spec.jsx
+++ b/src/components/action-list/ActionListHole.spec.jsx
@@ -7,7 +7,7 @@ describe('<ActionListHole />', () => {
   test('render', () => {
     const actionListHole = shallow(
       <ActionListHole>
-        <Button type="solid" size="small">
+        <Button variant="solid" size="small">
           accept
         </Button>
       </ActionListHole>

--- a/src/components/buttons/Button.a11y.spec.jsx
+++ b/src/components/buttons/Button.a11y.spec.jsx
@@ -147,7 +147,7 @@ describe('Button', () => {
   describe('with `toggle`', () => {
     it('has a button role and an accessible label', () => {
       const button = render(
-        <Button toggle="red" nativeType="button" aria-pressed="true">
+        <Button toggle="red" type="button" aria-pressed="true">
           Thanks
         </Button>
       );
@@ -212,7 +212,7 @@ describe('Button a11y', () => {
   describe('with `toggle`', () => {
     it('should have no a11y violations', async () => {
       await testA11y(
-        <Button toggle="red" nativeType="button" aria-pressed="true">
+        <Button toggle="red" type="button" aria-pressed="true">
           Thanks
         </Button>
       );

--- a/src/components/buttons/Button.jsx
+++ b/src/components/buttons/Button.jsx
@@ -104,7 +104,7 @@ type ButtonSizeType = 'l' | 'm' | 's';
 
 export type AriaLiveType = 'off' | 'polite' | 'assertive';
 
-export type NativeTypeType = 'button' | 'submit' | 'reset';
+export type ButtonTypeType = 'button' | 'submit' | 'reset';
 
 const TOGGLE_BUTTON_VARIANTS = [
   'solid-light',
@@ -253,7 +253,7 @@ export type ButtonPropsType = {
   /**
    * The default behavior of the button.
    */
-  type?: NativeTypeType,
+  type?: ButtonTypeType,
   /**
    * Callback, called by clicking on Button
    */
@@ -284,7 +284,7 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
       'aria-label': ariaLabel,
       loadingAriaLive = 'off',
       loadingAriaLabel,
-      nativeType,
+      type,
       ...props
     }: ButtonPropsType,
     ref
@@ -335,8 +335,8 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
       );
 
       invariant(
-        !(isLink && nativeType),
-        '`nativeType` prop is not working when href is provided'
+        !(isLink && type),
+        '`type` prop is not working when href is provided'
       );
 
       invariant(
@@ -389,7 +389,7 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
         target={target}
         aria-label={ariaLabel}
         onClick={onButtonClick}
-        type={nativeType}
+        type={type}
       >
         {loading && (
           <Spinner

--- a/src/components/buttons/Button.jsx
+++ b/src/components/buttons/Button.jsx
@@ -15,7 +15,7 @@ export const BUTTON_SIZE: {
   S: 's',
 };
 
-export const BUTTON_TYPE: {
+export const BUTTON_VARIANT: {
   SOLID: 'solid',
   SOLID_INVERTED: 'solid-inverted',
   SOLID_INDIGO: 'solid-indigo',
@@ -64,24 +64,24 @@ const SPINNER_SIZE_MAP = {
 };
 
 const SPINNER_COLOR_MAP = {
-  [BUTTON_TYPE.SOLID]: SPINNER_COLOR['white'],
-  [BUTTON_TYPE.SOLID_INVERTED]: SPINNER_COLOR['black'],
-  [BUTTON_TYPE.SOLID_INDIGO]: SPINNER_COLOR['white'],
-  [BUTTON_TYPE.SOLID_INDIGO_INVERTED]: SPINNER_COLOR['indigo-50'],
-  [BUTTON_TYPE.SOLID_LIGHT]: SPINNER_COLOR['black'],
-  [BUTTON_TYPE.OUTLINE]: SPINNER_COLOR['black'],
-  [BUTTON_TYPE.OUTLINE_INDIGO]: SPINNER_COLOR['indigo-50'],
-  [BUTTON_TYPE.OUTLINE_INVERTED]: SPINNER_COLOR['white'],
-  [BUTTON_TYPE.TRANSPARENT]: SPINNER_COLOR['black'],
-  [BUTTON_TYPE.TRANSPARENT_LIGHT]: SPINNER_COLOR['gray-50'],
-  [BUTTON_TYPE.TRANSPARENT_RED]: SPINNER_COLOR['red-50'],
-  [BUTTON_TYPE.TRANSPARENT_INVERTED]: SPINNER_COLOR['white'],
-  [BUTTON_TYPE.FACEBOOK]: SPINNER_COLOR['white'],
-  [BUTTON_TYPE.GOOGLE]: SPINNER_COLOR['black'],
-  [BUTTON_TYPE.APPLE]: SPINNER_COLOR['white'],
+  [BUTTON_VARIANT.SOLID]: SPINNER_COLOR['white'],
+  [BUTTON_VARIANT.SOLID_INVERTED]: SPINNER_COLOR['black'],
+  [BUTTON_VARIANT.SOLID_INDIGO]: SPINNER_COLOR['white'],
+  [BUTTON_VARIANT.SOLID_INDIGO_INVERTED]: SPINNER_COLOR['indigo-50'],
+  [BUTTON_VARIANT.SOLID_LIGHT]: SPINNER_COLOR['black'],
+  [BUTTON_VARIANT.OUTLINE]: SPINNER_COLOR['black'],
+  [BUTTON_VARIANT.OUTLINE_INDIGO]: SPINNER_COLOR['indigo-50'],
+  [BUTTON_VARIANT.OUTLINE_INVERTED]: SPINNER_COLOR['white'],
+  [BUTTON_VARIANT.TRANSPARENT]: SPINNER_COLOR['black'],
+  [BUTTON_VARIANT.TRANSPARENT_LIGHT]: SPINNER_COLOR['gray-50'],
+  [BUTTON_VARIANT.TRANSPARENT_RED]: SPINNER_COLOR['red-50'],
+  [BUTTON_VARIANT.TRANSPARENT_INVERTED]: SPINNER_COLOR['white'],
+  [BUTTON_VARIANT.FACEBOOK]: SPINNER_COLOR['white'],
+  [BUTTON_VARIANT.GOOGLE]: SPINNER_COLOR['black'],
+  [BUTTON_VARIANT.APPLE]: SPINNER_COLOR['white'],
 };
 
-type ButtonType =
+type ButtonVariantType =
   | 'solid'
   | 'solid-inverted'
   | 'solid-indigo'
@@ -106,7 +106,7 @@ export type AriaLiveType = 'off' | 'polite' | 'assertive';
 
 export type NativeTypeType = 'button' | 'submit' | 'reset';
 
-const TOGGLE_BUTTON_TYPES = [
+const TOGGLE_BUTTON_VARIANTS = [
   'solid-light',
   'outline',
   'transparent',
@@ -126,40 +126,40 @@ const anchorRelatedProps = [
 export type ButtonPropsType = {
   /**
    * Specify type of the button that you want to use
-   * @example <Button type="solid">
+   * @example <Button variant="solid">
    *            button
    *          </Button>
-   * @see type="solid" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid"#buttons
-   * @see type="solid-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-inverted"#buttons
+   * @see variant="solid" https://styleguide.brainly.com/latest/docs/interactive.html?variant="solid"#buttons
+   * @see variant="solid-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?variant="solid-inverted"#buttons
 
-   * @see type="solid-indigo" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-indigo"#buttons
-   * @see type="solid-indigo-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-indigo-inverted"#buttons
-   * @see type="solid-light" https://styleguide.brainly.com/latest/docs/interactive.html?type="solid-light"#buttons
-   * @see type="outline" https://styleguide.brainly.com/latest/docs/interactive.html?type="outline"#buttons
-   * @see type="outline-indigo" https://styleguide.brainly.com/latest/docs/interactive.html?type="outline-indigo"#buttons
-   * @see type="outline-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?type="outline-indigo-inverted"#buttons
-   * @see type="transparent" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent"#buttons
-   * @see type="transparent-light" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-light"#buttons
-   * @see type="transparent-red" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-red"#buttons
-   * @see type="transparent-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?type="transparent-inverted"#buttons
-   * @see type="facebook" https://styleguide.brainly.com/latest/docs/interactive.html?type="facebook"#buttons
-   * @see type="google" https://styleguide.brainly.com/latest/docs/interactive.html?type="google"#buttons
-   * @see type="apple" https://styleguide.brainly.com/latest/docs/interactive.html?type="apple"#buttons
+   * @see variant="solid-indigo" https://styleguide.brainly.com/latest/docs/interactive.html?variant="solid-indigo"#buttons
+   * @see variant="solid-indigo-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?variant="solid-indigo-inverted"#buttons
+   * @see variant="solid-light" https://styleguide.brainly.com/latest/docs/interactive.html?variant="solid-light"#buttons
+   * @see variant="outline" https://styleguide.brainly.com/latest/docs/interactive.html?variant="outline"#buttons
+   * @see variant="outline-indigo" https://styleguide.brainly.com/latest/docs/interactive.html?variant="outline-indigo"#buttons
+   * @see variant="outline-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?variant="outline-indigo-inverted"#buttons
+   * @see variant="transparent" https://styleguide.brainly.com/latest/docs/interactive.html?variant="transparent"#buttons
+   * @see variant="transparent-light" https://styleguide.brainly.com/latest/docs/interactive.html?variant="transparent-light"#buttons
+   * @see variant="transparent-red" https://styleguide.brainly.com/latest/docs/interactive.html?variant="transparent-red"#buttons
+   * @see variant="transparent-inverted" https://styleguide.brainly.com/latest/docs/interactive.html?variant="transparent-inverted"#buttons
+   * @see variant="facebook" https://styleguide.brainly.com/latest/docs/interactive.html?variant="facebook"#buttons
+   * @see variant="google" https://styleguide.brainly.com/latest/docs/interactive.html?variant="google"#buttons
+   * @see variant="apple" https://styleguide.brainly.com/latest/docs/interactive.html?variant="apple"#buttons
    *
    */
-  type: ButtonType,
+  variant: ButtonVariantType,
   /**
    * Set toggle state of the button.
-   * Caution: Toggle property work with for specific button types:
+   * Caution: Toggle property work with for specific button variants:
    * `solid-light`,`outline`, `outline-indigo`, `outline-inverted`,
    * `transparent`, `transparent-light`, `transparent-red`, `transparent-inverted`
    */
   toggle?: ButtonToggleType,
   /**
-   * You can render icon inside each type of button on the left side
+   * You can render icon inside each variant of button on the left side
    * @example <Button
-   *           icon={<Icon type="facebook" color="icon-white" size={24} />}
-   *           type="facebook"
+   *           icon={<Icon variant="facebook" color="icon-white" size={24} />}
+   *           variant="facebook"
    *          >
    *            Login with Facebook
    *          </Button>
@@ -167,9 +167,9 @@ export type ButtonPropsType = {
   icon?: React.Node,
   /** Optional and available when icon is set. it hides button's text
    * @example <Button
-   *            icon={<Icon type="facebook" color="icon-white" size={24} />}
+   *            icon={<Icon variant="facebook" color="icon-white" size={24} />}
    *            iconOnly
-   *            type="facebook"
+   *            variant="facebook"
    *          >
    *            Login with Facebook
    *          </Button>
@@ -183,7 +183,7 @@ export type ButtonPropsType = {
    * Children to be rendered inside Button
    * @example <Button
    *           icon={<Icon type="answer" color="icon-white" size={24} />}
-   *           type="solid"
+   *           variant="solid"
    *          >
    *            button
    *          </Button>
@@ -191,7 +191,7 @@ export type ButtonPropsType = {
   children?: React.Node,
   /**
    * There are three sizes options for buttons, not need to be specify, default is m
-   * @example <Button type="solid" size="m">
+   * @example <Button variant="solid" size="m">
    *            button
    *          </Button>
    * @see size="s" https://styleguide.brainly.com/latest/docs/interactive.html?size="s"#buttons
@@ -201,14 +201,14 @@ export type ButtonPropsType = {
   size?: ButtonSizeType,
   /**
    * Specify href for button, optional string
-   * @example <Button href="https://brainly.com/" size="m" type="solid-indigo">
+   * @example <Button href="https://brainly.com/" size="m" variant="solid-indigo">
    *            button
    *          </Button>
    */
   href?: string,
   /**
    * Optional boolean for disabled button
-   * @example <Button type="solid-indigo" disabled>
+   * @example <Button variant="solid-indigo" disabled>
    *            button
    *          </Button>
    */
@@ -228,7 +228,7 @@ export type ButtonPropsType = {
   loadingAriaLabel?: string,
   /**
    * Optional boolean for full width button
-   * @example <Button type="solid-indigo" fullWidth>
+   * @example <Button variant="solid-indigo" fullWidth>
    *            button
    *          </Button>
    */
@@ -253,7 +253,7 @@ export type ButtonPropsType = {
   /**
    * The default behavior of the button.
    */
-  nativeType?: NativeTypeType,
+  type?: NativeTypeType,
   /**
    * Callback, called by clicking on Button
    */
@@ -267,7 +267,7 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
   (
     {
       size = 'm',
-      type = 'solid',
+      variant = 'solid',
       icon,
       iconOnly,
       reversedOrder,
@@ -296,12 +296,15 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
       invariant(
         !(
           (toggle === 'red' &&
-            ![...TOGGLE_BUTTON_TYPES, 'transparent-red'].includes(type)) ||
-          (toggle === 'yellow' && ![...TOGGLE_BUTTON_TYPES].includes(type))
+            ![...TOGGLE_BUTTON_VARIANTS, 'transparent-red'].includes(
+              variant
+            )) ||
+          (toggle === 'yellow' &&
+            ![...TOGGLE_BUTTON_VARIANTS].includes(variant))
         ),
         `Value of toggle property '${String(
           toggle
-        )}' has no effect when button type is set to '${type}'.`
+        )}' has no effect when button variant is set to '${variant}'.`
       );
 
       invariant(
@@ -346,12 +349,12 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
       'sg-button',
       {
         [`sg-button--${String(size)}`]: size,
-        [`sg-button--${String(type)}`]: type,
+        [`sg-button--${String(variant)}`]: variant,
         'sg-button--disabled': isDisabled,
         'sg-button--loading': loading,
         'sg-button--full-width': fullWidth,
         'sg-button--icon-only': Boolean(icon) && iconOnly,
-        [`sg-button--${String(type)}-toggle-${String(toggle)}`]: toggle,
+        [`sg-button--${String(variant)}-toggle-${String(toggle)}`]: toggle,
         'sg-button--reversed-order': reversedOrder,
       },
       className
@@ -374,10 +377,10 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
       return onClick && onClick(e);
     };
 
-    const TypeToRender = isLink ? (isDisabled ? 'span' : 'a') : 'button';
+    const TagToRender = isLink ? (isDisabled ? 'span' : 'a') : 'button';
 
     return (
-      <TypeToRender
+      <TagToRender
         {...props}
         className={btnClass}
         href={href}
@@ -391,7 +394,7 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
         {loading && (
           <Spinner
             size={SPINNER_SIZE_MAP[size]}
-            color={SPINNER_COLOR_MAP[type]}
+            color={SPINNER_COLOR_MAP[variant]}
             className="sg-button__spinner"
             aria-live={loadingAriaLive}
             aria-label={loadingAriaLabel}
@@ -405,7 +408,7 @@ const Button = React.forwardRef<ButtonPropsType, HTMLElement>(
             <span className="sg-visually-hidden">{newTabLabel}</span>
           )}
         </span>
-      </TypeToRender>
+      </TagToRender>
     );
   }
 );

--- a/src/components/buttons/Button.spec.jsx
+++ b/src/components/buttons/Button.spec.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {Spinner, Icon} from '../..';
-import Button, {BUTTON_TYPE} from './Button';
+import Button, {BUTTON_VARIANT} from './Button';
 import {shallow} from 'enzyme';
 
 test('render', () => {
@@ -9,11 +9,11 @@ test('render', () => {
   expect(button.hasClass('sg-button')).toEqual(true);
 });
 
-test('type', () => {
-  const buttonType = BUTTON_TYPE.SOLID;
-  const button = shallow(<Button type={buttonType}>Some text</Button>);
+test('variant', () => {
+  const buttonVariant = BUTTON_VARIANT.SOLID;
+  const button = shallow(<Button variant={buttonVariant}>Some text</Button>);
 
-  expect(button.hasClass(`sg-button--${buttonType}`)).toEqual(true);
+  expect(button.hasClass(`sg-button--${buttonVariant}`)).toEqual(true);
 });
 
 test('disabled', () => {
@@ -64,7 +64,7 @@ test('no icon', () => {
 
 test('toggle', () => {
   const button = shallow(
-    <Button type="solid-light" toggle="red">
+    <Button variant="solid-light" toggle="red">
       Some text
     </Button>
   );

--- a/src/components/buttons/Button.stories.mdx
+++ b/src/components/buttons/Button.stories.mdx
@@ -1,5 +1,5 @@
 import {ArgsTable, Meta, Story, Canvas} from '@storybook/addon-docs';
-import Button, {BUTTON_SIZE, BUTTON_TYPE, BUTTON_TOGGLE} from './Button';
+import Button, {BUTTON_SIZE, BUTTON_VARIANT, BUTTON_TOGGLE} from './Button';
 import Icon, {TYPE as ICON_TYPES} from 'icons/Icon';
 import hex from '../colors/hex';
 import {StoryVariantTable} from '../../docs/utils';
@@ -65,10 +65,10 @@ const iconSize = {
 
 ## Stories
 
-### Types
+### Variants
 
 <Canvas>
-  <Story name="Types">
+  <Story name="Variants">
     {args => (
       <StoryVariantTable className="sg-button-stories-table">
         <thead>
@@ -144,22 +144,22 @@ const iconSize = {
         </thead>
         <tbody>
           {[
-            BUTTON_TYPE.SOLID,
-            BUTTON_TYPE.SOLID_INVERTED,
-            BUTTON_TYPE.SOLID_INDIGO,
-            BUTTON_TYPE.SOLID_INDIGO_INVERTED,
-            BUTTON_TYPE.SOLID_LIGHT,
-            BUTTON_TYPE.OUTLINE,
-            BUTTON_TYPE.OUTLINE_INDIGO,
-            BUTTON_TYPE.OUTLINE_INVERTED,
-            BUTTON_TYPE.TRANSPARENT,
-            BUTTON_TYPE.TRANSPARENT_LIGHT,
-            BUTTON_TYPE.TRANSPARENT_RED,
-            BUTTON_TYPE.TRANSPARENT_INVERTED,
-            BUTTON_TYPE.FACEBOOK,
-            BUTTON_TYPE.GOOGLE,
-            BUTTON_TYPE.APPLE,
-          ].map(buttonType => (
+            BUTTON_VARIANT.SOLID,
+            BUTTON_VARIANT.SOLID_INVERTED,
+            BUTTON_VARIANT.SOLID_INDIGO,
+            BUTTON_VARIANT.SOLID_INDIGO_INVERTED,
+            BUTTON_VARIANT.SOLID_LIGHT,
+            BUTTON_VARIANT.OUTLINE,
+            BUTTON_VARIANT.OUTLINE_INDIGO,
+            BUTTON_VARIANT.OUTLINE_INVERTED,
+            BUTTON_VARIANT.TRANSPARENT,
+            BUTTON_VARIANT.TRANSPARENT_LIGHT,
+            BUTTON_VARIANT.TRANSPARENT_RED,
+            BUTTON_VARIANT.TRANSPARENT_INVERTED,
+            BUTTON_VARIANT.FACEBOOK,
+            BUTTON_VARIANT.GOOGLE,
+            BUTTON_VARIANT.APPLE,
+          ].map(buttonVariant => (
             <tr
               style={{
                 backgroundColor: [
@@ -167,11 +167,11 @@ const iconSize = {
                   'solid-indigo-inverted',
                   'transparent-inverted',
                   'outline-inverted',
-                ].includes(buttonType)
+                ].includes(buttonVariant)
                   ? hex.black
                   : 'transparent',
               }}
-              key={buttonType}
+              key={buttonVariant}
             >
               <td>
                 <div
@@ -191,90 +191,90 @@ const iconSize = {
                         'solid-indigo-inverted',
                         'transparent-inverted',
                         'outline-inverted',
-                      ].includes(buttonType)
+                      ].includes(buttonVariant)
                         ? 'text-white'
                         : 'text-gray-40'
                     }
                     size="medium"
                   >
-                    {buttonType.toLowerCase()}
+                    {buttonVariant.toLowerCase()}
                   </Headline>
                 </div>
               </td>
               <td>
                 <div>
-                  <Button {...args} type={buttonType} />
+                  <Button {...args} variant={buttonVariant} />
                 </div>
               </td>
               <td>
-                <Button {...args} type={buttonType} disabled />
+                <Button {...args} variant={buttonVariant} disabled />
               </td>
               <td>
-                <Button {...args} type={buttonType} loading />
+                <Button {...args} variant={buttonVariant} loading />
               </td>
               <td>
                 {[
-                  BUTTON_TYPE.SOLID,
-                  BUTTON_TYPE.SOLID_INVERTED,
-                  BUTTON_TYPE.SOLID_INDIGO,
-                  BUTTON_TYPE.SOLID_INDIGO_INVERTED,
-                  BUTTON_TYPE.SOLID_LIGHT,
-                  BUTTON_TYPE.OUTLINE,
-                  BUTTON_TYPE.OUTLINE_INDIGO,
-                  BUTTON_TYPE.OUTLINE_INVERTED,
-                  BUTTON_TYPE.TRANSPARENT,
-                  BUTTON_TYPE.TRANSPARENT_LIGHT,
-                  BUTTON_TYPE.TRANSPARENT_RED,
-                  BUTTON_TYPE.TRANSPARENT_INVERTED,
-                ].includes(buttonType) ? (
+                  BUTTON_VARIANT.SOLID,
+                  BUTTON_VARIANT.SOLID_INVERTED,
+                  BUTTON_VARIANT.SOLID_INDIGO,
+                  BUTTON_VARIANT.SOLID_INDIGO_INVERTED,
+                  BUTTON_VARIANT.SOLID_LIGHT,
+                  BUTTON_VARIANT.OUTLINE,
+                  BUTTON_VARIANT.OUTLINE_INDIGO,
+                  BUTTON_VARIANT.OUTLINE_INVERTED,
+                  BUTTON_VARIANT.TRANSPARENT,
+                  BUTTON_VARIANT.TRANSPARENT_LIGHT,
+                  BUTTON_VARIANT.TRANSPARENT_RED,
+                  BUTTON_VARIANT.TRANSPARENT_INVERTED,
+                ].includes(buttonVariant) ? (
                   <Button
                     {...args}
-                    type={buttonType}
+                    variant={buttonVariant}
                     icon={
                       <Icon type={ICON_TYPES.HEART_OUTLINED} color="adaptive" />
                     }
                   />
                 ) : null}
-                {buttonType === BUTTON_TYPE.GOOGLE ? (
+                {buttonVariant === BUTTON_VARIANT.GOOGLE ? (
                   <Button
                     {...args}
-                    type={buttonType}
+                    variant={buttonVariant}
                     icon={<Icon type={ICON_TYPES.GOOGLE} color="adaptive" />}
                   />
                 ) : null}
-                {buttonType === BUTTON_TYPE.FACEBOOK ? (
+                {buttonVariant === BUTTON_VARIANT.FACEBOOK ? (
                   <Button
                     {...args}
-                    type={buttonType}
+                    variant={buttonVariant}
                     icon={<Icon type={ICON_TYPES.FACEBOOK} color="adaptive" />}
                   />
                 ) : null}
-                {buttonType === BUTTON_TYPE.APPLE ? (
+                {buttonVariant === BUTTON_VARIANT.APPLE ? (
                   <Button
                     {...args}
-                    type={buttonType}
+                    variant={buttonVariant}
                     icon={<Icon type={ICON_TYPES.APPLE} color="adaptive" />}
                   />
                 ) : null}
               </td>
               <td>
                 {[
-                  BUTTON_TYPE.SOLID,
-                  BUTTON_TYPE.SOLID_INVERTED,
-                  BUTTON_TYPE.SOLID_INDIGO,
-                  BUTTON_TYPE.SOLID_INDIGO_INVERTED,
-                  BUTTON_TYPE.SOLID_LIGHT,
-                  BUTTON_TYPE.OUTLINE,
-                  BUTTON_TYPE.OUTLINE_INDIGO,
-                  BUTTON_TYPE.OUTLINE_INVERTED,
-                  BUTTON_TYPE.TRANSPARENT,
-                  BUTTON_TYPE.TRANSPARENT_LIGHT,
-                  BUTTON_TYPE.TRANSPARENT_RED,
-                  BUTTON_TYPE.TRANSPARENT_INVERTED,
-                ].includes(buttonType) ? (
+                  BUTTON_VARIANT.SOLID,
+                  BUTTON_VARIANT.SOLID_INVERTED,
+                  BUTTON_VARIANT.SOLID_INDIGO,
+                  BUTTON_VARIANT.SOLID_INDIGO_INVERTED,
+                  BUTTON_VARIANT.SOLID_LIGHT,
+                  BUTTON_VARIANT.OUTLINE,
+                  BUTTON_VARIANT.OUTLINE_INDIGO,
+                  BUTTON_VARIANT.OUTLINE_INVERTED,
+                  BUTTON_VARIANT.TRANSPARENT,
+                  BUTTON_VARIANT.TRANSPARENT_LIGHT,
+                  BUTTON_VARIANT.TRANSPARENT_RED,
+                  BUTTON_VARIANT.TRANSPARENT_INVERTED,
+                ].includes(buttonVariant) ? (
                   <Button
                     {...args}
-                    type={buttonType}
+                    variant={buttonVariant}
                     iconOnly
                     icon={
                       <Icon type={ICON_TYPES.HEART_OUTLINED} color="adaptive" />
@@ -288,7 +288,7 @@ const iconSize = {
                   'outline',
                   'transparent',
                   'transparent-light',
-                ].includes(buttonType)
+                ].includes(buttonVariant)
                   ? [null, ...Object.values(BUTTON_TOGGLE)].map(toggleType => (
                       <div style={{marginBottom: '15px'}} key={toggleType}>
                         <Button
@@ -296,7 +296,7 @@ const iconSize = {
                           icon={
                             <Icon type={ICON_TYPES.HEART} color="adaptive" />
                           }
-                          type={buttonType}
+                          variant={buttonVariant}
                           toggle={toggleType}
                         />
                       </div>
@@ -307,12 +307,12 @@ const iconSize = {
                   'outline-inverted',
                   'transparent-red',
                   'transparent-inverted',
-                ].includes(buttonType) ? (
-                  <div style={{marginBottom: '15px'}} key={buttonType}>
+                ].includes(buttonVariant) ? (
+                  <div style={{marginBottom: '15px'}} key={buttonVariant}>
                     <Button
                       {...args}
                       icon={<Icon type={ICON_TYPES.HEART} color="adaptive" />}
-                      type={buttonType}
+                      variant={buttonVariant}
                     />
                   </div>
                 ) : null}
@@ -470,7 +470,7 @@ const iconSize = {
                         </Headline>
                       </td>
                       <td>
-                        <Button {...args} size={size} type="transparent">
+                        <Button {...args} size={size} variant="transparent">
                           button
                         </Button>
                       </td>
@@ -481,7 +481,7 @@ const iconSize = {
                           icon={
                             <Icon type={ICON_TYPES.ANSWER} color="adaptive" />
                           }
-                          type="transparent"
+                          variant="transparent"
                         >
                           button
                         </Button>
@@ -494,7 +494,7 @@ const iconSize = {
                             <Icon type={ICON_TYPES.ANSWER} color="adaptive" />
                           }
                           reversedOrder
-                          type="transparent"
+                          variant="transparent"
                         >
                           button
                         </Button>

--- a/src/components/buttons/README.md
+++ b/src/components/buttons/README.md
@@ -7,7 +7,7 @@ Buttons are created to help user to make actions, choices and to move around the
 ```jsx
 import {Button} from 'style-guide';
 
-<Button type="solid-indigo" size="small">
+<Button variant="solid-indigo" size="small">
   I am solid small button
 </Button>;
 ```
@@ -27,15 +27,15 @@ There are 4 types of solid buttons avalaible, that are used as main action butto
 ```jsx
 import {Button} from 'style-guide';
 
-<Button type="solid">
+<Button variant="solid">
     I am black button
 </Button>
 
-<Button type="solid-inverted">
+<Button variant="solid-inverted">
     I am white button
 </Button>
 
-<Button type="solid-indigo">
+<Button variant="solid-indigo">
     I am indigo button
 </Button>
 ```
@@ -47,7 +47,7 @@ We have one outline button, e.g answer button on feed, which is white with black
 ```jsx
 import {Button} from 'style-guide';
 
-<Button type="outline">I am white button with border</Button>;
+<Button variant="outline">I am white button with border</Button>;
 ```
 
 #### Link buttons
@@ -57,21 +57,21 @@ We have 4 link buttons avalaible, black, white, red and yellow. They are also us
 ```jsx
 import {Button} from 'style-guide';
 
-<Button type="transparent">
+<Button variant="transparent">
     I am black link button
 </Button>
 
-<Button type="transparent-inverted">
+<Button variant="transparent-inverted">
     I am white link button
 </Button>
 
-<Button type="transparent-red">
+<Button variant="transparent-red">
     I am red link button
 </Button>
 
 {/* Example of the thank you button created with link button */}
 <Button
-  type="transparent-red"
+  variant="transparent-red"
   icon={<Icon type={iconTypes.HEART} color={ICON_COLOR['icon-red-50']} size={24} />}
 >
   Thank you
@@ -85,7 +85,7 @@ There is also 1 additional button created for special case: facebook button, whi
 ```jsx
 import {Button} from 'style-guide';
 
-<Button type="facebook">I am FB button</Button>;
+<Button variant="facebook">I am FB button</Button>;
 ```
 
 #### Buttons with icons
@@ -97,14 +97,14 @@ import {Button} from 'style-guide';
 
 <Button
     size="small"
-    type="facebook"
+    variant="facebook"
     icon={<Icon type={iconTypes.FACEBOOK} color="icon-white" size={16} />}
 >
     Log in
 </Button>
 
 <Button
-    type="facebook"
+    variant="facebook"
     icon={<Icon type={iconTypes.FACEBOOK} color="icon-white" size={24} />}
 >
     Log in
@@ -112,7 +112,7 @@ import {Button} from 'style-guide';
 
 <Button
     size="large"
-    type="facebook"
+    variant="facebook"
     icon={<Icon type={iconTypes.FACEBOOK} color="icon-white" size={32} />}
 >
     Log in

--- a/src/components/buttons/stories/Button.a11y.mdx
+++ b/src/components/buttons/stories/Button.a11y.mdx
@@ -37,10 +37,10 @@
 
 #### Button with `toggle`
 
-| Pattern                        | Comment                          | Status                                 |
-| ------------------------------ | -------------------------------- | -------------------------------------- |
-| **Should** have type `button`  | Use `nativeType` to set the type | Implementation: DONE<br />Tests: TO DO |
-| **Should** have `aria-pressed` |                                  | Implementation: DONE<br />Tests: TO DO |
+| Pattern                        | Comment                    | Status                                 |
+| ------------------------------ | -------------------------- | -------------------------------------- |
+| **Should** have type `button`  | Use `type` to set the type | Implementation: DONE<br />Tests: TO DO |
+| **Should** have `aria-pressed` |                            | Implementation: DONE<br />Tests: TO DO |
 
 ### Usage
 
@@ -104,7 +104,7 @@
 ```jsx
 <Button
   toggle="red"
-  nativeType="button"
+  type="button"
   icon={<Icon aria-hidden type="heart" color="adaptive" />}
   aria-pressed="true"
   onClick={onClick}

--- a/src/components/dialog/Dialog.stories.mdx
+++ b/src/components/dialog/Dialog.stories.mdx
@@ -78,7 +78,7 @@ import Text from '../text/Text';
       const anotherHeaderId = 'another-dialog-header';
       return (
         <div>
-          <Button type="solid-indigo" onClick={() => setOpen(true)}>
+          <Button variant="solid-indigo" onClick={() => setOpen(true)}>
             open dialog
           </Button>
           <Dialog
@@ -114,10 +114,10 @@ import Text from '../text/Text';
                 </Link>
               </Flex>
               <Flex justifyContent="flex-end" className="sg-space-x-s">
-                <Button type="outline" onClick={handleDismiss}>
+                <Button variant="outline" onClick={handleDismiss}>
                   cancel
                 </Button>
-                <Button type="solid">proceed</Button>
+                <Button variant="solid">proceed</Button>
               </Flex>
             </DialogBody>
           </Dialog>
@@ -138,10 +138,10 @@ import Text from '../text/Text';
             </DialogHeader>
             <DialogBody>
               <Flex justifyContent="flex-end" className="sg-space-x-s">
-                <Button type="outline" onClick={handleDismissAnother}>
+                <Button variant="outline" onClick={handleDismissAnother}>
                   cancel
                 </Button>
-                <Button type="solid">proceed</Button>
+                <Button variant="solid">proceed</Button>
               </Flex>
             </DialogBody>
           </Dialog>
@@ -162,7 +162,7 @@ import Text from '../text/Text';
       const anotherHeaderId = 'another-dialog-header';
       return (
         <div>
-          <Button type="solid-indigo" onClick={() => setOpen(true)}>
+          <Button variant="solid-indigo" onClick={() => setOpen(true)}>
             open dialog
           </Button>
           <Dialog
@@ -241,10 +241,10 @@ import Text from '../text/Text';
                 </Link>
               </Flex>
               <Flex justifyContent="flex-end" className="sg-space-x-s">
-                <Button type="outline" onClick={handleDismiss}>
+                <Button variant="outline" onClick={handleDismiss}>
                   cancel
                 </Button>
-                <Button type="solid">proceed</Button>
+                <Button variant="solid">proceed</Button>
               </Flex>
             </DialogBody>
           </Dialog>
@@ -265,10 +265,10 @@ import Text from '../text/Text';
             </DialogHeader>
             <DialogBody>
               <Flex justifyContent="flex-end" className="sg-space-x-s">
-                <Button type="outline" onClick={handleDismissAnother}>
+                <Button variant="outline" onClick={handleDismissAnother}>
                   cancel
                 </Button>
-                <Button type="solid">proceed</Button>
+                <Button variant="solid">proceed</Button>
               </Flex>
             </DialogBody>
           </Dialog>
@@ -287,7 +287,7 @@ import Text from '../text/Text';
       const anotherHeaderId = 'another-dialog-header';
       return (
         <div>
-          <Button type="solid-indigo" onClick={() => setOpen(true)}>
+          <Button variant="solid-indigo" onClick={() => setOpen(true)}>
             open dialog
           </Button>
           <Dialog
@@ -316,10 +316,10 @@ import Text from '../text/Text';
                 Information you provide to us directly.
               </Flex>
               <Flex justifyContent="flex-end" className="sg-space-x-s">
-                <Button type="outline" onClick={handleDismiss}>
+                <Button variant="outline" onClick={handleDismiss}>
                   cancel
                 </Button>
-                <Button type="solid">proceed</Button>
+                <Button variant="solid">proceed</Button>
               </Flex>
             </DialogBody>
           </Dialog>
@@ -352,7 +352,7 @@ import Text from '../text/Text';
       const anotherHeaderId = 'another-dialog-header';
       return (
         <div>
-          <Button type="solid-indigo" onClick={() => setOpen(true)}>
+          <Button variant="solid-indigo" onClick={() => setOpen(true)}>
             open dialog
           </Button>
           <Dialog
@@ -500,10 +500,10 @@ import Text from '../text/Text';
                 </Link>
               </Flex>
               <Flex justifyContent="flex-end" className="sg-space-x-s">
-                <Button type="outline" onClick={handleDismiss}>
+                <Button variant="outline" onClick={handleDismiss}>
                   cancel
                 </Button>
-                <Button type="solid">proceed</Button>
+                <Button variant="solid">proceed</Button>
               </Flex>
             </DialogBody>
           </Dialog>
@@ -524,10 +524,10 @@ import Text from '../text/Text';
             </DialogHeader>
             <DialogBody>
               <Flex justifyContent="flex-end" className="sg-space-x-s">
-                <Button type="outline" onClick={handleDismissAnother}>
+                <Button variant="outline" onClick={handleDismissAnother}>
                   cancel
                 </Button>
-                <Button type="solid">proceed</Button>
+                <Button variant="solid">proceed</Button>
               </Flex>
             </DialogBody>
           </Dialog>

--- a/src/components/dialog/DialogCloseButton.jsx
+++ b/src/components/dialog/DialogCloseButton.jsx
@@ -21,7 +21,7 @@ const DialogCloseButton = ({
   disabled,
 }: DialogCloseButtonPropsType) => (
   <Button
-    type="transparent"
+    variant="transparent"
     className={cx('sg-dialog__close-button', className)}
     icon={<Icon type="close" color={ICON_COLOR['icon-black']} size={24} />}
     onClick={onClick}

--- a/src/components/header/Header.stories.mdx
+++ b/src/components/header/Header.stories.mdx
@@ -91,7 +91,7 @@ import PageHeader from 'blocks/PageHeader';
               <RWDHelper hide={RWD_TYPE.SMALL_ONLY}>
                 <div>
                   <HeaderRight>
-                    <Button type="solid" size="small">
+                    <Button variant="solid" size="small">
                       Register
                     </Button>
                     <IconAsButton
@@ -145,7 +145,7 @@ import PageHeader from 'blocks/PageHeader';
             <RWDHelper hide={RWD_TYPE.SMALL_ONLY}>
               <div>
                 <HeaderRight>
-                  <Button type="solid" size="small">
+                  <Button variant="solid" size="small">
                     Register
                   </Button>
                   <IconAsButton
@@ -197,12 +197,12 @@ import PageHeader from 'blocks/PageHeader';
                   <HeaderRight>
                     <ActionList>
                       <ActionListHole>
-                        <Button type="solid-inverted" size="small">
+                        <Button variant="solid-inverted" size="small">
                           Log in
                         </Button>
                       </ActionListHole>
                       <ActionListHole>
-                        <Button type="solid" size="small">
+                        <Button variant="solid" size="small">
                           Join now
                         </Button>
                       </ActionListHole>
@@ -263,12 +263,12 @@ import PageHeader from 'blocks/PageHeader';
                   <HeaderRight>
                     <ActionList>
                       <ActionListHole>
-                        <Button type="solid-inverted" size="small">
+                        <Button variant="solid-inverted" size="small">
                           Log in
                         </Button>
                       </ActionListHole>
                       <ActionListHole>
-                        <Button type="solid" size="small">
+                        <Button variant="solid" size="small">
                           Join now
                         </Button>
                       </ActionListHole>

--- a/src/components/header/iframe-pages/small-device.jsx
+++ b/src/components/header/iframe-pages/small-device.jsx
@@ -40,7 +40,7 @@ const SmallDeviceExample = () => (
             <RWDHelper hide={RWD_TYPE.SMALL_ONLY}>
               <div>
                 <HeaderRight>
-                  <Button type="solid" size="small">
+                  <Button variant="solid" size="small">
                     Register
                   </Button>
                   <IconAsButton

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -525,7 +525,7 @@ export type IconPropsType =
       /**
       * Option to change tag to span, which allows correct HTML structure
       * @example  <Button
-                    type="secondary"
+                    variant="secondary"
                   >
                     Get +50
                     <Icon
@@ -571,7 +571,7 @@ export type IconPropsType =
       /**
       * Option to change tag to span, which allows correct HTML structure
       * @example  <Button
-                    type="secondary"
+                    variant="secondary"
                   >
                     Get +50
                     <Icon

--- a/src/components/search/Search.jsx
+++ b/src/components/search/Search.jsx
@@ -70,7 +70,7 @@ const Search = ({
       {withRoundButton ? (
         <div className={`${baseClassName}__icon`}>
           <Button
-            type="solid"
+            variant="solid"
             className={cx({
               'sg-search-button--s': size === 's',
             })}

--- a/src/components/toplayer/iframe-pages/notlogged_toplayer.jsx
+++ b/src/components/toplayer/iframe-pages/notlogged_toplayer.jsx
@@ -64,7 +64,7 @@ const content = (
     </ContentBoxContent>
 
     <ContentBoxContent spacedBottom={SPACING_SIZE.LARGE}>
-      <Button type="solid-indigo">Join us</Button>
+      <Button variant="solid-indigo">Join us</Button>
     </ContentBoxContent>
   </ContentBox>
 );

--- a/src/components/toplayer/iframe-pages/small_spaced_toplayer.jsx
+++ b/src/components/toplayer/iframe-pages/small_spaced_toplayer.jsx
@@ -56,7 +56,7 @@ const content = (
     </ContentBoxContent>
 
     <ContentBoxContent spacedBottom={SPACING_SIZE.LARGE}>
-      <Button type="solid">Join us</Button>
+      <Button variant="solid">Join us</Button>
     </ContentBoxContent>
   </ContentBox>
 );

--- a/src/components/transition/stories/ExpandingDetails.jsx
+++ b/src/components/transition/stories/ExpandingDetails.jsx
@@ -166,7 +166,7 @@ const ExpandableBoxContent = ({
         {fullContent}
       </Text>
       <Button
-        type="solid"
+        variant="solid"
         style={{
           position: 'absolute',
           left: 24,

--- a/src/components/transition/stories/FillMode.jsx
+++ b/src/components/transition/stories/FillMode.jsx
@@ -51,7 +51,7 @@ export const FillMode = () => {
         ))}
       </Flex>
 
-      <Button type="solid" onClick={() => setActive(b => !b)} fullWidth>
+      <Button variant="solid" onClick={() => setActive(b => !b)} fullWidth>
         {active ? 'hide' : 'show'}
       </Button>
 

--- a/src/components/transition/stories/FluidList.jsx
+++ b/src/components/transition/stories/FluidList.jsx
@@ -39,7 +39,7 @@ export const FluidList = () => {
 
   return (
     <Stage ref={containerRef} className="sg-space-y-xs" format="portrait">
-      <Button type="outline" onClick={addItem} fullWidth>
+      <Button variant="outline" onClick={addItem} fullWidth>
         add item
       </Button>
 

--- a/src/components/transition/stories/OffsetBehavior.jsx
+++ b/src/components/transition/stories/OffsetBehavior.jsx
@@ -99,7 +99,7 @@ export const OffsetBehavior = () => {
       </Transition>
 
       <Button
-        type="solid"
+        variant="solid"
         icon={<Icon type={open ? 'close' : 'plus'} />}
         onClick={() => setOpen(b => !b)}
         iconOnly

--- a/src/components/transition/stories/SharedAxis.jsx
+++ b/src/components/transition/stories/SharedAxis.jsx
@@ -69,7 +69,7 @@ export const SharedAxis = () => {
         {colorsOrder.map((color, index) => (
           <Button
             key={color}
-            type={index === currentViewIndex ? 'solid-light' : 'transparent'}
+            variant={index === currentViewIndex ? 'solid-light' : 'transparent'}
             icon={<Icon type="circle" color={buttonIconColors[color]} />}
             onClick={() => changeView(index)}
             iconOnly

--- a/src/components/transition/stories/StaggeredMotion.jsx
+++ b/src/components/transition/stories/StaggeredMotion.jsx
@@ -21,7 +21,7 @@ export const StaggeredMotion = () => {
 
   return (
     <Stage className="sg-space-y-xs" format="portrait">
-      <Button type="outline" onClick={() => setOpen(b => !b)} fullWidth>
+      <Button variant="outline" onClick={() => setOpen(b => !b)} fullWidth>
         {open ? 'close' : 'open'}
       </Button>
 

--- a/src/components/transition/stories/TypewriterEffect.jsx
+++ b/src/components/transition/stories/TypewriterEffect.jsx
@@ -21,7 +21,7 @@ export const TypewriterEffect = () => {
   return (
     <Flex className="sg-space-x-xs" alignItems="center">
       <Button
-        type="solid-light"
+        variant="solid-light"
         onClick={() => setActive(b => !b)}
         toggle={active ? 'red' : undefined}
       >

--- a/src/components/transition/stories/common/DummyBox.jsx
+++ b/src/components/transition/stories/common/DummyBox.jsx
@@ -52,7 +52,7 @@ const DummyBox = React.forwardRef<PropsType, HTMLElement>(
         <Button
           size="s"
           icon={<Icon type="close" size={24} />}
-          type="transparent-inverted"
+          variant="transparent-inverted"
           iconOnly
         />
       )}


### PR DESCRIPTION
`type` prop renamed to `variant` and `nativeType` renamed to `type`. This change allows the developer to use the `type` attribute of the native `button` element.