### PR TITLE
Change action event to trigger on master

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -3,7 +3,8 @@ name: Continuos Integration
 on:
   push:
   pull_request:
-    branches: [main]
+    branches:
+      - master
 
 jobs:
   test:


### PR DESCRIPTION
Previously it was a main. Even though both names should work after github renamed default branch name, name should match in gh actions.