### PR TITLE
fix path to logos

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -15,7 +15,7 @@ node ./scripts/build-sandbox-types.js
 PUBLIC_PATH=$HOST/$VERSION/docs/ yarn build-sandbox --mode production
 PUBLIC_PATH=$HOST/$VERSION/docs/ yarn build-sandbox-addon --mode production
 yarn build-newsletter-stories
-VERSION=$VERSION yarn build-storybook --quiet -o dist/storybook/$VERSION/docs
+PUBLIC_PATH=$HOST/ VERSION=$VERSION yarn build-storybook --quiet -o dist/storybook/$VERSION/docs
 
 optstring="d"
 


### PR DESCRIPTION
On dev and prod storybook logotypes were loaded from localhost. Now path is set based on environment