### PR TITLE
remove baseline as accepted prop for Flex justifyContent

### DIFF
--- a/src/components/flex/Flex.tsx
+++ b/src/components/flex/Flex.tsx
@@ -39,7 +39,6 @@ type FlexJustifyValuesType =
   | 'center'
   | 'flex-start'
   | 'flex-end'
-  | 'baseline'
   | 'space-between'
   | 'space-around'
   | 'space-evenly'
@@ -131,7 +130,6 @@ export type FlexPropsType = {
    * @see justifyContent=center https://styleguide.brainly.com/latest/docs/interactive.html?justifyContent=center#flexbox
    * @see justifyContent=flex-start https://styleguide.brainly.com/latest/docs/interactive.html?ustifyContent=flex-start#flexbox
    * @see justifyContent=flex-end https://styleguide.brainly.com/latest/docs/interactive.html?justifyContent=flex-end#flexbox
-   * @see justifyContent=baseline https://styleguide.brainly.com/latest/docs/interactive.html?justifyContent=baseline#flexbox
    * @see justifyContent=space-between https://styleguide.brainly.com/latest/docs/interactive.html?justifyContent=space-between#flexbox
    * @see justifyContent=space-around https://styleguide.brainly.com/latest/docs/interactive.html?justifyContent=space-around#flexbox
    * @see justifyContent=space-evenly https://styleguide.brainly.com/latest/docs/interactive.html?justifyContent=space-evenly#flexbox

--- a/src/components/flex/FlexConsts.ts
+++ b/src/components/flex/FlexConsts.ts
@@ -9,7 +9,6 @@ export const FLEX_JUSTIFY_VALUES = {
   CENTER: 'center',
   FLEX_START: 'flex-start',
   FLEX_END: 'flex-end',
-  BASELINE: 'baseline',
   SPACE_BETWEEN: 'space-between',
   SPACE_AROUND: 'space-around',
   SPACE_EVENLY: 'space-evenly',

--- a/src/components/flex/_flex.scss
+++ b/src/components/flex/_flex.scss
@@ -13,8 +13,7 @@ $flexSpacingsMap: (
 
 $marginSides: (top right bottom left);
 
-$flexProps: (justify-content align-items align-self);
-$flexJustifyValues: (space-between space-evenly space-around);
+$flexProps: (align-items align-self);
 $flexAlignmentValues: (center flex-start flex-end baseline stretch);
 
 .sg-flex {
@@ -83,7 +82,17 @@ $flexAlignmentValues: (center flex-start flex-end baseline stretch);
       flex-direction: row-reverse;
     }
 
-    @each $value in $flexJustifyValues {
+    @each $value
+      in (
+        center,
+        flex-start,
+        flex-end,
+        space-between,
+        space-around,
+        space-evenly,
+        stretch
+      )
+    {
       @include makeResponsive($variant, 'sg-flex--justify-content-#{$value}') {
         justify-content: #{$value};
       }


### PR DESCRIPTION
We will not generate styles for this prop, and typescript will complain when used.

We changed API, however this shouldn't be real breaking change because there will be no effect on user