### PR TITLE
change dialog bottomsheet border radius

### DIFF
--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -176,7 +176,7 @@ $dialogMaxWidthMap: (
 
     &--appearance-dialog {
       background-color: $white;
-      border-radius: $borderRadiusDefault $borderRadiusDefault 0 0;
+      border-radius: 24px 24px 0 0;
       box-shadow: $dialogBoxShadow;
 
       @include sgResponsive(md) {


### PR DESCRIPTION
in order to align with the bottomsheet dialog we use for mobile app there is a suggestion to round the corners to 24px on web as well.

discussed with Michał Skowronek, Maciek Nowak and Olga Wysopal, shown on sharpener.

| before | after |
| -- | -- |
| <img width="532" alt="Screenshot 2023-01-12 at 10 09 07" src="https://user-images.githubusercontent.com/53941885/212026203-102e06b9-e2cf-4911-a3fb-94327f55f31d.png"> | <img width="529" alt="Screenshot 2023-01-12 at 10 09 12" src="https://user-images.githubusercontent.com/53941885/212026224-3fb675f7-f5ec-4340-bc3d-d9c8512b45c7.png"> |
