### PR TITLE
Deploy images on branch builds

### DIFF
--- a/buildspec-storybook-branches-images.yml
+++ b/buildspec-storybook-branches-images.yml
@@ -10,7 +10,7 @@ phases:
     commands:
       - HOST=https://styleguide-dev.brainly.com VERSION=branch/$GIT_BRANCH ./scripts/build.sh -d
 artifacts:
-  name: 'branch/$GIT_BRANCH'
+  name: 'images'
   files:
     - '**/*'
-  base-directory: 'dist/storybook/branch/$GIT_BRANCH'
+  base-directory: 'dist/storybook/images'

--- a/buildspec-storybook-branches.yml
+++ b/buildspec-storybook-branches.yml
@@ -14,3 +14,12 @@ artifacts:
   files:
     - '**/*'
   base-directory: 'dist/storybook/branch/$GIT_BRANCH'
+  secondary-artifacts:
+    images:
+      files:
+        - '**/*'
+      base-directory: 'dist/storybook/images'
+    fonts:
+      files:
+        - '**/*'
+      base-directory: 'dist/storybook/fonts'


### PR DESCRIPTION
This is temporary fix until we will be able to use makefile to build from branch.
We have to wait for https://brainly.atlassian.net/browse/AI-2027