### PR TITLE
fix invalid subheadline font weight

### DIFF
--- a/src/components/text/_subheadlines.scss
+++ b/src/components/text/_subheadlines.scss
@@ -69,7 +69,7 @@ $subheadlineSizeRules: (
     font-family: $fontFamilyUntitledSerif;
     display: block;
     color: $black;
-    font-weight: $fontWeightBold;
+    font-weight: $fontWeightNormal;
     max-width: 100%;
 
     &--inherited {


### PR DESCRIPTION
According to https://design.brainly.com/8adfd5f36/p/44cf68-typography/t/97b03b Subheadline should use font weight 400