### PR TITLE
Change Rating component - change icon type, spacings and UI of active state

### DIFF
--- a/src/components/rating/Rating.jsx
+++ b/src/components/rating/Rating.jsx
@@ -174,7 +174,7 @@ class Rating extends React.Component<RatingPropsType> {
     }
 
     return (
-      <div className={ratingClass} aria-label={label}>
+      <div className={ratingClass} aria-label={label} role="group">
         <p className="sg-rate-box__rate">
           {!noLabel && <span aria-hidden>{rateString}</span>}
           {Boolean(rate) && (

--- a/src/components/rating/Rating.jsx
+++ b/src/components/rating/Rating.jsx
@@ -5,7 +5,6 @@ import classnames from 'classnames';
 import Star from './subcomponents/Star';
 import RateCounter from './subcomponents/RateCounter';
 import {__DEV__, invariant} from '../utils';
-import {ICON_COLOR} from '../icons/Icon';
 
 type RatingSizeType = 's' | 'xs';
 

--- a/src/components/rating/Rating.jsx
+++ b/src/components/rating/Rating.jsx
@@ -5,6 +5,7 @@ import classnames from 'classnames';
 import Star from './subcomponents/Star';
 import RateCounter from './subcomponents/RateCounter';
 import {__DEV__, invariant} from '../utils';
+import {ICON_COLOR} from '../icons/Icon';
 
 type RatingSizeType = 's' | 'xs';
 
@@ -177,7 +178,9 @@ class Rating extends React.Component<RatingPropsType> {
       <div className={ratingClass} aria-label={label}>
         <p className="sg-rate-box__rate">
           {!noLabel && <span aria-hidden>{rateString}</span>}
-          {rate && <span className="sg-visually-hidden">{metricString}</span>}
+          {Boolean(rate) && (
+            <span className="sg-visually-hidden">{metricString}</span>
+          )}
         </p>
         <div
           className="sg-rate-box__stars-container"
@@ -203,6 +206,7 @@ class Rating extends React.Component<RatingPropsType> {
                 key={props.value}
                 onMouseEnter={this.starsMouseEnterFunctions[props.value]}
                 {...props}
+                type="star_outlined"
               />
             ))}
           </div>

--- a/src/components/rating/Rating.jsx
+++ b/src/components/rating/Rating.jsx
@@ -174,7 +174,8 @@ class Rating extends React.Component<RatingPropsType> {
     }
 
     return (
-      <div className={ratingClass} aria-label={label} role="group">
+      <div className={ratingClass}>
+        <span className="sg-visually-hidden">{label}</span>
         <p className="sg-rate-box__rate">
           {!noLabel && <span aria-hidden>{rateString}</span>}
           {Boolean(rate) && (

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -1,9 +1,8 @@
 @use 'sass:math';
 $rateHeight: componentSize(s);
-$rateStarColor: $gray-50;
+$rateStarColor: $icon-yellow-50;
 $rateStarCheckedColor: $icon-yellow-50;
-$rateStarActiveColor: $gray-40;
-$rateStarActiveCheckedColor: $yellow-40;
+$rateStarActiveColor: $icon-gray-50;
 $rateCounterColor: $gray-50;
 $rateFontSize: fontSize(obscure);
 $rateIconSize: componentSize(xs);
@@ -38,14 +37,20 @@ $includeHtml: false !default;
       }
 
       .sg-rate-box__stars-container:hover {
-        .sg-rate-box__filled-stars {
+        .sg-rate-box__background-stars {
           display: none;
+        }
+
+        .sg-rate-box__filled-stars {
+          width: 100% !important;
+          pointer-events: unset;
+          position: relative;
         }
       }
 
-      .sg-rate-box__background-stars {
+      .sg-rate-box__filled-stars {
         .sg-rate-box__star:hover ~ .sg-rate-box__star {
-          color: $rateStarColor;
+          color: $rateStarActiveColor;
         }
 
         &:active .sg-rate-box__star:hover ~ .sg-rate-box__star {
@@ -58,7 +63,7 @@ $includeHtml: false !default;
         }
 
         &:active:hover .sg-rate-box__star {
-          color: $rateStarActiveCheckedColor;
+          color: $rateStarCheckedColor;
           transition: none;
         }
       }

--- a/src/components/rating/_rating.scss
+++ b/src/components/rating/_rating.scss
@@ -119,7 +119,7 @@ $includeHtml: false !default;
       @include fixOperaMiniLabelText();
       font-weight: $fontWeightBold;
       color: $rateCounterColor;
-      margin: 0 0 0 gutter(math.div(1, 4));
+      margin: 0 0 0 spacing(xxs);
       position: relative;
     }
 
@@ -145,7 +145,7 @@ $includeHtml: false !default;
       color: $rateCounterColor;
 
       & span[aria-hidden] {
-        margin: 0 gutter(math.div(1, 4)) 0 0;
+        margin: 0 spacing(xxs) 0 0;
       }
     }
 

--- a/src/components/rating/subcomponents/Star.jsx
+++ b/src/components/rating/subcomponents/Star.jsx
@@ -13,7 +13,7 @@ export type StarPropsType = {
   active?: boolean,
   'aria-label'?: string,
   value?: number,
-  type: 'star' | 'star_outlined',
+  type?: 'star' | 'star_outlined',
   ...
 };
 

--- a/src/components/rating/subcomponents/Star.jsx
+++ b/src/components/rating/subcomponents/Star.jsx
@@ -13,6 +13,7 @@ export type StarPropsType = {
   active?: boolean,
   'aria-label'?: string,
   value?: number,
+  type: 'star' | 'star_outlined',
   ...
 };
 
@@ -23,6 +24,7 @@ const Star = ({
   active,
   'aria-label': label,
   value,
+  type = 'star',
   ...props
 }: StarPropsType) => {
   if (__DEV__) {
@@ -45,7 +47,7 @@ const Star = ({
         />
       )}
       <Icon
-        type="star"
+        type={type}
         size={size}
         color={ICON_COLOR.ADAPTIVE}
         className="sg-rate-box__star-icon"


### PR DESCRIPTION
- change spacing between number of votes and stars and between rating and stars from 6px to 4px
- change star type to star_outlined when empty
- fix bug -> '0' visible before rating when it equals 0

**BUG FIX**
Before:
![image](https://user-images.githubusercontent.com/39903772/210737065-524cf8ac-a2ee-4433-840e-f616356aef6b.png)

After:
![image](https://user-images.githubusercontent.com/39903772/210737077-de3af6cb-3394-4e75-8afe-f805cf30a800.png)


**CHANGED SPACINGS**
Before:
![image](https://user-images.githubusercontent.com/39903772/210737052-13683ade-db8f-49c7-a591-33be711457ca.png)

After:
![image](https://user-images.githubusercontent.com/39903772/210737032-ed33fe4b-f579-43c9-8604-02d78fcff9be.png)


**ACTIVE STATE**
Before:

https://user-images.githubusercontent.com/39903772/210737805-d37681fb-02d3-48e0-be81-088af2b57048.mov


After (UI for active is done as it's in the custom `Rating` component on QPage currently):

https://user-images.githubusercontent.com/39903772/210737818-edda2c7f-8df9-4e92-8117-3f22e7ca3737.mov



