### PR TITLE
Add useId hook to prevent SSR hydration ID mismatch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "220.7.2-alpha.1",
+  "version": "220.7.1",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "220.7.1",
+  "version": "220.7.2-alpha.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "220.7.1",
+  "version": "220.7.2-alpha.2",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "220.7.2-alpha.0",
+  "version": "220.7.2-alpha.1",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "220.7.2-alpha.2",
+  "version": "220.7.1",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -612,7 +612,7 @@ export type IconPropsType =
       ...
     };
 
-function getIdSuffix(id: string, type: string) {
+function getIdSuffix(id?: string | null, type: string) {
   return id ? `${type}-${id}` : type;
 }
 

--- a/src/components/icons/Icon.jsx
+++ b/src/components/icons/Icon.jsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import {generateId} from '../utils';
+import {useId} from '../utils';
 
 export type IconTypeType =
   | 'academic_cap'
@@ -612,8 +612,8 @@ export type IconPropsType =
       ...
     };
 
-function generateIdSuffix(type: string) {
-  return `${type}-${generateId()}`;
+function getIdSuffix(id: string, type: string) {
+  return id ? `${type}-${id}` : type;
 }
 
 const Icon = ({
@@ -643,7 +643,8 @@ const Icon = ({
   const iconType = `#icon-${type}`;
   const Tag = tagType;
 
-  const idSuffix = generateIdSuffix(type);
+  const id = useId();
+  const idSuffix = getIdSuffix(id, type);
   const titleId = `title-${idSuffix}`;
   const defaultTitle = String(type).replace(/_/g, ' ');
   const descId = `desc-${idSuffix}`;

--- a/src/components/text/Link.jsx
+++ b/src/components/text/Link.jsx
@@ -2,7 +2,7 @@
 
 import * as React from 'react';
 import classNames from 'classnames';
-import {__DEV__, invariant, generateId} from '../utils';
+import {__DEV__, invariant, useId} from '../utils';
 import Text from './Text';
 import type {TextColorType, TextSizeType} from './Text';
 import {
@@ -96,7 +96,7 @@ const Link = (props: LinkPropsType) => {
     hideNewTabIndicator = false,
     ...additionalProps
   } = props;
-  const {current: labelId} = React.useRef(generateId());
+  const labelId = useId();
 
   let textSize: ResponsivePropType<TextSizeType>;
 

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -4,3 +4,5 @@ export {__DEV__} from './consts';
 export {default as invariant} from './invariant';
 export {default as useReducedMotion} from './useReducedMotion';
 export {default as generateId} from './generateId';
+export {useId} from './useId';
+export {useIsomorphicLayoutEffect} from './useIsomorphicLayoutEffect';

--- a/src/components/utils/useId.js
+++ b/src/components/utils/useId.js
@@ -6,17 +6,6 @@ import {useIsomorphicLayoutEffect as useLayoutEffect} from './useIsomorphicLayou
 import generateId from './generateId';
 
 let serverHandoffComplete = false;
-let id = 0;
-
-function genId() {
-  return ++id;
-}
-
-export function useId() {
-  const [id] = React.useState(() => genId());
-
-  return id;
-}
 
 /**
  * useId
@@ -27,7 +16,7 @@ export function useId() {
  *
  * Note: The returned ID will initially be `null` and will update after a component mounts.
  */
-export function useIdBeta() {
+export function useId() {
   const initialId = serverHandoffComplete ? generateId() : null;
   const [id, setId] = React.useState(initialId);
 

--- a/src/components/utils/useId.js
+++ b/src/components/utils/useId.js
@@ -7,6 +7,15 @@ import generateId from './generateId';
 
 let serverHandoffComplete = false;
 
+/**
+ * useId
+ *
+ * inspired by https://github.com/reach/reach-ui/blob/dev/packages/auto-id/src/reach-auto-id.ts
+ *
+ * Generates unique IDs while avoiding hydration mismatches
+ *
+ * Note: The returned ID will initially be `null` and will update after a component mounts.
+ */
 export function useId() {
   const initialId = serverHandoffComplete ? generateId() : null;
   const [id, setId] = React.useState(initialId);

--- a/src/components/utils/useId.js
+++ b/src/components/utils/useId.js
@@ -1,0 +1,28 @@
+// @flow strict
+
+import * as React from 'react';
+
+import {useIsomorphicLayoutEffect as useLayoutEffect} from './useIsomorphicLayoutEffect';
+import generateId from './generateId';
+
+let serverHandoffComplete = false;
+
+export function useId() {
+  const initialId = serverHandoffComplete ? generateId() : null;
+  const [id, setId] = React.useState(initialId);
+
+  useLayoutEffect(() => {
+    if (id === null) {
+      setId(generateId());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  React.useEffect(() => {
+    if (serverHandoffComplete === false) {
+      serverHandoffComplete = true;
+    }
+  }, []);
+
+  return id ?? undefined;
+}

--- a/src/components/utils/useId.js
+++ b/src/components/utils/useId.js
@@ -6,6 +6,17 @@ import {useIsomorphicLayoutEffect as useLayoutEffect} from './useIsomorphicLayou
 import generateId from './generateId';
 
 let serverHandoffComplete = false;
+let id = 0;
+
+function genId() {
+  return ++id;
+}
+
+export function useId() {
+  const [id] = React.useState(() => genId());
+
+  return id;
+}
 
 /**
  * useId
@@ -16,7 +27,7 @@ let serverHandoffComplete = false;
  *
  * Note: The returned ID will initially be `null` and will update after a component mounts.
  */
-export function useId() {
+export function useIdBeta() {
   const initialId = serverHandoffComplete ? generateId() : null;
   const [id, setId] = React.useState(initialId);
 


### PR DESCRIPTION
**Issue:**

Server vs client mismatch of generated id

<img width="667" alt="Screenshot 2022-12-16 at 10 06 05" src="https://user-images.githubusercontent.com/1231144/208062944-a35c6dcc-bd88-4594-9e34-429ddccdb7ab.png">


**Notes:**
- slightly 😉  inspired by `@reach/auto-id` lib
- released as `v220.7.2-alpha.1` and tested in web app