### PR TITLE
Use public chromatic project token to allow external contribution

### DIFF
--- a/.github/workflows/integrate.yml
+++ b/.github/workflows/integrate.yml
@@ -25,7 +25,7 @@ jobs:
         uses: chromaui/action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: 5ef54a1fca5c
           exitZeroOnChanges: true
           autoAcceptChanges: 'master'
           buildScriptName: 'build-chromatic'


### PR DESCRIPTION
Making chromatic project token public, is the only way to allow for running chromatic against external forks.

![CleanShot 2023-03-15 at 11 05 53](https://user-images.githubusercontent.com/8572321/225276542-e57ac34d-85d3-4a44-a4fe-8fd3aef3bfce.png)
