### PR TITLE
Rename type, htmlType, tagType to as

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "222.1.0",
+  "version": "223.0.0-beta.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "223.0.0-beta.0",
+  "version": "222.1.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",

--- a/src/components/avatar/Avatar.stories.mdx
+++ b/src/components/avatar/Avatar.stories.mdx
@@ -58,7 +58,7 @@ import AvatarA11y from './stories/Avatar.a11y.mdx';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -69,7 +69,7 @@ import AvatarA11y from './stories/Avatar.a11y.mdx';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -80,7 +80,7 @@ import AvatarA11y from './stories/Avatar.a11y.mdx';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -96,7 +96,7 @@ import AvatarA11y from './stories/Avatar.a11y.mdx';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >

--- a/src/components/buttons/Button.stories.mdx
+++ b/src/components/buttons/Button.stories.mdx
@@ -83,7 +83,7 @@ const iconSize = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -94,7 +94,7 @@ const iconSize = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -105,7 +105,7 @@ const iconSize = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -116,7 +116,7 @@ const iconSize = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -127,7 +127,7 @@ const iconSize = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -138,7 +138,7 @@ const iconSize = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -189,7 +189,7 @@ const iconSize = {
                   <Headline
                     extraBold
                     transform="uppercase"
-                    type="span"
+                    as="span"
                     color={
                       [
                         'solid-inverted',
@@ -347,7 +347,7 @@ const iconSize = {
                       <Headline
                         extraBold
                         transform="uppercase"
-                        type="span"
+                        as="span"
                         color="text-gray-40"
                         size="medium"
                       >
@@ -358,7 +358,7 @@ const iconSize = {
                       <Headline
                         extraBold
                         transform="uppercase"
-                        type="span"
+                        as="span"
                         color="text-gray-40"
                         size="medium"
                       >
@@ -369,7 +369,7 @@ const iconSize = {
                       <Headline
                         extraBold
                         transform="uppercase"
-                        type="span"
+                        as="span"
                         color="text-gray-40"
                         size="medium"
                       >
@@ -383,7 +383,7 @@ const iconSize = {
                         <Headline
                           extraBold
                           transform="uppercase"
-                          type="span"
+                          as="span"
                           color="text-gray-40"
                           size="medium"
                         >
@@ -431,7 +431,7 @@ const iconSize = {
                       <Headline
                         extraBold
                         transform="uppercase"
-                        type="span"
+                        as="span"
                         color="text-gray-40"
                         size="medium"
                       >
@@ -442,7 +442,7 @@ const iconSize = {
                       <Headline
                         extraBold
                         transform="uppercase"
-                        type="span"
+                        as="span"
                         color="text-gray-40"
                         size="medium"
                       >
@@ -453,7 +453,7 @@ const iconSize = {
                       <Headline
                         extraBold
                         transform="uppercase"
-                        type="span"
+                        as="span"
                         color="text-gray-40"
                         size="medium"
                       >
@@ -467,7 +467,7 @@ const iconSize = {
                         <Headline
                           extraBold
                           transform="uppercase"
-                          type="span"
+                          as="span"
                           color="text-gray-40"
                           size="medium"
                         >

--- a/src/components/buttons/stories/rules.a11y.ts
+++ b/src/components/buttons/stories/rules.a11y.ts
@@ -100,7 +100,7 @@ export const hrefRules = [
 export const toggleRules = [
   {
     pattern: '<b>Should</b> have type <code>button</code>.',
-    comment: 'Use <code>type` to set the type.',
+    comment: 'Use <code>type</code> to set the type.',
     status: 'DONE',
     tests: 'TO DO',
   },

--- a/src/components/counters/Counter.tsx
+++ b/src/components/counters/Counter.tsx
@@ -137,7 +137,7 @@ const Counter = ({
 
         <Flex alignItems="center">
           <Text
-            type="span"
+            as="span"
             weight="bold"
             size={
               size !== undefined && size !== null && size === 'xxs'

--- a/src/components/counters/Counters.stories.mdx
+++ b/src/components/counters/Counters.stories.mdx
@@ -61,7 +61,7 @@ import PageHeader from 'blocks/PageHeader';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -72,7 +72,7 @@ import PageHeader from 'blocks/PageHeader';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -83,7 +83,7 @@ import PageHeader from 'blocks/PageHeader';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -99,7 +99,7 @@ import PageHeader from 'blocks/PageHeader';
                   <Headline
                     extraBold
                     transform="uppercase"
-                    type="span"
+                    as="span"
                     color="text-gray-40"
                     size="medium"
                   >
@@ -129,7 +129,7 @@ import PageHeader from 'blocks/PageHeader';
                       size={size}
                     >
                       +15
-                      <Text type="span" color="text-gray-60" inherited>
+                      <Text as="span" color="text-gray-60" inherited>
                         {size !== 'xxs' && ` pts`}{' '}
                       </Text>
                     </Counter>

--- a/src/components/counters/stories/Counter.a11y.mdx
+++ b/src/components/counters/stories/Counter.a11y.mdx
@@ -23,7 +23,7 @@ import rules from './rules.a11y';
 ```jsx
 <Counter aria-label="Points to earn:" icon={ICON_TYPE.POINTS}>
   +15
-  <Text type="span" color="text-gray-60" inherited>
+  <Text as="span" color="text-gray-60" inherited>
     pts
   </Text>
 </Counter>

--- a/src/components/flash-messages/FlashMessage.stories.mdx
+++ b/src/components/flash-messages/FlashMessage.stories.mdx
@@ -46,7 +46,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-right"

--- a/src/components/flex/Flex.spec.tsx
+++ b/src/components/flex/Flex.spec.tsx
@@ -259,7 +259,7 @@ describe('<Flex>', () => {
   });
   it('renders component with different html tag', () => {
     const component = shallow(
-      <Flex htmlTag="ul">
+      <Flex as="ul">
         <div>test</div>
       </Flex>
     );

--- a/src/components/flex/Flex.stories.mdx
+++ b/src/components/flex/Flex.stories.mdx
@@ -28,7 +28,7 @@ const indigoBoxStyle = {
         disable: true,
       },
     },
-    htmlTag: {
+    as: {
       defaultValue: 'div',
       table: {
         defaultValue: {summary: 'div'},

--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -80,7 +80,7 @@ export type FlexPropsType = {
   /**
    * Html tag used as container
    */
-  htmlTag?: FlexContainerType;
+  as?: FlexContainerType;
 
   /**
    * Additional class names
@@ -244,7 +244,7 @@ export type FlexPropsType = {
 } & Omit<
   React.AllHTMLAttributes<HTMLElement>,
   | 'children'
-  | 'htmlTag'
+  | 'as'
   | 'className'
   | 'fullWidth'
   | 'fullHeight'
@@ -266,7 +266,7 @@ export type FlexPropsType = {
 const Flex = React.forwardRef<HTMLElement, FlexPropsType>(
   (props: FlexPropsType, ref) => {
     const {
-      htmlTag: Container = 'div',
+      as: Container = 'div',
       fullWidth,
       fullHeight,
       noShrink,

--- a/src/components/flex/stories/Flex.a11y.mdx
+++ b/src/components/flex/stories/Flex.a11y.mdx
@@ -5,6 +5,5 @@ import rules from './rules.a11y';
 <AccessibilityList rules={rules} />
 
 <InfoBox>
-  <code>Flex</code> should comply with the rules defined by the{' '}
-  <code>htmlTag</code>.
+  <code>Flex</code> should comply with the rules defined by the <code>as</code>.
 </InfoBox>

--- a/src/components/form-elements/ErrorMessage.tsx
+++ b/src/components/form-elements/ErrorMessage.tsx
@@ -29,7 +29,7 @@ const ErrorMessage = ({
       id={id}
       color={color}
       size="small"
-      type="span"
+      as="span"
       weight="bold"
     >
       {children}

--- a/src/components/form-elements/Input.stories.mdx
+++ b/src/components/form-elements/Input.stories.mdx
@@ -45,7 +45,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-center"
@@ -60,7 +60,7 @@ import Input, {SIZE, COLOR} from './Input';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -91,7 +91,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-center"
@@ -103,7 +103,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-center"
@@ -115,7 +115,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-center"
@@ -129,7 +129,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-right"
@@ -152,7 +152,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-right"
@@ -175,7 +175,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-right"
@@ -196,7 +196,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-right"
@@ -217,7 +217,7 @@ import Input, {SIZE, COLOR} from './Input';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
                 align="to-right"

--- a/src/components/form-elements/Select.stories.mdx
+++ b/src/components/form-elements/Select.stories.mdx
@@ -57,7 +57,7 @@ import Headline from '../text/Headline';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -88,7 +88,7 @@ import Headline from '../text/Headline';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -99,7 +99,7 @@ import Headline from '../text/Headline';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -110,7 +110,7 @@ import Headline from '../text/Headline';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -123,7 +123,7 @@ import Headline from '../text/Headline';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -145,7 +145,7 @@ import Headline from '../text/Headline';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-white"
                 size="medium"
               >
@@ -167,7 +167,7 @@ import Headline from '../text/Headline';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -189,7 +189,7 @@ import Headline from '../text/Headline';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -211,7 +211,7 @@ import Headline from '../text/Headline';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >

--- a/src/components/form-elements/Textarea.spec.tsx
+++ b/src/components/form-elements/Textarea.spec.tsx
@@ -72,7 +72,7 @@ test('Type', () => {
 
   const textarea = mount(
     // eslint-disable-next-line react/jsx-no-bind
-    <Textarea type={CustomTextarea} />
+    <Textarea as={CustomTextarea} />
   );
 
   expect(textarea.find('[data-super-custom="superCustom"]')).toHaveLength(1);

--- a/src/components/form-elements/Textarea.stories.mdx
+++ b/src/components/form-elements/Textarea.stories.mdx
@@ -152,7 +152,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -163,7 +163,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -174,7 +174,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -187,7 +187,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -209,7 +209,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-white"
                 size="medium"
               >
@@ -231,7 +231,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -250,7 +250,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -269,7 +269,7 @@ import PageHeader from 'blocks/PageHeader';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >

--- a/src/components/form-elements/Textarea.tsx
+++ b/src/components/form-elements/Textarea.tsx
@@ -18,8 +18,7 @@ export const TEXTAREA_COLOR = {
 } as const;
 
 export type TextareaPropsType = {
-  // $FlowFixMe any generic prop types here broke autocomplete, so let's leave it as is for now
-  type?: string | ((arg0: any) => React.ReactNode);
+  as?: string | ((arg0: any) => React.ReactNode);
 
   /**
    * Additional function to set ref for textarea
@@ -98,7 +97,7 @@ export type TextareaPropsType = {
   className?: string;
 } & Omit<
   React.AllHTMLAttributes<HTMLElement>,
-  | 'type'
+  | 'as'
   | 'textareaRef'
   | 'value'
   | 'color'
@@ -127,7 +126,7 @@ const Textarea = (props: TextareaPropsType) => {
     className,
     textareaRef,
     errorMessage,
-    type: Type = 'textarea',
+    as: Type = 'textarea',
     ...additionalProps
   } = props;
 

--- a/src/components/form-elements/checkbox/Checkbox.stories.mdx
+++ b/src/components/form-elements/checkbox/Checkbox.stories.mdx
@@ -70,7 +70,7 @@ import CheckboxA11y from './stories/Checkbox.a11y.mdx';
                     key={index}
                     extraBold
                     transform="uppercase"
-                    type="span"
+                    as="span"
                     color="text-gray-70"
                     size="small"
                   >
@@ -103,7 +103,7 @@ import CheckboxA11y from './stories/Checkbox.a11y.mdx';
                   <Headline
                     extraBold
                     transform="uppercase"
-                    type="span"
+                    as="span"
                     color="text-gray-70"
                     size="small"
                   >
@@ -198,7 +198,7 @@ import CheckboxA11y from './stories/Checkbox.a11y.mdx';
                     key={index}
                     extraBold
                     transform="uppercase"
-                    type="span"
+                    as="span"
                     color="text-gray-70"
                     size="small"
                   >
@@ -247,7 +247,7 @@ import CheckboxA11y from './stories/Checkbox.a11y.mdx';
                   <Headline
                     extraBold
                     transform="uppercase"
-                    type="span"
+                    as="span"
                     color="text-gray-70"
                     size="small"
                   >

--- a/src/components/form-elements/checkbox/Checkbox.tsx
+++ b/src/components/form-elements/checkbox/Checkbox.tsx
@@ -297,7 +297,7 @@ const Checkbox = ({
         {!ariaLabelledBy && hasLabel && (
           <Text
             htmlFor={checkboxId}
-            type="label"
+            as="label"
             size={labelSize}
             weight="bold"
             className={labelClass}
@@ -314,7 +314,7 @@ const Checkbox = ({
               id={descriptionId}
               className="sg-checkbox__description"
               size="small"
-              type="span"
+              as="span"
               breakWords
             >
               {description}

--- a/src/components/form-elements/radio/Radio.stories.mdx
+++ b/src/components/form-elements/radio/Radio.stories.mdx
@@ -66,7 +66,7 @@ import RadioA11y from './stories/Radio.a11y.mdx';
                         key={index}
                         extraBold
                         transform="uppercase"
-                        type="span"
+                        as="span"
                         color="text-gray-70"
                         size="small"
                       >
@@ -100,7 +100,7 @@ import RadioA11y from './stories/Radio.a11y.mdx';
                     <Headline
                       extraBold
                       transform="uppercase"
-                      type="span"
+                      as="span"
                       color="text-gray-70"
                       size="small"
                     >
@@ -173,7 +173,7 @@ import RadioA11y from './stories/Radio.a11y.mdx';
                         key={index}
                         extraBold
                         transform="uppercase"
-                        type="span"
+                        as="span"
                         color="text-gray-70"
                         size="small"
                       >
@@ -223,7 +223,7 @@ import RadioA11y from './stories/Radio.a11y.mdx';
                     <Headline
                       extraBold
                       transform="uppercase"
-                      type="span"
+                      as="span"
                       color="text-gray-70"
                       size="small"
                     >

--- a/src/components/form-elements/radio/Radio.tsx
+++ b/src/components/form-elements/radio/Radio.tsx
@@ -250,7 +250,7 @@ const Radio = ({
           <Text
             id={labelId}
             htmlFor={radioId}
-            type="label"
+            as="label"
             size={labelSize}
             weight="bold"
             className={labelClass}
@@ -264,7 +264,7 @@ const Radio = ({
           id={descriptionId}
           className="sg-radio__description"
           size="small"
-          type="span"
+          as="span"
           breakWords
         >
           {description}

--- a/src/components/form-elements/radio/stories/useRadioContextStories.tsx
+++ b/src/components/form-elements/radio/stories/useRadioContextStories.tsx
@@ -36,7 +36,7 @@ const CustomRadioComponent = ({
 
   const Benefit = ({item}: {item: string}) => {
     return (
-      <Flex marginBottom="m" htmlTag="li">
+      <Flex marginBottom="m" as="li">
         <Flex alignItems="center" justifyContent="center">
           <Icon
             type="check"
@@ -96,7 +96,7 @@ const CustomRadioComponent = ({
         />
         <Text
           id={labelId}
-          type="label"
+          as="label"
           weight="bold"
           transform="capitalize"
           style={{
@@ -107,7 +107,7 @@ const CustomRadioComponent = ({
         </Text>
       </Flex>
       <Flex
-        htmlTag="ul"
+        as="ul"
         direction="column"
         alignItems="flex-start"
         style={{

--- a/src/components/form-elements/radio/useRadioContext.stories.mdx
+++ b/src/components/form-elements/radio/useRadioContext.stories.mdx
@@ -116,7 +116,7 @@ const CustomRadioComponent = ({
 
   const Benefit = ({item}: {item: string}) => {
     return (
-      <Flex marginBottom="8px" htmlTag="li">
+      <Flex marginBottom="8px" as="li">
         <Flex alignItems="center" justifyContent="center">
           <Icon
             type="check"
@@ -176,7 +176,7 @@ const CustomRadioComponent = ({
         </Text>
       </Flex>
       <Flex
-        htmlTag="ul"
+        as="ul"
         direction="column"
         alignItems="flex-start"
         style={{padding: '0'}}

--- a/src/components/icon-as-button/IconAsButton.stories.mdx
+++ b/src/components/icon-as-button/IconAsButton.stories.mdx
@@ -64,7 +64,7 @@ import {formatTags} from '../../docs/utils';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -75,7 +75,7 @@ import {formatTags} from '../../docs/utils';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -86,7 +86,7 @@ import {formatTags} from '../../docs/utils';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -97,7 +97,7 @@ import {formatTags} from '../../docs/utils';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -120,7 +120,7 @@ import {formatTags} from '../../docs/utils';
                   <Headline
                     extraBold
                     transform="uppercase"
-                    type="span"
+                    as="span"
                     color="text-gray-40"
                     size="medium"
                   >

--- a/src/components/icons/Icon.spec.tsx
+++ b/src/components/icons/Icon.spec.tsx
@@ -54,9 +54,7 @@ test('size', () => {
   expect(icon.hasClass(`sg-icon--x${size}`)).toEqual(true);
 });
 test('tag type', () => {
-  const component = shallow(
-    <Icon type={TYPE.ANSWER} size={16} tagType="span" />
-  );
+  const component = shallow(<Icon type={TYPE.ANSWER} size={16} as="span" />);
 
   expect(component.find('span')).toHaveLength(1);
 });

--- a/src/components/icons/Icon.stories.mdx
+++ b/src/components/icons/Icon.stories.mdx
@@ -22,7 +22,7 @@ import {formatTags} from '../../docs/utils';
         },
       },
     },
-    tagType: {
+    as: {
       description:
         'Option to change tag to span, which allows correct HTML structure',
       table: {
@@ -95,7 +95,7 @@ import {formatTags} from '../../docs/utils';
           <Headline
             extraBold
             transform="uppercase"
-            type="span"
+            as="span"
             color="text-gray-40"
             size="medium"
             style={{marginBottom: 10, marginLeft: 10}}
@@ -112,7 +112,7 @@ import {formatTags} from '../../docs/utils';
           <Headline
             extraBold
             transform="uppercase"
-            type="span"
+            as="span"
             color="text-gray-40"
             size="medium"
             style={{marginBottom: 10, marginLeft: 10, marginTop: 40}}
@@ -129,7 +129,7 @@ import {formatTags} from '../../docs/utils';
           <Headline
             extraBold
             transform="uppercase"
-            type="span"
+            as="span"
             color="text-gray-40"
             size="medium"
             style={{marginBottom: 10, marginLeft: 10, marginTop: 40}}
@@ -146,7 +146,7 @@ import {formatTags} from '../../docs/utils';
           <Headline
             extraBold
             transform="uppercase"
-            type="span"
+            as="span"
             color="text-gray-40"
             size="medium"
             style={{marginBottom: 10, marginLeft: 10, marginTop: 40}}
@@ -163,7 +163,7 @@ import {formatTags} from '../../docs/utils';
           <Headline
             extraBold
             transform="uppercase"
-            type="span"
+            as="span"
             color="text-gray-40"
             size="medium"
             style={{marginBottom: 10, marginLeft: 10, marginTop: 40}}

--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -174,7 +174,7 @@ export type IconColorType =
   | 'icon-gray-50'
   | 'icon-gray-40';
 
-export type IconTagType = 'div' | 'span';
+export type IconAsType = 'div' | 'span';
 export type IconSizeType = 16 | 24 | 32 | 40 | 56 | 80 | 104;
 
 export const TYPE = {
@@ -395,11 +395,11 @@ export type IconPropsType =
                   type={iconTypes.POINTS}
                   color="dark"
                   size={16}
-                  tagType="span"
+                  as="span"
                 />
               </Button>
   */
-      tagType?: IconTagType;
+      as?: IconAsType;
 
       /**
        * An accessible, short-text description; defaults to `type`
@@ -412,13 +412,7 @@ export type IconPropsType =
       description?: string;
     } & Omit<
       React.AllHTMLAttributes<HTMLElement>,
-      | 'className'
-      | 'color'
-      | 'size'
-      | 'type'
-      | 'tagType'
-      | 'title'
-      | 'description'
+      'className' | 'color' | 'size' | 'type' | 'as' | 'title' | 'description'
     >)
   | ({
       /**
@@ -455,11 +449,11 @@ export type IconPropsType =
                   type={iconTypes.POINTS}
                   color="dark"
                   size={16}
-                  tagType="span"
+                  as="span"
                 />
               </Button>
   */
-      tagType?: IconTagType;
+      as?: IconAsType;
 
       /**
        * An accessible, short-text description; defaults to `type`
@@ -476,7 +470,7 @@ export type IconPropsType =
       | 'className'
       | 'color'
       | 'size'
-      | 'tagType'
+      | 'as'
       | 'title'
       | 'description'
     >);
@@ -490,7 +484,7 @@ const Icon = ({
   size = 24,
   type,
   children,
-  tagType = 'div',
+  as = 'div',
   className,
   title,
   description,
@@ -505,7 +499,7 @@ const Icon = ({
     className
   );
   const iconType = `#icon-${type}`;
-  const Tag = tagType;
+  const Tag = as;
   const idSuffix = generateIdSuffix(type);
   const titleId = `title-${idSuffix}`;
   const defaultTitle = String(type).replace(/_/g, ' ');

--- a/src/components/labels/Label.stories.mdx
+++ b/src/components/labels/Label.stories.mdx
@@ -80,7 +80,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -91,7 +91,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -102,7 +102,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -113,7 +113,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -178,7 +178,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -189,7 +189,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -200,7 +200,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -211,7 +211,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -262,7 +262,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -273,7 +273,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -284,7 +284,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -295,7 +295,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -357,7 +357,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -368,7 +368,7 @@ const TRANSPARENT_ICON_COLOR_MAP = {
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >

--- a/src/components/list/MenuList.spec.tsx
+++ b/src/components/list/MenuList.spec.tsx
@@ -34,12 +34,12 @@ describe('<MenuItem />', () => {
     expect(menuItem.find('.sg-menu-list__link')).toHaveLength(1);
   });
   test('renders different type of html element', () => {
-    const menuItem = shallow(<MenuItem type="span" text="test" />);
+    const menuItem = shallow(<MenuItem as="span" text="test" />);
 
     expect(menuItem.find('span')).toHaveLength(1);
   });
   test('passes props to link element', () => {
-    const menuItem = shallow(<MenuItem type="span" text="test" id="m4l" />);
+    const menuItem = shallow(<MenuItem as="span" text="test" id="m4l" />);
 
     expect(menuItem.find('.sg-menu-list__link').props().id).toEqual('m4l');
   });

--- a/src/components/list/subcomponents/MenuItem.tsx
+++ b/src/components/list/subcomponents/MenuItem.tsx
@@ -5,21 +5,19 @@ export type MenuItemPropsType = {
   className?: string;
   href?: string;
   text: string;
-  // $FlowFixMe
-  type?: string | ((arg0: any) => React.ReactNode);
+  as?: string | ((arg0: any) => React.ReactNode);
 } & Omit<
   React.AllHTMLAttributes<HTMLElement>,
-  'className' | 'href' | 'text' | 'type'
+  'className' | 'href' | 'text' | 'as'
 >;
 
 const MenuItem = ({
   text,
   href,
-  type,
+  as: Type = 'a',
   className,
   ...restProps
 }: MenuItemPropsType) => {
-  const Type = type !== undefined ? type : 'a';
   const elementClass = classnames('sg-menu-list__link', className);
 
   return (

--- a/src/components/search/Search.stories.mdx
+++ b/src/components/search/Search.stories.mdx
@@ -75,7 +75,7 @@ import {formatTags} from '../../docs/utils';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -88,7 +88,7 @@ import {formatTags} from '../../docs/utils';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -103,7 +103,7 @@ import {formatTags} from '../../docs/utils';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -142,7 +142,7 @@ import {formatTags} from '../../docs/utils';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -155,7 +155,7 @@ import {formatTags} from '../../docs/utils';
                 <Headline
                   extraBold
                   transform="uppercase"
-                  type="span"
+                  as="span"
                   color="text-gray-40"
                   size="medium"
                 >
@@ -169,7 +169,7 @@ import {formatTags} from '../../docs/utils';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -196,7 +196,7 @@ import {formatTags} from '../../docs/utils';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-white"
                 size="medium"
               >
@@ -219,7 +219,7 @@ import {formatTags} from '../../docs/utils';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-gray-40"
                 size="medium"
               >
@@ -246,7 +246,7 @@ import {formatTags} from '../../docs/utils';
               <Headline
                 extraBold
                 transform="uppercase"
-                type="span"
+                as="span"
                 color="text-white"
                 size="medium"
               >

--- a/src/components/text/Headline.spec.tsx
+++ b/src/components/text/Headline.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Headline, {
   HEADLINE_SIZE,
-  HEADLINE_TYPE,
+  HEADLINE_AS,
   HEADLINE_TRANSFORM,
   HEADLINE_ALIGN,
 } from './Headline';
@@ -40,9 +40,9 @@ it('size is responsive prop', () => {
   ).toEqual(true);
 });
 test('type', () => {
-  const headline = mount(<Headline type={HEADLINE_TYPE.H3}>Test</Headline>);
+  const headline = mount(<Headline as={HEADLINE_AS.H3}>Test</Headline>);
 
-  expect(headline.props().type).toEqual(HEADLINE_TYPE.H3);
+  expect(headline.props().type).toEqual(HEADLINE_AS.H3);
 });
 test('text-white', () => {
   const text = shallow(<Headline color="text-white">Test</Headline>);

--- a/src/components/text/Headline.spec.tsx
+++ b/src/components/text/Headline.spec.tsx
@@ -42,7 +42,7 @@ it('size is responsive prop', () => {
 test('type', () => {
   const headline = mount(<Headline as={HEADLINE_AS.H3}>Test</Headline>);
 
-  expect(headline.props().type).toEqual(HEADLINE_AS.H3);
+  expect(headline.props().as).toEqual(HEADLINE_AS.H3);
 });
 test('text-white', () => {
   const text = shallow(<Headline color="text-white">Test</Headline>);

--- a/src/components/text/Headline.stories.mdx
+++ b/src/components/text/Headline.stories.mdx
@@ -102,7 +102,7 @@ import PageHeader from 'blocks/PageHeader';
 <Canvas>
   <Story name="Nested">
     {args => (
-      <Headline {...args} type="h2" color={TEXT_COLOR['text-red-60']}>
+      <Headline {...args} as="h2" color={TEXT_COLOR['text-red-60']}>
         Outer headline{' '}
         <Headline inherited as="span">
           nested Headline with inherited styles

--- a/src/components/text/Headline.stories.mdx
+++ b/src/components/text/Headline.stories.mdx
@@ -6,7 +6,7 @@ import {
   HEADLINE_ALIGN,
   HEADLINE_SIZE,
   HEADLINE_TRANSFORM,
-  HEADLINE_TYPE,
+  HEADLINE_AS,
 } from './headlineConsts';
 import HeadlineA11y from './stories/Headline.a11y.mdx';
 import PageHeader from 'blocks/PageHeader';
@@ -19,7 +19,7 @@ import PageHeader from 'blocks/PageHeader';
   }}
   argTypes={{
     children: {control: 'text'},
-    type: {table: {defaultValue: {summary: HEADLINE_TYPE.H1}}},
+    type: {table: {defaultValue: {summary: HEADLINE_AS.H1}}},
     size: {
       description: '(Responsive)',
       table: {

--- a/src/components/text/Headline.stories.mdx
+++ b/src/components/text/Headline.stories.mdx
@@ -104,7 +104,7 @@ import PageHeader from 'blocks/PageHeader';
     {args => (
       <Headline {...args} type="h2" color={TEXT_COLOR['text-red-60']}>
         Outer headline{' '}
-        <Headline inherited type="span">
+        <Headline inherited as="span">
           nested Headline with inherited styles
         </Headline>
       </Headline>

--- a/src/components/text/Headline.tsx
+++ b/src/components/text/Headline.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import {HEADLINE_TYPE} from './headlineConsts';
+import {HEADLINE_AS} from './headlineConsts';
 import {TEXT_COLOR} from './Text';
 import type {TextColorType} from './Text';
 import {generateResponsiveClassNames} from '../utils/responsive-props';
 import type {ResponsivePropType} from '../utils/responsive-props';
 
-export type HeadlineTypeType =
+export type HeadlineAsType =
   | 'span'
   | 'h1'
   | 'h2'
@@ -36,7 +36,7 @@ export type HeadlineAlignType =
   | 'to-right'
   | 'justify';
 export {
-  HEADLINE_TYPE,
+  HEADLINE_AS,
   HEADLINE_SIZE,
   HEADLINE_TRANSFORM,
   HEADLINE_ALIGN,
@@ -45,7 +45,7 @@ export {TEXT_COLOR};
 export type HeadlinePropsType = {
   children?: React.ReactNode;
   size?: ResponsivePropType<HeadlineSizeType>;
-  type?: HeadlineTypeType;
+  as?: HeadlineAsType;
   color?: TextColorType | null | undefined;
   transform?: ResponsivePropType<HeadlineTransformType | null | undefined>;
   align?: ResponsivePropType<HeadlineAlignType | null | undefined>;
@@ -67,7 +67,7 @@ export type HeadlinePropsType = {
 
 const Headline = ({
   children,
-  type = HEADLINE_TYPE.H1,
+  as = HEADLINE_AS.H1,
   size,
   extraBold,
   transform,
@@ -77,13 +77,13 @@ const Headline = ({
   inherited = false,
   ...props
 }: HeadlinePropsType) => {
-  const Type = type;
+  const Type = as;
   const headlineClass = classNames(
     'sg-headline',
     {
       'sg-headline--inherited': inherited,
       [`sg-headline--${String(color)}`]: color,
-      'sg-headline--extra-bold': type === 'strong',
+      'sg-headline--extra-bold': as === 'strong',
     },
     ...generateResponsiveClassNames(
       propValue => `sg-headline--${propValue}`,

--- a/src/components/text/Link.stories.mdx
+++ b/src/components/text/Link.stories.mdx
@@ -168,7 +168,7 @@ import PageHeader from 'blocks/PageHeader';
 <Canvas>
   <Story name="Nested">
     {args => (
-      <Text type="h2" color={TEXT_COLOR['text-red-60']}>
+      <Text as="h2" color={TEXT_COLOR['text-red-60']}>
         Outer text-
         <Link as="button" inherited {...args}>
           nested Link with inherited styles

--- a/src/components/text/Link.tsx
+++ b/src/components/text/Link.tsx
@@ -168,7 +168,7 @@ const Link = (props: LinkPropsType) => {
     return (
       <Text
         {...additionalProps}
-        type="label"
+        as="label"
         className={linkClass}
         size={textSize}
       >
@@ -203,7 +203,7 @@ const Link = (props: LinkPropsType) => {
   return (
     <Text
       {...additionalProps}
-      type={linkType}
+      as={linkType}
       href={href || ''}
       className={linkClass}
       size={textSize}

--- a/src/components/text/Subheadline.spec.tsx
+++ b/src/components/text/Subheadline.spec.tsx
@@ -46,7 +46,7 @@ test('type', () => {
     <Subheadline as={SUBHEADLINE_AS.H3}>Test</Subheadline>
   );
 
-  expect(headline.props().type).toEqual(SUBHEADLINE_AS.H3);
+  expect(headline.props().as).toEqual(SUBHEADLINE_AS.H3);
 });
 test('color', () => {
   const text = shallow(

--- a/src/components/text/Subheadline.spec.tsx
+++ b/src/components/text/Subheadline.spec.tsx
@@ -3,7 +3,7 @@ import Subheadline from './Subheadline';
 import {mount, shallow} from 'enzyme';
 import {
   SUBHEADLINE_SIZE,
-  SUBHEADLINE_TYPE,
+  SUBHEADLINE_AS,
   SUBHEADLINE_ALIGN,
   SUBHEADLINE_TRANSFORM,
 } from './subheadlineConsts';
@@ -43,10 +43,10 @@ it('size is responsive prop', () => {
 });
 test('type', () => {
   const headline = mount(
-    <Subheadline type={SUBHEADLINE_TYPE.H3}>Test</Subheadline>
+    <Subheadline as={SUBHEADLINE_AS.H3}>Test</Subheadline>
   );
 
-  expect(headline.props().type).toEqual(SUBHEADLINE_TYPE.H3);
+  expect(headline.props().type).toEqual(SUBHEADLINE_AS.H3);
 });
 test('color', () => {
   const text = shallow(

--- a/src/components/text/Subheadline.stories.mdx
+++ b/src/components/text/Subheadline.stories.mdx
@@ -162,7 +162,7 @@ Using prop `inherited` makes Subheadline inherits styles from parent e.g. size. 
 <Canvas>
   <Story name="Inherited Styles">
     {args => (
-      <Subheadline {...args} type="h2" size="large">
+      <Subheadline {...args} as="h2" size="large">
         The Brainly community is constantly{' '}
         <Subheadline inherited as="span" color={TEXT_COLOR['text-indigo-60']}>
           buzzing

--- a/src/components/text/Subheadline.stories.mdx
+++ b/src/components/text/Subheadline.stories.mdx
@@ -7,7 +7,7 @@ import {
   SUBHEADLINE_ALIGN,
   SUBHEADLINE_SIZE,
   SUBHEADLINE_TRANSFORM,
-  SUBHEADLINE_TYPE,
+  SUBHEADLINE_AS,
 } from './subheadlineConsts';
 import Box from '../box/Box';
 import Flex from '../flex/Flex';
@@ -24,7 +24,7 @@ import PageHeader from 'blocks/PageHeader';
     children: {
       control: 'text',
     },
-    type: {table: {defaultValue: {summary: SUBHEADLINE_TYPE.H2}}},
+    type: {table: {defaultValue: {summary: SUBHEADLINE_AS.H2}}},
     size: {
       description: '(Responsive)',
       table: {

--- a/src/components/text/Subheadline.stories.mdx
+++ b/src/components/text/Subheadline.stories.mdx
@@ -164,7 +164,7 @@ Using prop `inherited` makes Subheadline inherits styles from parent e.g. size. 
     {args => (
       <Subheadline {...args} type="h2" size="large">
         The Brainly community is constantly{' '}
-        <Subheadline inherited type="span" color={TEXT_COLOR['text-indigo-60']}>
+        <Subheadline inherited as="span" color={TEXT_COLOR['text-indigo-60']}>
           buzzing
         </Subheadline>{' '}
         with the excitement of endless collaboration.

--- a/src/components/text/Subheadline.tsx
+++ b/src/components/text/Subheadline.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import {SUBHEADLINE_TYPE} from './subheadlineConsts';
+import {SUBHEADLINE_AS} from './subheadlineConsts';
 import type {TextColorType} from './Text';
 import {generateResponsiveClassNames} from '../utils/responsive-props';
 import type {ResponsivePropType} from '../utils/responsive-props';
 
-export type SubheadlineTypeType =
+export type SubheadlineAsType =
   | 'span'
   | 'h1'
   | 'h2'
@@ -34,7 +34,7 @@ export type SubheadlineAlignType =
   | 'to-right'
   | 'justify';
 export {
-  SUBHEADLINE_TYPE,
+  SUBHEADLINE_AS,
   SUBHEADLINE_SIZE,
   SUBHEADLINE_TRANSFORM,
   SUBHEADLINE_ALIGN,
@@ -43,7 +43,7 @@ export {TEXT_COLOR} from './Text';
 export type SubheadlinePropsType = {
   children?: React.ReactNode;
   size?: ResponsivePropType<SubheadlineSizeType>;
-  type?: SubheadlineTypeType;
+  as?: SubheadlineAsType;
   color?: TextColorType | null | undefined;
   transform?: ResponsivePropType<SubheadlineTransformType | null | undefined>;
   align?: ResponsivePropType<SubheadlineAlignType | null | undefined>;
@@ -63,7 +63,7 @@ export type SubheadlinePropsType = {
 
 const Subheadline = ({
   children,
-  type = SUBHEADLINE_TYPE.H2,
+  as = SUBHEADLINE_AS.H2,
   size,
   transform,
   align,
@@ -72,7 +72,7 @@ const Subheadline = ({
   inherited = false,
   ...props
 }: SubheadlinePropsType) => {
-  const Type = type;
+  const Type = as;
   const subheadlineClass = classNames(
     'sg-subheadline',
     {

--- a/src/components/text/Text.spec.tsx
+++ b/src/components/text/Text.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Text from './Text';
 import {
-  TEXT_TYPE,
+  TEXT_AS,
   TEXT_SIZE,
   TEXT_WEIGHT,
   TEXT_TRANSFORM,
@@ -35,13 +35,13 @@ it('size is responsive prop', () => {
 });
 test('type', () => {
   const text = 'random text';
-  const component = shallow(<Text type={TEXT_TYPE.SPAN}>{text}</Text>);
+  const component = shallow(<Text as={TEXT_AS.SPAN}>{text}</Text>);
 
   expect(component.find('span').contains(text)).toEqual(true);
 });
 test('type - label', () => {
   const text = 'random text';
-  const component = shallow(<Text type={TEXT_TYPE.LABEL}>{text}</Text>);
+  const component = shallow(<Text as={TEXT_AS.LABEL}>{text}</Text>);
 
   expect(component.find('label').contains(text)).toEqual(true);
 });

--- a/src/components/text/Text.stories.mdx
+++ b/src/components/text/Text.stories.mdx
@@ -6,7 +6,7 @@ import {
   TEXT_TRANSFORM,
   TEXT_WEIGHT,
   TEXT_WHITE_SPACE,
-  TEXT_TYPE,
+  TEXT_AS,
 } from './textConsts';
 import TextA11y from './stories/text.a11y.mdx';
 import PageHeader from 'blocks/PageHeader';
@@ -22,7 +22,7 @@ import PageHeader from 'blocks/PageHeader';
     children: {
       control: 'text',
     },
-    type: {table: {defaultValue: {summary: TEXT_TYPE.DIV}}},
+    type: {table: {defaultValue: {summary: TEXT_AS.DIV}}},
     size: {
       description: '(Responsive)',
       table: {

--- a/src/components/text/Text.stories.mdx
+++ b/src/components/text/Text.stories.mdx
@@ -142,7 +142,7 @@ Text component does not inherit any styles by default. To turn inheritance you c
 <Canvas>
   <Story name="Inherited styles">
     {args => (
-      <Text {...args} type="h2" size="large">
+      <Text {...args} as="h2" size="large">
         <Text inherited as="span" weight="bold">
           83%
         </Text>{' '}

--- a/src/components/text/Text.stories.mdx
+++ b/src/components/text/Text.stories.mdx
@@ -143,11 +143,11 @@ Text component does not inherit any styles by default. To turn inheritance you c
   <Story name="Inherited styles">
     {args => (
       <Text {...args} type="h2" size="large">
-        <Text inherited type="span" weight="bold">
+        <Text inherited as="span" weight="bold">
           83%
         </Text>{' '}
         of students say Brainly has made them more knowledgeable,{' '}
-        <Text inherited type="span" weight="bold">
+        <Text inherited as="span" weight="bold">
           84%
         </Text>{' '}
         find it has inspired them to ask more questions.

--- a/src/components/text/Text.tsx
+++ b/src/components/text/Text.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import classNames from 'classnames';
-import {TEXT_TYPE, TEXT_WHITE_SPACE} from './textConsts';
+import {TEXT_AS, TEXT_WHITE_SPACE} from './textConsts';
 import {generateResponsiveClassNames} from '../utils/responsive-props';
 import type {ResponsivePropType} from '../utils/responsive-props';
 
-export type TextTypeType =
+export type TextAsType =
   | 'span'
   | 'p'
   | 'h1'
@@ -53,11 +53,11 @@ export type TextTransformType = 'uppercase' | 'lowercase' | 'capitalize';
 export type TextAlignType = 'to-left' | 'to-center' | 'to-right' | 'justify';
 export type TextWhiteSpaceType = 'pre-wrap' | 'pre-line' | 'normal';
 export {
-  TYPE, // backward compatibility
+  AS, // backward compatibility
   SIZE, // backward compatibility
   COLOR, // backward compatibility
   WEIGHT, // backward compatibility
-  TEXT_TYPE,
+  TEXT_AS,
   TEXT_SIZE,
   TEXT_COLOR,
   TEXT_WEIGHT,
@@ -68,7 +68,7 @@ export {
 export type TextPropsType = {
   children?: React.ReactNode;
   size?: ResponsivePropType<TextSizeType>;
-  type?: TextTypeType;
+  as?: TextAsType;
   color?: TextColorType | null | undefined;
   weight?: ResponsivePropType<TextWeightType>;
   transform?: ResponsivePropType<TextTransformType | null | undefined>;
@@ -103,7 +103,7 @@ export type TextPropsType = {
 
 const Text = ({
   children,
-  type = TEXT_TYPE.DIV,
+  as = TEXT_AS.DIV,
   size,
   weight,
   color,
@@ -118,14 +118,14 @@ const Text = ({
   inherited = false,
   ...props
 }: TextPropsType) => {
-  const Type = type;
+  const Type = as;
   const textClass = classNames(
     'sg-text',
     {
       'sg-text--inherited': inherited,
       [`sg-text--${String(color)}`]: color,
       'sg-text--container': asContainer,
-      'sg-text--bold': type === 'strong',
+      'sg-text--bold': as === 'strong',
     },
     ...generateResponsiveClassNames(size => `sg-text--${size}`, size),
     ...generateResponsiveClassNames(weight => `sg-text--${weight}`, weight),

--- a/src/components/text/TextBit.spec.tsx
+++ b/src/components/text/TextBit.spec.tsx
@@ -24,7 +24,7 @@ test('size is responsive prop', () => {
 test('type', () => {
   const textBit = mount(<TextBit as={TEXT_BIT_AS.H3}>Test</TextBit>);
 
-  expect(textBit.props().type).toEqual(TEXT_BIT_AS.H3);
+  expect(textBit.props().as).toEqual(TEXT_BIT_AS.H3);
 });
 test('color', () => {
   const textBit = shallow(<TextBit color="text-blue-40">Test</TextBit>);

--- a/src/components/text/TextBit.spec.tsx
+++ b/src/components/text/TextBit.spec.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import TextBit, {TEXT_BIT_TYPE, TEXT_BIT_SIZE} from './TextBit';
+import TextBit, {TEXT_BIT_AS, TEXT_BIT_SIZE} from './TextBit';
 import {shallow, mount} from 'enzyme';
 
 test('render', () => {
-  const textBit = shallow(<TextBit type={TEXT_BIT_TYPE.H1}>Test</TextBit>);
+  const textBit = shallow(<TextBit as={TEXT_BIT_AS.H1}>Test</TextBit>);
 
   expect(textBit.hasClass('sg-text-bit')).toBeTruthy();
 });
@@ -22,9 +22,9 @@ test('size is responsive prop', () => {
   ).toEqual(true);
 });
 test('type', () => {
-  const textBit = mount(<TextBit type={TEXT_BIT_TYPE.H3}>Test</TextBit>);
+  const textBit = mount(<TextBit as={TEXT_BIT_AS.H3}>Test</TextBit>);
 
-  expect(textBit.props().type).toEqual(TEXT_BIT_TYPE.H3);
+  expect(textBit.props().type).toEqual(TEXT_BIT_AS.H3);
 });
 test('color', () => {
   const textBit = shallow(<TextBit color="text-blue-40">Test</TextBit>);

--- a/src/components/text/TextBit.stories.mdx
+++ b/src/components/text/TextBit.stories.mdx
@@ -59,7 +59,7 @@ import PageHeader from 'blocks/PageHeader';
 <Canvas>
   <Story name="Nested">
     {args => (
-      <TextBit {...args} type="h2">
+      <TextBit {...args} as="h2">
         SEARCH{' '}
         <TextBit inherited as="span" color="text-green-60">
           QUESTIONS{' '}

--- a/src/components/text/TextBit.stories.mdx
+++ b/src/components/text/TextBit.stories.mdx
@@ -61,7 +61,7 @@ import PageHeader from 'blocks/PageHeader';
     {args => (
       <TextBit {...args} type="h2">
         SEARCH{' '}
-        <TextBit inherited type="span" color="text-green-60">
+        <TextBit inherited as="span" color="text-green-60">
           QUESTIONS{' '}
         </TextBit>
         OR ASK YOUR OWN

--- a/src/components/text/TextBit.tsx
+++ b/src/components/text/TextBit.tsx
@@ -5,7 +5,7 @@ import {TEXT_COLOR} from './textConsts';
 import {generateResponsiveClassNames} from '../utils/responsive-props';
 import type {ResponsivePropType} from '../utils/responsive-props';
 
-type TextBitTypeType =
+type TextBitAsType =
   | 'h1'
   | 'h2'
   | 'h3'
@@ -20,9 +20,10 @@ type TextBitTypeType =
   | 'em'
   | 'del'
   | 'ins';
+
 type TextBitSizeType = 'small' | 'medium' | 'large' | 'xlarge';
 
-export const TEXT_BIT_TYPE = {
+export const TEXT_BIT_AS = {
   H1: 'h1',
   H2: 'h2',
   H3: 'h3',
@@ -49,7 +50,7 @@ export const TEXT_BIT_SIZE = {
 export {TEXT_COLOR};
 export type TextBitPropsType = {
   children: React.ReactNode;
-  type?: TextBitTypeType;
+  as?: TextBitAsType;
   size?: ResponsivePropType<TextBitSizeType>;
   color?: TextColorType | null | undefined;
   className?: string | null | undefined;
@@ -61,14 +62,14 @@ export type TextBitPropsType = {
 
 const TextBit = ({
   children,
-  type = TEXT_BIT_TYPE.H1,
+  as = TEXT_BIT_AS.H1,
   size,
   color,
   className,
   inherited,
   ...props
 }: TextBitPropsType) => {
-  const Type = type;
+  const Type = as;
   const textClass = classNames(
     'sg-text-bit',
     ...generateResponsiveClassNames(size => `sg-text-bit--${size}`, size),

--- a/src/components/text/headlineConsts.ts
+++ b/src/components/text/headlineConsts.ts
@@ -1,4 +1,4 @@
-export const HEADLINE_TYPE: {
+export const HEADLINE_AS: {
   H1: 'h1';
   H2: 'h2';
   H3: 'h3';

--- a/src/components/text/stories/Headline.a11y.mdx
+++ b/src/components/text/stories/Headline.a11y.mdx
@@ -10,10 +10,10 @@ import TextRules from './textRules.a11y.mdx';
 
 <!-- prettier-ignore -->
 ```jsx
-<Headline type="h2" size="xlarge" extraBold>
+<Headline as="h2" size="xlarge" extraBold>
   Discover more with Textbook Detective
 </Headline>
-<Text type="p">
+<Text as="p">
   Textbook Solutions for all books of class 1 to class 12 solved by our Experts. The solutions comply with all books.
 </Text>
 ```
@@ -23,6 +23,6 @@ import TextRules from './textRules.a11y.mdx';
 <!-- prettier-ignore -->
 ```jsx
 <Headline>
-  Discover <Headline type="strong">more</Headline> with Textbook Detective
+  Discover <Headline as="strong">more</Headline> with Textbook Detective
 </Headline>
 ```

--- a/src/components/text/stories/Subheadline.a11y.mdx
+++ b/src/components/text/stories/Subheadline.a11y.mdx
@@ -10,19 +10,19 @@ import TextRules from './textRules.a11y.mdx';
 
 <!-- prettier-ignore -->
 ```jsx
-<Headline type="h1">
+<Headline as="h1">
   Discover more with Textbook Detective
 </Headline>
-<Subheadline type="h2">
+<Subheadline as="h2">
   College Textbook Answers
 </Subheadline>
-<Text type="p">
+<Text as="p">
   Textbook Solutions for all books solved by our Experts. The solutions comply with all books...
 </Text>
-<Subheadline type="h2">
+<Subheadline as="h2">
   High School Textbook Answers
 </Subheadline>
-<Text type="p">
+<Text as="p">
   Textbook Solutions for all books of class 9 to class 12 solved by our Experts. The solutions comply with all books...
 </Text>
 ```
@@ -32,6 +32,6 @@ import TextRules from './textRules.a11y.mdx';
 <!-- prettier-ignore -->
 ```jsx
 <Subheadline>
-  Discover <Subheadline type="em" color="text-indigo-60">more</Subheadline> with Textbook Detective
+  Discover <Subheadline as="em" color="text-indigo-60">more</Subheadline> with Textbook Detective
 </Subheadline>
 ```

--- a/src/components/text/stories/TextBit.a11y.mdx
+++ b/src/components/text/stories/TextBit.a11y.mdx
@@ -10,7 +10,7 @@ import TextRules from './textRules.a11y.mdx';
 
 <!-- prettier-ignore -->
 ```jsx
-<TextBit type="blockquote">
-  This app is so much more than I expected. I was just needing help to figureout a <TextBit type="del" inherited>math</TextBit> problem
+<TextBit as="blockquote">
+  This app is so much more than I expected. I was just needing help to figureout a <TextBit as="del" inherited>math</TextBit> problem
 </TextBit>
 ```

--- a/src/components/text/stories/text.a11y.mdx
+++ b/src/components/text/stories/text.a11y.mdx
@@ -11,7 +11,7 @@ import TextRules from './textRules.a11y.mdx';
 <!-- prettier-ignore -->
 ```jsx
 <Text>
-  Discover <Text type="strong">more</Text> with <Text type="em" color="text-blue-60">Textbook Detective</Text>
+  Discover <Text as="strong">more</Text> with <Text as="em" color="text-blue-60">Textbook Detective</Text>
 </Text>
 ```
 
@@ -19,7 +19,7 @@ import TextRules from './textRules.a11y.mdx';
 
 <!-- prettier-ignore -->
 ```jsx
-<Text type="p" style={{"max-width": "80ch"}}>
+<Text as="p" style={{"max-width": "80ch"}}>
   Brainly app is so much more than anyone could expected. When someone is just needing help to figure out a chemistry problem...
 </Text>
 ```

--- a/src/components/text/stories/text.stories.mdx
+++ b/src/components/text/stories/text.stories.mdx
@@ -3,7 +3,7 @@ import {Typeset, TypeSpecimen, Label} from 'blocks/Typeset';
 import Text from '../Text';
 import Link, {LINK_WEIGHT, LINK_SIZE, LINK_COLOR} from '../Link';
 import {
-  TEXT_TYPE,
+  TEXT_AS,
   TEXT_SIZE,
   TEXT_COLOR,
   TEXT_WEIGHT,
@@ -11,12 +11,12 @@ import {
   TEXT_ALIGN,
 } from '../textConsts';
 import Headline, {
-  HEADLINE_TYPE,
+  HEADLINE_AS,
   HEADLINE_SIZE,
   HEADLINE_TRANSFORM,
   HEADLINE_ALIGN,
 } from '../Headline';
-import Subheadline, {SUBHEADLINE_TYPE, SUBHEADLINE_SIZE} from '../Subheadline';
+import Subheadline, {SUBHEADLINE_ASs, SUBHEADLINE_SIZE} from '../Subheadline';
 import TextBit, {TEXT_BIT_SIZE, TEXT_BIT_COLOR} from '../TextBit';
 import PageHeader from 'blocks/PageHeader';
 
@@ -153,7 +153,7 @@ export const HeadlineExamples = extraBold => {
           <Label>{size}</Label>
           <Headline
             key={size}
-            as={HEADLINE_TYPE.H2}
+            as={HEADLINE_AS.H2}
             size={size}
             extraBold={extraBold}
           >
@@ -230,7 +230,7 @@ export const SubheadlineExamples = () => {
       sizeVariant.push(
         <TypeSpecimen key={size}>
           <Label>{size}</Label>
-          <Subheadline key={size} as={SUBHEADLINE_TYPE.H2} size={size}>
+          <Subheadline key={size} as={SUBHEADLINE_AS.H2} size={size}>
             Headline
           </Subheadline>
         </TypeSpecimen>
@@ -302,7 +302,7 @@ export const TextExamples = weight => {
         <TypeSpecimen key={size}>
           <Label>{size}</Label>
           <Text
-            as={TEXT_TYPE.H2}
+            as={TEXT_AS.H2}
             size={size}
             color="text-gray-70"
             weight={weight}

--- a/src/components/text/stories/text.stories.mdx
+++ b/src/components/text/stories/text.stories.mdx
@@ -153,7 +153,7 @@ export const HeadlineExamples = extraBold => {
           <Label>{size}</Label>
           <Headline
             key={size}
-            type={HEADLINE_TYPE.H2}
+            as={HEADLINE_TYPE.H2}
             size={size}
             extraBold={extraBold}
           >
@@ -230,7 +230,7 @@ export const SubheadlineExamples = () => {
       sizeVariant.push(
         <TypeSpecimen key={size}>
           <Label>{size}</Label>
-          <Subheadline key={size} type={SUBHEADLINE_TYPE.H2} size={size}>
+          <Subheadline key={size} as={SUBHEADLINE_TYPE.H2} size={size}>
             Headline
           </Subheadline>
         </TypeSpecimen>
@@ -302,7 +302,7 @@ export const TextExamples = weight => {
         <TypeSpecimen key={size}>
           <Label>{size}</Label>
           <Text
-            type={TEXT_TYPE.H2}
+            as={TEXT_TYPE.H2}
             size={size}
             color="text-gray-70"
             weight={weight}

--- a/src/components/text/stories/textRules.a11y.ts
+++ b/src/components/text/stories/textRules.a11y.ts
@@ -14,7 +14,7 @@ const rules = [
   {
     pattern: '<b>Should</b> create a logical content structure.',
     comment:
-      'Logical content structure is created by proper html semantics. Use <code>type</code> to set tag.',
+      'Logical content structure is created by proper html semantics. Use <code>as</code> to set tag.',
     status: 'DONE',
     tests: 'N/A',
   },

--- a/src/components/text/subheadlineConsts.ts
+++ b/src/components/text/subheadlineConsts.ts
@@ -1,4 +1,4 @@
-export const SUBHEADLINE_TYPE = {
+export const SUBHEADLINE_AS = {
   H1: 'h1',
   H2: 'h2',
   H3: 'h3',

--- a/src/components/text/textConsts.ts
+++ b/src/components/text/textConsts.ts
@@ -1,4 +1,4 @@
-export const TEXT_TYPE = {
+export const TEXT_AS = {
   SPAN: 'span',
   P: 'p',
   H1: 'h1',
@@ -18,7 +18,7 @@ export const TEXT_TYPE = {
   INS: 'ins',
 } as const;
 
-export const TYPE = TEXT_TYPE; // backward compatibility
+export const AS = TEXT_AS; // backward compatibility
 
 export const TEXT_SIZE = {
   XXSMALL: 'xxsmall',

--- a/src/docs/stories/introduction.stories.mdx
+++ b/src/docs/stories/introduction.stories.mdx
@@ -22,7 +22,7 @@ import revManifest from 'RevManifest';
     <Flex marginTop={['s', , 'm']}>
       <TextBit
         className="intro-page-header__text"
-        type="h1"
+        as="h1"
         size={['small', 'medium', 'large']}
         color="text-black"
         align="center"

--- a/src/docs/stories/utilities/animations.stories.mdx
+++ b/src/docs/stories/utilities/animations.stories.mdx
@@ -31,7 +31,7 @@ Use fade-in effect in 3 variants: normal, fast and slow.
         <Headline
           extraBold
           transform="uppercase"
-          type="span"
+          as="span"
           color="text-gray-60"
           size="xsmall"
         >
@@ -42,7 +42,7 @@ Use fade-in effect in 3 variants: normal, fast and slow.
         <Headline
           extraBold
           transform="uppercase"
-          type="span"
+          as="span"
           color="text-gray-60"
           size="xsmall"
         >

--- a/src/docs/stories/utilities/shadows.stories.mdx
+++ b/src/docs/stories/utilities/shadows.stories.mdx
@@ -18,7 +18,7 @@ You can use following single purpose flexible classes to highlight differences i
         <Headline
           extraBold
           transform="uppercase"
-          type="span"
+          as="span"
           color="text-gray-60"
           size="xsmall"
         >
@@ -29,7 +29,7 @@ You can use following single purpose flexible classes to highlight differences i
         <Headline
           extraBold
           transform="uppercase"
-          type="span"
+          as="span"
           color="text-gray-60"
           size="xsmall"
         >

--- a/src/docs/stories/utilities/spacing.stories.mdx
+++ b/src/docs/stories/utilities/spacing.stories.mdx
@@ -29,7 +29,7 @@ Control the horizontal space between children.
         <Headline
           extraBold
           transform="uppercase"
-          type="span"
+          as="span"
           color="text-gray-60"
           size="xsmall"
         >
@@ -40,7 +40,7 @@ Control the horizontal space between children.
         <Headline
           extraBold
           transform="uppercase"
-          type="span"
+          as="span"
           color="text-gray-60"
           size="xsmall"
         >
@@ -82,7 +82,7 @@ Control the vertical space between children.
         <Headline
           extraBold
           transform="uppercase"
-          type="span"
+          as="span"
           color="text-gray-60"
           size="xsmall"
         >
@@ -112,7 +112,7 @@ Control the vertical space between children.
         <Headline
           extraBold
           transform="uppercase"
-          type="span"
+          as="span"
           color="text-gray-60"
           size="xsmall"
         >

--- a/src/docs/utils.tsx
+++ b/src/docs/utils.tsx
@@ -46,7 +46,7 @@ export const StoryVariant = ({
     <Headline
       extraBold
       transform="uppercase"
-      type="span"
+      as="span"
       color={whiteText ? 'text-white' : 'text-gray-60'}
       size="xsmall"
       className="sg-story-variant__name"


### PR DESCRIPTION
Changes:
- `Flex` - `htmlTag` renamed to `as`
- `Textarea` - `type` renamed to `as`
- `Icon` - `tagType` renamed to `as`
- `MenuItem` - `type` renamed to `as`
- `Headline`, `Subheadline`, `Text`, `TextBit` - `type` renamed to `as`


closes #2606