### PR TITLE
Add colors and types to Counter component

### DIFF
--- a/src/components/counters/Counter.tsx
+++ b/src/components/counters/Counter.tsx
@@ -23,7 +23,7 @@ export const COUNTER_TYPE = {
   light: 'light',
 } as const;
 
-export const COLORS_SOLID_MAP = {
+const SOLID_COLOR_BACKGROUND_MAP = {
   blue: 'blue-60',
   green: 'green-60',
   indigo: 'indigo-60',
@@ -43,7 +43,7 @@ const SOLID_COLOR_TEXT_MAP = {
   achromatic: 'text-white',
 } as const;
 
-export const COLORS_LIGHT_MAP = {
+const LIGHT_COLOR_BACKGROUND_MAP = {
   blue: 'blue-20',
   green: 'green-20',
   indigo: 'indigo-20',
@@ -53,7 +53,7 @@ export const COLORS_LIGHT_MAP = {
   achromatic: 'white',
 } as const;
 
-export const COUNTER_COLORS_SET = {
+export const COUNTER_COLOR = {
   BLUE: 'blue',
   GREEN: 'green',
   INDIGO: 'indigo',
@@ -148,7 +148,7 @@ const Counter = ({
   ...props
 }: CounterPropsType) => {
   const backgroundColor =
-    type === 'solid' ? COLORS_SOLID_MAP[color] : COLORS_LIGHT_MAP[color];
+    type === 'solid' ? SOLID_COLOR_BACKGROUND_MAP[color] : LIGHT_COLOR_BACKGROUND_MAP[color];
   const counterClass = cx(
     'sg-counter',
     {
@@ -161,7 +161,7 @@ const Counter = ({
   );
 
   const textColor =
-    type === 'solid' ? SOLID_COLOR_TEXT_MAP[color] : TEXT_COLOR['text-black'];
+    type === 'solid' ? SOLID_COLOR_TEXT_MAP[color] : 'text-black';
 
   let content;
 

--- a/src/components/counters/Counter.tsx
+++ b/src/components/counters/Counter.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import cx from 'classnames';
-import Text, {TEXT_COLOR} from '../text/Text';
+import Text from '../text/Text';
 import Flex from '../flex/Flex';
 import Icon from '../icons/Icon';
 import type {IconTypeType} from '../icons/Icon';

--- a/src/components/counters/Counter.tsx
+++ b/src/components/counters/Counter.tsx
@@ -141,7 +141,7 @@ const Counter = ({
   children,
   className,
   size,
-  color = 'blue',
+  color = 'red',
   type = 'solid',
   withAnimation,
   'aria-label': ariaLabel,

--- a/src/components/counters/Counter.tsx
+++ b/src/components/counters/Counter.tsx
@@ -1,15 +1,66 @@
 import * as React from 'react';
 import cx from 'classnames';
-import Text from '../text/Text';
+import Text, {TEXT_COLOR} from '../text/Text';
 import Flex from '../flex/Flex';
 import Icon from '../icons/Icon';
 import type {IconTypeType} from '../icons/Icon';
 
 type CounterSizeType = 'xs' | 'xxs';
-type ColorType = 'red-60' | 'blue-60';
-export const COUNTER_COLOR = {
-  'red-60': 'red-60',
-  'blue-60': 'blue-60',
+
+export type CounterColorType =
+  | 'blue'
+  | 'green'
+  | 'indigo'
+  | 'red'
+  | 'yellow'
+  | 'gray'
+  | 'achromatic';
+
+export type CounterType = 'light' | 'solid';
+
+export const LABEL_TYPE = {
+  light: 'light',
+  SOLID: 'solid',
+} as const;
+
+export const COLORS_SOLID_MAP = {
+  blue: 'blue-60',
+  green: 'green-60',
+  indigo: 'indigo-60',
+  red: 'red-60',
+  yellow: 'yellow-40',
+  gray: 'gray-40',
+  achromatic: 'black',
+} as const;
+
+const SOLID_COLOR_TEXT_MAP = {
+  blue: 'text-white',
+  green: 'text-white',
+  indigo: 'text-white',
+  red: 'text-white',
+  yellow: 'text-black',
+  gray: 'text-black',
+  achromatic: 'text-white',
+} as const;
+
+export const COLORS_LIGHT_MAP = {
+  blue: 'blue-20',
+  green: 'green-20',
+  indigo: 'indigo-20',
+  red: 'red-20',
+  yellow: 'yellow-20',
+  gray: 'gray-20',
+  achromatic: 'white',
+} as const;
+
+export const COUNTER_COLORS_SET = {
+  BLUE: 'blue',
+  GREEN: 'green',
+  INDIGO: 'indigo',
+  RED: 'red',
+  YELLOW: 'yellow',
+  GRAY: 'gray',
+  ACHROMATIC: 'achromatic',
 } as const;
 
 export const COUNTER_SIZE = {
@@ -48,7 +99,13 @@ export type CounterPropsType = {
    * Counter background color
    * @example <Counter color="blue-60">1</Counter>
    */
-  color?: ColorType | null | undefined;
+  color?: CounterColorType | null | undefined;
+
+  /**
+   * Specify type of counter
+   * @example <Counter type="solid">1</Counter>
+   */
+  type?: CounterType;
 
   /**
    * Optional boolean for counter with animation
@@ -73,6 +130,7 @@ export type CounterPropsType = {
   | 'icon'
   | 'size'
   | 'color'
+  | 'type'
   | 'withAnimation'
   | 'className'
   | 'undefined'
@@ -83,21 +141,28 @@ const Counter = ({
   children,
   className,
   size,
-  color = 'red-60',
+  color = 'blue',
+  type,
   withAnimation,
   'aria-label': ariaLabel,
   ...props
 }: CounterPropsType) => {
+  const backgroundColor =
+    type === 'solid' ? COLORS_SOLID_MAP[color] : COLORS_LIGHT_MAP[color];
   const counterClass = cx(
     'sg-counter',
     {
       [`sg-counter--${String(size)}`]: size,
-      [`sg-counter--${String(color)}`]: color,
+      [`sg-counter--${String(backgroundColor)}`]: backgroundColor,
       'sg-counter--with-animation': withAnimation,
       'sg-counter--with-icon': icon,
     },
     className
   );
+
+  const textColor =
+    type === 'solid' ? SOLID_COLOR_TEXT_MAP[color] : TEXT_COLOR['text-black'];
+
   let content;
 
   content = (
@@ -108,7 +173,7 @@ const Counter = ({
           : 'small'
       }
       weight="bold"
-      color="text-white"
+      color={textColor}
       className={
         size === 'xxs' ? 'sg-counter__text' : 'sg-counter__text-spaced'
       }

--- a/src/components/counters/Counter.tsx
+++ b/src/components/counters/Counter.tsx
@@ -148,7 +148,9 @@ const Counter = ({
   ...props
 }: CounterPropsType) => {
   const backgroundColor =
-    type === 'solid' ? SOLID_COLOR_BACKGROUND_MAP[color] : LIGHT_COLOR_BACKGROUND_MAP[color];
+    type === 'solid'
+      ? SOLID_COLOR_BACKGROUND_MAP[color]
+      : LIGHT_COLOR_BACKGROUND_MAP[color];
   const counterClass = cx(
     'sg-counter',
     {

--- a/src/components/counters/Counter.tsx
+++ b/src/components/counters/Counter.tsx
@@ -16,11 +16,11 @@ export type CounterColorType =
   | 'gray'
   | 'achromatic';
 
-export type CounterType = 'light' | 'solid';
+export type CounterType = 'solid' | 'light';
 
-export const LABEL_TYPE = {
+export const COUNTER_TYPE = {
+  solid: 'solid',
   light: 'light',
-  SOLID: 'solid',
 } as const;
 
 export const COLORS_SOLID_MAP = {
@@ -142,7 +142,7 @@ const Counter = ({
   className,
   size,
   color = 'blue',
-  type,
+  type = 'solid',
   withAnimation,
   'aria-label': ariaLabel,
   ...props

--- a/src/components/counters/Counter.tsx
+++ b/src/components/counters/Counter.tsx
@@ -16,9 +16,9 @@ export type CounterColorType =
   | 'gray'
   | 'achromatic';
 
-export type CounterType = 'solid' | 'light';
+export type CounterVariantType = 'solid' | 'light';
 
-export const COUNTER_TYPE = {
+export const COUNTER_VARIANT = {
   solid: 'solid',
   light: 'light',
 } as const;
@@ -71,25 +71,23 @@ export const COUNTER_SIZE = {
 export type CounterPropsType = {
   /**
    * Children to be rendered inside Counter
-   * @example <Counter type="basic">
+   * @example <Counter>
    *            text
    *          </Counter>
    */
   children: React.ReactNode;
 
   /**
-   * Specify type of the counter that you want to use, two types for now
-   * @example <Counter type="basic">
+   * You can render icon inside of counter
+   * @example <Counter icon="points">
    *            1
    *          </Counter>
-   * @see type="basic" https://styleguide.brainly.com/latest/docs/interactive.html?type="basic"#counters
-   * @see type="points" https://styleguide.brainly.com/latest/docs/interactive.html?type="points"#counters
    */
   icon?: IconTypeType | null | undefined;
 
   /**
    * There are two sizes options for counters, not need to be specify, default is xs
-   * @example <Counter icon="points">
+   * @example <Counter>
    *            1pts
    *          </Counter>
    */
@@ -102,14 +100,14 @@ export type CounterPropsType = {
   color?: CounterColorType | null | undefined;
 
   /**
-   * Specify type of counter
-   * @example <Counter type="solid">1</Counter>
+   * Specify variant of counter
+   * @example <Counter variant="solid">1</Counter>
    */
-  type?: CounterType;
+  variant?: CounterVariantType;
 
   /**
    * Optional boolean for counter with animation
-   * @example <Counter type="basic" withAnimation>
+   * @example <Counter withAnimation>
    *            12
    *          </Counter>
    */
@@ -130,7 +128,7 @@ export type CounterPropsType = {
   | 'icon'
   | 'size'
   | 'color'
-  | 'type'
+  | 'variant'
   | 'withAnimation'
   | 'className'
   | 'undefined'
@@ -140,15 +138,15 @@ const Counter = ({
   icon,
   children,
   className,
-  size,
+  size = 'xs',
   color = 'red',
-  type = 'solid',
+  variant = 'solid',
   withAnimation,
   'aria-label': ariaLabel,
   ...props
 }: CounterPropsType) => {
   const backgroundColor =
-    type === 'solid'
+    variant === 'solid'
       ? SOLID_COLOR_BACKGROUND_MAP[color]
       : LIGHT_COLOR_BACKGROUND_MAP[color];
   const counterClass = cx(
@@ -163,7 +161,7 @@ const Counter = ({
   );
 
   const textColor =
-    type === 'solid' ? SOLID_COLOR_TEXT_MAP[color] : 'text-black';
+    variant === 'solid' ? SOLID_COLOR_TEXT_MAP[color] : 'text-black';
 
   let content;
 

--- a/src/components/counters/Counters.stories.mdx
+++ b/src/components/counters/Counters.stories.mdx
@@ -5,7 +5,7 @@ import {formatTags} from '../../docs/utils';
 import Counter, {
   COUNTER_SIZE,
   COUNTER_TYPE,
-  COUNTER_COLORS_SET,
+  COUNTER_COLOR,
 } from './Counter';
 import {TYPE as ICON_TYPE} from '../icons/Icon';
 import Flex from '../flex/Flex';
@@ -21,7 +21,7 @@ import PageHeader from 'blocks/PageHeader';
     size: {control: {type: 'select', options: COUNTER_SIZE}},
     withAnimation: {control: 'boolean'},
     type: {control: {type: 'select', options: COUNTER_TYPE}},
-    color: {control: {type: 'select', options: COUNTER_COLORS_SET}},
+    color: {control: {type: 'select', options: COUNTER_COLOR}},
     icon: {
       control: {type: 'select', options: Object.values(ICON_TYPE)},
       table: {type: {summary: formatTags(Object.values(ICON_TYPE))}},
@@ -185,7 +185,7 @@ import PageHeader from 'blocks/PageHeader';
             </tr>
           </thead>
           <tbody>
-            {Object.values(COUNTER_COLORS_SET).map(color => (
+            {Object.values(COUNTER_COLOR).map(color => (
               <tr key={color}>
                 <td>
                   <Headline

--- a/src/components/counters/Counters.stories.mdx
+++ b/src/components/counters/Counters.stories.mdx
@@ -2,7 +2,11 @@ import {ArgsTable, Meta, Story, Canvas} from '@storybook/addon-docs';
 import {StoryVariant, StoryVariantTable} from '../../docs/utils';
 import {formatTags} from '../../docs/utils';
 
-import Counter, {COUNTER_SIZE} from './Counter';
+import Counter, {
+  COUNTER_SIZE,
+  COUNTER_TYPE,
+  COUNTER_COLORS_SET,
+} from './Counter';
 import {TYPE as ICON_TYPE} from '../icons/Icon';
 import Flex from '../flex/Flex';
 import Headline from '../text/Headline';
@@ -16,6 +20,8 @@ import PageHeader from 'blocks/PageHeader';
   argTypes={{
     size: {control: {type: 'select', options: COUNTER_SIZE}},
     withAnimation: {control: 'boolean'},
+    type: {control: {type: 'select', options: COUNTER_TYPE}},
+    color: {control: {type: 'select', options: COUNTER_COLORS_SET}},
     icon: {
       control: {type: 'select', options: Object.values(ICON_TYPE)},
       table: {type: {summary: formatTags(Object.values(ICON_TYPE))}},
@@ -47,10 +53,10 @@ import PageHeader from 'blocks/PageHeader';
 
 ## Stories
 
-### Sizes, colors and types
+### Sizes and types
 
 <Canvas>
-  <Story name="SizesColorsAndTypes">
+  <Story name="SizesAndTypes">
     {args => (
       <div>
         <StoryVariantTable>
@@ -65,7 +71,7 @@ import PageHeader from 'blocks/PageHeader';
                   color="text-gray-40"
                   size="medium"
                 >
-                  default
+                  solid
                 </Headline>
               </th>
               <th>
@@ -76,7 +82,7 @@ import PageHeader from 'blocks/PageHeader';
                   color="text-gray-40"
                   size="medium"
                 >
-                  blue
+                  light
                 </Headline>
               </th>
               <th>
@@ -108,14 +114,14 @@ import PageHeader from 'blocks/PageHeader';
                 </td>
                 <td>
                   <Flex justifyContent="center">
-                    <Counter key={size} {...args} size={size}>
+                    <Counter key={size} {...args} size={size} type="solid">
                       2
                     </Counter>
                   </Flex>
                 </td>
                 <td>
                   <Flex justifyContent="center">
-                    <Counter key={size} {...args} size={size} color="blue-60">
+                    <Counter key={size} {...args} size="xs" type="light">
                       2
                     </Counter>
                   </Flex>
@@ -132,6 +138,94 @@ import PageHeader from 'blocks/PageHeader';
                       <Text as="span" color="text-gray-60" inherited>
                         {size !== 'xxs' && ` pts`}{' '}
                       </Text>
+                    </Counter>
+                  </Flex>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </StoryVariantTable>
+      </div>
+    )}
+  </Story>
+</Canvas>
+
+### Colors
+
+<Canvas>
+  <Story name="Colors">
+    {args => (
+      <div>
+        <StoryVariantTable>
+          <thead>
+            <tr>
+              <th />
+              <th>
+                <Headline
+                  extraBold
+                  transform="uppercase"
+                  as="span"
+                  color="text-gray-40"
+                  size="medium"
+                >
+                  solid
+                </Headline>
+              </th>
+              <th>
+                <Headline
+                  extraBold
+                  transform="uppercase"
+                  as="span"
+                  color="text-gray-40"
+                  size="medium"
+                >
+                  light
+                </Headline>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {Object.values(COUNTER_COLORS_SET).map(color => (
+              <tr key={color}>
+                <td>
+                  <Headline
+                    extraBold
+                    transform="uppercase"
+                    as="span"
+                    color="text-gray-40"
+                    size="medium"
+                  >
+                    {color}
+                  </Headline>
+                </td>
+                <td>
+                  <Flex justifyContent="center">
+                    <Counter
+                      key={color}
+                      {...args}
+                      size="xs"
+                      type="solid"
+                      color={color}
+                    >
+                      2
+                    </Counter>
+                  </Flex>
+                </td>
+                <td
+                  style={{
+                    backgroundColor:
+                      color === 'achromatic' ? 'black' : 'transparent',
+                  }}
+                >
+                  <Flex justifyContent="center">
+                    <Counter
+                      key={color}
+                      {...args}
+                      size="xs"
+                      type="light"
+                      color={color}
+                    >
+                      2
                     </Counter>
                   </Flex>
                 </td>

--- a/src/components/counters/Counters.stories.mdx
+++ b/src/components/counters/Counters.stories.mdx
@@ -2,7 +2,7 @@ import {ArgsTable, Meta, Story, Canvas} from '@storybook/addon-docs';
 import {StoryVariant, StoryVariantTable} from '../../docs/utils';
 import {formatTags} from '../../docs/utils';
 
-import Counter, {COUNTER_SIZE, COUNTER_TYPE, COUNTER_COLOR} from './Counter';
+import Counter, {COUNTER_SIZE, COUNTER_VARIANT, COUNTER_COLOR} from './Counter';
 import {TYPE as ICON_TYPE} from '../icons/Icon';
 import Flex from '../flex/Flex';
 import Headline from '../text/Headline';
@@ -16,7 +16,7 @@ import PageHeader from 'blocks/PageHeader';
   argTypes={{
     size: {control: {type: 'select', options: COUNTER_SIZE}},
     withAnimation: {control: 'boolean'},
-    type: {control: {type: 'select', options: COUNTER_TYPE}},
+    variant: {control: {type: 'select', options: COUNTER_VARIANT}},
     color: {control: {type: 'select', options: COUNTER_COLOR}},
     icon: {
       control: {type: 'select', options: Object.values(ICON_TYPE)},
@@ -30,7 +30,6 @@ import PageHeader from 'blocks/PageHeader';
   }}
   args={{
     children: '25',
-    size: 'xs',
   }}
 />
 
@@ -49,10 +48,10 @@ import PageHeader from 'blocks/PageHeader';
 
 ## Stories
 
-### Sizes and types
+### Sizes and variants
 
 <Canvas>
-  <Story name="SizesAndTypes">
+  <Story name="SizesAndVariants">
     {args => (
       <div>
         <StoryVariantTable>
@@ -110,14 +109,14 @@ import PageHeader from 'blocks/PageHeader';
                 </td>
                 <td>
                   <Flex justifyContent="center">
-                    <Counter key={size} {...args} size={size} type="solid">
+                    <Counter key={size} {...args} size={size} variant="solid">
                       2
                     </Counter>
                   </Flex>
                 </td>
                 <td>
                   <Flex justifyContent="center">
-                    <Counter key={size} {...args} size="xs" type="light">
+                    <Counter key={size} {...args} size="xs" variant="light">
                       2
                     </Counter>
                   </Flex>
@@ -200,7 +199,7 @@ import PageHeader from 'blocks/PageHeader';
                       key={color}
                       {...args}
                       size="xs"
-                      type="solid"
+                      variant="solid"
                       color={color}
                     >
                       2
@@ -218,7 +217,7 @@ import PageHeader from 'blocks/PageHeader';
                       key={color}
                       {...args}
                       size="xs"
-                      type="light"
+                      variant="light"
                       color={color}
                     >
                       2

--- a/src/components/counters/Counters.stories.mdx
+++ b/src/components/counters/Counters.stories.mdx
@@ -2,11 +2,7 @@ import {ArgsTable, Meta, Story, Canvas} from '@storybook/addon-docs';
 import {StoryVariant, StoryVariantTable} from '../../docs/utils';
 import {formatTags} from '../../docs/utils';
 
-import Counter, {
-  COUNTER_SIZE,
-  COUNTER_TYPE,
-  COUNTER_COLOR,
-} from './Counter';
+import Counter, {COUNTER_SIZE, COUNTER_TYPE, COUNTER_COLOR} from './Counter';
 import {TYPE as ICON_TYPE} from '../icons/Icon';
 import Flex from '../flex/Flex';
 import Headline from '../text/Headline';

--- a/src/components/counters/_counters.scss
+++ b/src/components/counters/_counters.scss
@@ -26,12 +26,60 @@ $counterSizeXS: componentSize(xs);
       top: 3px;
     }
 
-    &--red-60 {
-      background-color: $red-60;
+    &--black {
+      background-color: $black;
+    }
+
+    &--white {
+      background-color: $white;
     }
 
     &--blue-60 {
       background-color: $blue-60;
+    }
+
+    &--green-60 {
+      background-color: $green-60;
+    }
+
+    &--indigo-60 {
+      background-color: $indigo-60;
+    }
+
+    &--red-60 {
+      background-color: $red-60;
+    }
+
+    &--yellow-40 {
+      background-color: $yellow-40;
+    }
+
+    &--gray-40 {
+      background-color: $gray-40;
+    }
+
+    &--blue-20 {
+      background-color: $blue-20;
+    }
+
+    &--green-20 {
+      background-color: $green-20;
+    }
+
+    &--indigo-20 {
+      background-color: $indigo-20;
+    }
+
+    &--red-20 {
+      background-color: $red-20;
+    }
+
+    &--yellow-20 {
+      background-color: $yellow-20;
+    }
+
+    &--gray-20 {
+      background-color: $gray-20;
     }
 
     &--with-icon {

--- a/src/components/counters/_counters.scss
+++ b/src/components/counters/_counters.scss
@@ -13,7 +13,7 @@ $counterSizeXS: componentSize(xs);
     justify-content: center;
     align-content: center;
     flex-shrink: 0;
-    background-color: $red-60;
+    background-color: var(--red-60);
     cursor: default;
 
     &__text {
@@ -27,59 +27,59 @@ $counterSizeXS: componentSize(xs);
     }
 
     &--black {
-      background-color: $black;
+      background-color: var(--black);
     }
 
     &--white {
-      background-color: $white;
+      background-color: var(--white);
     }
 
     &--blue-60 {
-      background-color: $blue-60;
+      background-color: var(--blue-60);
     }
 
     &--green-60 {
-      background-color: $green-60;
+      background-color: var(--green-60);
     }
 
     &--indigo-60 {
-      background-color: $indigo-60;
+      background-color: var(--indigo-60);
     }
 
     &--red-60 {
-      background-color: $red-60;
+      background-color: var(--red-60);
     }
 
     &--yellow-40 {
-      background-color: $yellow-40;
+      background-color: var(--yellow-40);
     }
 
     &--gray-40 {
-      background-color: $gray-40;
+      background-color: var(--gray-40);
     }
 
     &--blue-20 {
-      background-color: $blue-20;
+      background-color: var(--blue-20);
     }
 
     &--green-20 {
-      background-color: $green-20;
+      background-color: var(--green-20);
     }
 
     &--indigo-20 {
-      background-color: $indigo-20;
+      background-color: var(--indigo-20);
     }
 
     &--red-20 {
-      background-color: $red-20;
+      background-color: var(--red-20);
     }
 
     &--yellow-20 {
-      background-color: $yellow-20;
+      background-color: var(--yellow-20);
     }
 
     &--gray-20 {
-      background-color: $gray-20;
+      background-color: var(--gray-20);
     }
 
     &--with-icon {
@@ -87,7 +87,7 @@ $counterSizeXS: componentSize(xs);
       padding: 0;
       border-radius: $counterSizeXS;
       padding-right: spacing(xs);
-      background: $gray-20;
+      background: var(--gray-20);
       position: relative;
       vertical-align: top;
 
@@ -125,7 +125,7 @@ $counterSizeXS: componentSize(xs);
         border-radius: 10px;
         left: 2px;
         top: 2px;
-        background-color: $white;
+        background-color: var(--white);
       }
 
       &--xxs {


### PR DESCRIPTION
This PR adds types to counter component, dividing it to `solid` and `light` as we have in label component.
![Screenshot 2023-04-04 at 19 52 45](https://user-images.githubusercontent.com/53941885/229876659-0b0a45d1-4993-40b9-bf10-5d6b7c21353d.png)

Additionally, it allows to use all the same color sets as we have in label component for `solid` and `light`
![Screenshot 2023-04-04 at 19 53 38](https://user-images.githubusercontent.com/53941885/229877020-e4be5121-2a3a-4045-80ef-1cc99ddf3251.png)