### PR TITLE
High contrast mode for Button

### DIFF
--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -113,7 +113,6 @@ $largeButtonSize: componentSize(l);
 
   &--disabled {
     opacity: 0.45;
-    cursor: not-allowed;
   }
 
   &--full-width {
@@ -349,5 +348,9 @@ $largeButtonSize: componentSize(l);
       clip: rect(0, 0, 0, 0);
       border: none;
     }
+  }
+
+  @media (forced-colors: active) {
+    border: 2px solid ButtonText;
   }
 }


### PR DESCRIPTION
In high contrast mode, Buttons should be recognizable as buttons. One popular way is to add a border in each variant of the Button - this also indicates how large the target area is.

<img width="877" alt="Screenshot 2022-09-22 at 17 03 53" src="https://user-images.githubusercontent.com/60467496/191784455-098568bd-6091-44a0-be11-4d847d7098f5.png">
