### PR TITLE
doc: fix spacing doc

### DIFF
--- a/src/sass/README.md
+++ b/src/sass/README.md
@@ -26,9 +26,10 @@ These variables are encouraged to be used within components and custom CSS. The 
 
 | Variable | Value |
 | -------- | ----- |
+| none     | 0px   |
 | xxs      | 4px   |
 | xs       | 8px   |
-| x        | 16px  |
+| s        | 16px  |
 | m        | 24px  |
 | l        | 40px  |
 | xl       | 64px  |


### PR DESCRIPTION
Change readme to match [real values](https://github.com/brainly/style-guide/blob/master/src/sass/_config.scss#L45).