### PR TITLE
Fix textarea losing focus after error message is displayed

### DIFF
--- a/src/components/form-elements/Textarea.jsx
+++ b/src/components/form-elements/Textarea.jsx
@@ -138,7 +138,7 @@ const Textarea = (props: TextareaPropsType) => {
   const errorMessageDisplayed =
     invalid === true && errorMessage !== undefined && errorMessage !== '';
 
-  return errorMessageDisplayed ? (
+  return (
     <div className={wrapperClass}>
       <Type
         {...additionalProps}
@@ -146,19 +146,14 @@ const Textarea = (props: TextareaPropsType) => {
         ref={textareaRef}
         value={value}
       />
-      <Flex marginTop="xxs" marginLeft="s" marginRight="s">
-        <Text size="xsmall" color="text-red-60">
-          {errorMessage}
-        </Text>
-      </Flex>
+      {errorMessageDisplayed && (
+        <Flex marginTop="xxs" marginLeft="s" marginRight="s">
+          <Text size="xsmall" color="text-red-60">
+            {errorMessage}
+          </Text>
+        </Flex>
+      )}
     </div>
-  ) : (
-    <Type
-      {...additionalProps}
-      className={textareaClass}
-      ref={textareaRef}
-      value={value}
-    />
   );
 };
 


### PR DESCRIPTION
It's the same [issue](https://github.com/brainly/style-guide/pull/2550/) we spotted and fixed for `Input` component.

Preview:

https://user-images.githubusercontent.com/1231144/204576617-24321a16-03fb-43ba-bb68-aa52d63fe0f3.mov

