### PR TITLE
Use type button in dialog close button

### DIFF
--- a/src/components/dialog/DialogCloseButton.tsx
+++ b/src/components/dialog/DialogCloseButton.tsx
@@ -27,6 +27,7 @@ const DialogCloseButton = ({
     iconOnly
     data-testid={dataTestId}
     disabled={disabled}
+    type="button"
   />
 );
 


### PR DESCRIPTION
... Use type `button` in dialog close button to avoid side effects related to form submission.