### PR TITLE
metrics-cli: pass ignore argument to main

### DIFF
--- a/bin/metrics/cli.js
+++ b/bin/metrics/cli.js
@@ -29,6 +29,7 @@ const command = meow({
 
 main(command.input, {
   dry: command.flags.dry,
+  ignore: command.flags.ignore,
 })
   .then(() => {
     process.exit(0);


### PR DESCRIPTION
Metrics CLI is not passing ignore arguments to `main.js`, causing  ignore option not to work. I added this missing argument to main function