### PR TITLE
Remove "title" node from svg icons during build

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,6 @@ Go to these links to find documentation about [the Flexbox component](src/compon
 
 1. Your svg file has to be exported with a `viewBox="0 0 512 512"`.
 2. Clean up the file: keep only `xmlns` and `viewBox` attributes on `svg` tag and remove the rest (eventually you can use `data-fixedcolors` attribute on `svg` icon which has to have fixed colors for some reason). There is no need to optimize a `<path>` since it will be optimized during build process with [svgo](https://www.npmjs.com/package/svgo).
-3. Remove the title.
 
 Now, your file should look like:
 

--- a/scripts/tasks/svgs-generate.js
+++ b/scripts/tasks/svgs-generate.js
@@ -15,7 +15,12 @@ function svgSymbolCleanUp(config, shape, sprite, callback) {
         childNodes[i].removeAttribute('fill');
       }
     }
+
+    if (childNodes[i].nodeName === 'title') {
+      symbol.removeChild(childNodes[i]);
+    }
   }
+
   callback(null);
 }
 

--- a/scripts/tasks/svgs-generate.js
+++ b/scripts/tasks/svgs-generate.js
@@ -18,6 +18,7 @@ function svgSymbolCleanUp(config, shape, sprite, callback) {
 
     if (childNodes[i].nodeName === 'title') {
       symbol.removeChild(childNodes[i]);
+      i--;
     }
   }
 

--- a/svgo.config.js
+++ b/svgo.config.js
@@ -9,18 +9,18 @@ const removeClass = {
 
 module.exports = {
   subjectIcons: {
-    plugins: [],
+    plugins: ['removeTitle'],
   },
   subjectMonoIcons: {
-    plugins: [removeClass, removeFillNonFixedColors],
+    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle'],
   },
   icons: {
-    plugins: [removeClass, removeFillNonFixedColors],
+    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle'],
   },
   mathSymbols: {
-    plugins: [removeClass, removeFillNonFixedColors],
+    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle'],
   },
   mobileIcons: {
-    plugins: [removeClass, removeFillNonFixedColors],
+    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle'],
   },
 };


### PR DESCRIPTION
Update the icons building process with an additional step - removing the “title” node.