### PR TITLE
Make SubjectIcon svg title id unique

### DIFF
--- a/src/components/icons/Icon.tsx
+++ b/src/components/icons/Icon.tsx
@@ -521,8 +521,12 @@ const Icon = ({
           // @ts-expect-error
           suppressHydrationWarning
         >
-          {/* @ts-expect-error */}
-          <text id={titleId} hidden suppressHydrationWarning>
+          <text
+            id={titleId}
+            visibility="hidden"
+            /* @ts-expect-error */
+            suppressHydrationWarning
+          >
             {title || defaultTitle}
           </text>
           {description && <desc id={descId}>{description}</desc>}

--- a/src/components/subject-icons/SubjectIcon.tsx
+++ b/src/components/subject-icons/SubjectIcon.tsx
@@ -200,8 +200,20 @@ const SubjectIcon = ({
   const defaultTitle = type.replace(/-alt$/g, '').replace(/-/g, ' ');
 
   return (
-    <svg {...props} className={iconClass} aria-labelledby={titleId} role="img">
-      <text id={titleId} visibility="hidden">
+    <svg
+      {...props}
+      className={iconClass}
+      aria-labelledby={titleId}
+      role="img"
+      /* @ts-expect-error */
+      suppressHydrationWarning
+    >
+      <text
+        id={titleId}
+        visibility="hidden"
+        /* @ts-expect-error */
+        suppressHydrationWarning
+      >
         {title || defaultTitle}
       </text>
       <use xlinkHref={iconType} aria-hidden="true" />

--- a/src/components/subject-icons/SubjectIcon.tsx
+++ b/src/components/subject-icons/SubjectIcon.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import classNames from 'classnames';
 import type {IconColorType} from '../icons/Icon';
 import {ICON_COLOR} from '../icons/Icon';
+import {generateId} from '../utils';
 
 export type IconTypeType =
   | 'accountancy'
@@ -172,7 +173,7 @@ export type SubjectIconPropsType = {
   monoColor?: IconColorType;
   title?: string;
 } & Omit<
-  React.AllHTMLAttributes<HTMLElement>,
+  React.SVGProps<SVGSVGElement>,
   'className' | 'type' | 'size' | 'monoColor' | 'title'
 >;
 
@@ -184,6 +185,7 @@ const SubjectIcon = ({
   title,
   ...props
 }: SubjectIconPropsType) => {
+  const {current: id} = React.useRef(generateId());
   const iconClass = classNames(
     'sg-subject-icon',
     {
@@ -194,14 +196,12 @@ const SubjectIcon = ({
     className
   );
   const iconType = `#icon-subject-${monoColor ? 'mono-' : ''}${type}`;
-  const titleId = `sg-math-symbol-icon-${type}-title`;
+  const titleId = `sg-math-symbol-icon-${type}-title-${id}`;
   const defaultTitle = type.replace(/-alt$/g, '').replace(/-/g, ' ');
 
   return (
-    // @ts-expect-error ts migration
     <svg {...props} className={iconClass} aria-labelledby={titleId} role="img">
-      {/* @ts-expect-error ts migration */}
-      <text id={titleId} hidden>
+      <text id={titleId} visibility="hidden">
         {title || defaultTitle}
       </text>
       <use xlinkHref={iconType} aria-hidden="true" />


### PR DESCRIPTION
Closes #2677

I applied the same strategy as Icon. Title id will now include hash.

There was invalid `hidden` attribute added to <text>. Now is replaced with `visibility="hidden"`
https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/visibility