### PR TITLE
Handle haptic feedback for safari ios

### DIFF
--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import Spinner, {SPINNER_SIZE, SPINNER_COLOR} from '../spinner/Spinner';
 import cx from 'classnames';
 import {__DEV__, invariant} from '../utils';
+import {useState} from '@storybook/addons';
 
 export const BUTTON_SIZE: {
   L: 'l';
@@ -306,6 +307,8 @@ const Button = React.forwardRef(
     const isDisabled = disabled || loading;
     const isLink = !!href;
 
+    const [pressEffectActive, setPressEffectActive] = React.useState(false);
+
     if (__DEV__) {
       invariant(
         !(
@@ -365,6 +368,7 @@ const Button = React.forwardRef(
         'sg-button--reversed-order': reversedOrder,
         [onPressEffect ? `sg-button--press-${onPressEffect}` : '']:
           onPressEffect,
+        [`sg-button--press-${onPressEffect}-active`]: pressEffectActive,
       },
       className
     );
@@ -385,6 +389,18 @@ const Button = React.forwardRef(
       return onClick && onClick(e);
     };
 
+    const handleTouchStart = () => {
+      if (onPressEffect) {
+        setPressEffectActive(true);
+      }
+    };
+
+    const handleTouchEnd = () => {
+      if (onPressEffect) {
+        setPressEffectActive(false);
+      }
+    };
+
     const TagToRender = isLink ? (isDisabled ? 'span' : 'a') : 'button';
 
     return (
@@ -398,6 +414,8 @@ const Button = React.forwardRef(
         target={target}
         aria-label={ariaLabel}
         onClick={onButtonClick}
+        onTouchStart={handleTouchStart}
+        onTouchEnd={handleTouchEnd}
         type={type}
       >
         {loading && (

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -2,7 +2,6 @@ import * as React from 'react';
 import Spinner, {SPINNER_SIZE, SPINNER_COLOR} from '../spinner/Spinner';
 import cx from 'classnames';
 import {__DEV__, invariant} from '../utils';
-import {useState} from '@storybook/addons';
 
 export const BUTTON_SIZE: {
   L: 'l';

--- a/src/components/buttons/Button.tsx
+++ b/src/components/buttons/Button.tsx
@@ -306,8 +306,6 @@ const Button = React.forwardRef(
     const isDisabled = disabled || loading;
     const isLink = !!href;
 
-    const [pressEffectActive, setPressEffectActive] = React.useState(false);
-
     if (__DEV__) {
       invariant(
         !(
@@ -367,7 +365,6 @@ const Button = React.forwardRef(
         'sg-button--reversed-order': reversedOrder,
         [onPressEffect ? `sg-button--press-${onPressEffect}` : '']:
           onPressEffect,
-        [`sg-button--press-${onPressEffect}-active`]: pressEffectActive,
       },
       className
     );
@@ -388,18 +385,6 @@ const Button = React.forwardRef(
       return onClick && onClick(e);
     };
 
-    const handleTouchStart = () => {
-      if (onPressEffect) {
-        setPressEffectActive(true);
-      }
-    };
-
-    const handleTouchEnd = () => {
-      if (onPressEffect) {
-        setPressEffectActive(false);
-      }
-    };
-
     const TagToRender = isLink ? (isDisabled ? 'span' : 'a') : 'button';
 
     return (
@@ -413,8 +398,9 @@ const Button = React.forwardRef(
         target={target}
         aria-label={ariaLabel}
         onClick={onButtonClick}
-        onTouchStart={handleTouchStart}
-        onTouchEnd={handleTouchEnd}
+        // On iOS the :active pseudo state is triggered only when there is a touch event set on the HTML element
+        // and we use active pseudo class to provide haptic feedback.
+        onTouchStart={() => null}
         type={type}
       >
         {loading && (

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -39,6 +39,10 @@ $largeButtonSize: componentSize(l);
   transition-duration: 0.2s;
   transition-timing-function: ease-in-out;
   box-sizing: border-box;
+  touch-action: manipulation;
+  -webkit-user-select: none;
+  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  user-select: none;
 
   &__text {
     position: relative;
@@ -350,8 +354,8 @@ $largeButtonSize: componentSize(l);
 
   &--press-scale-down {
     transition: transform $durationModerate2 cubic-bezier(0.35, 0, 0.1, 1);
-
-    &:active {
+    &:active,
+    &-active {
       transform: scale(0.86);
     }
   }

--- a/src/components/buttons/_buttons.scss
+++ b/src/components/buttons/_buttons.scss
@@ -354,8 +354,7 @@ $largeButtonSize: componentSize(l);
 
   &--press-scale-down {
     transition: transform $durationModerate2 cubic-bezier(0.35, 0, 0.1, 1);
-    &:active,
-    &-active {
+    &:active {
       transform: scale(0.86);
     }
   }


### PR DESCRIPTION
- Removing click highlight on ios
- Removing user select for all buttons 
- Handling haptic feedback on js level - onTouchStart/End for safari ios

@clxandstuff this is to fix haptic on ios. I am aware that the newest changes published on beta are in [transparent-hover-haptic-feedback-test](https://github.com/brainly/style-guide/compare/transparent-hover-haptic-feedback-test) so this need to be merged aferwards.

https://user-images.githubusercontent.com/8572321/216069895-ec816460-24f4-4ffc-a81e-3e8a931aec2c.mp4


