### PR TITLE
Dialog - Add Appearance Prop

### DIFF
--- a/src/components/dialog/Dialog.jsx
+++ b/src/components/dialog/Dialog.jsx
@@ -196,6 +196,7 @@ function BaseDialog({
   );
 
   const containerClass = cx('sg-dialog__container', {
+    'sg-dialog__container--fullscreen': size === 'fullscreen',
     'sg-dialog__container--scroll': scroll === 'inside',
     'sg-dialog__container--open': deferredOpen,
     'sg-dialog__container--exiting': exiting,

--- a/src/components/dialog/Dialog.jsx
+++ b/src/components/dialog/Dialog.jsx
@@ -35,6 +35,7 @@ export type DialogPropsType = $ReadOnly<{
   onExitTransitionEnd?: () => void,
   'data-testid'?: string,
   position?: 'center' | 'top',
+  appearance?: 'none' | 'dialog',
 }>;
 
 /**
@@ -47,6 +48,7 @@ Dialog.defaultProps = ({
   reduceMotion: false,
   scroll: 'outside',
   position: 'center',
+  appearance: 'dialog',
 }: $Shape<DialogPropsType>);
 
 /**
@@ -69,6 +71,7 @@ function BaseDialog({
   onExitTransitionEnd,
   'data-testid': dataTestId,
   position = 'center',
+  appearance = 'dialog',
 }: DialogPropsType) {
   const overlayRef = React.useRef(null);
   const containerRef = React.useRef(null);
@@ -202,6 +205,7 @@ function BaseDialog({
     'sg-dialog__container--exiting': exiting,
     'sg-dialog__container--reduce-motion': reduceMotion,
     'sg-dialog__container--top': position === 'top',
+    'sg-dialog__container--appearance-dialog': appearance === 'dialog',
   });
 
   const childrenWithoutSlots = React.useMemo(

--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -103,9 +103,6 @@ $dialogMaxWidthMap: (
     flex: auto;
     flex-direction: column;
     position: relative;
-    background-color: $white;
-    border-radius: $borderRadiusDefault $borderRadiusDefault 0 0;
-    box-shadow: $dialogBoxShadow;
     width: 100%;
     margin-top: auto;
     margin-bottom: 0;
@@ -116,19 +113,16 @@ $dialogMaxWidthMap: (
     transition-timing-function: $easingExit, $easingLinear;
     opacity: 0;
 
+    @include sgResponsive(md) {
+      margin-bottom: auto;
+    }
+
     &[data-animating='true'] {
       transform: translate3d(0, $dialogSlideWindowDistance, 0);
     }
 
-    @include sgResponsive(md) {
-      border-radius: $borderRadiusDefault;
-      margin-bottom: auto;
-    }
-
     &--fullscreen {
       transition-duration: $durationGentle2, $durationQuick2;
-      border-radius: 0;
-      box-shadow: none;
       max-width: 100%;
       min-height: 100%;
 
@@ -165,6 +159,21 @@ $dialogMaxWidthMap: (
 
       &[data-animating='true'] {
         transform: translate3d(0, 0, 0);
+      }
+    }
+
+    &--appearance-dialog {
+      background-color: $white;
+      border-radius: $borderRadiusDefault $borderRadiusDefault 0 0;
+      box-shadow: $dialogBoxShadow;
+
+      @include sgResponsive(md) {
+        border-radius: $borderRadiusDefault;
+      }
+
+      &.sg-dialog__container--fullscreen {
+        border-radius: 0;
+        box-shadow: none;
       }
     }
   }

--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -125,7 +125,7 @@ $dialogMaxWidthMap: (
       margin-bottom: auto;
     }
 
-    &--size-fullscreen {
+    &--fullscreen {
       transition-duration: $durationGentle2, $durationQuick2;
       border-radius: 0;
       box-shadow: none;


### PR DESCRIPTION
### Why?
There is a need to pass differently styled children and treat a `Dialog` as a functional container, literally an unstyled "window" without its own visual addition... deduplication example in asking a question flow:

https://user-images.githubusercontent.com/13873576/203343672-177e3ce5-4e49-42cf-bf54-e878355f102a.mp4

### How?
|appearance="dialog" (default)|appearance="none"|
|-|-|
|<img width="720" alt="Screenshot 2022-11-22 at 15 33 45" src="https://user-images.githubusercontent.com/13873576/203343797-ea2ce9ef-3a33-4b85-a929-a7bbd01f3aa6.png">|<img width="720" alt="Screenshot 2022-11-22 at 15 47 37" src="https://user-images.githubusercontent.com/13873576/203344039-5a1a63e2-fc19-4962-abfa-d428f11c0aec.png">|

### Additional fixes
[This PR](https://github.com/brainly/style-guide/pull/2471) broke fullscreen behavior by moving its responsibility to the overlay element while leaving styling in the container's modifier class without enabling it in JS.

***(look at the rounded corner)***

|before|after|
|-|-|
|<img width="263" alt="Screenshot 2022-11-22 at 15 28 58" src="https://user-images.githubusercontent.com/13873576/203343364-30a30bf1-d8bc-45a5-ba29-b03b04157a27.png">|<img width="263" alt="Screenshot 2022-11-22 at 15 29 51" src="https://user-images.githubusercontent.com/13873576/203343371-6d96c75f-e11f-4c9b-8c48-3a4ee484706c.png">|
