### PR TITLE
Add misc implicit group to the story

### DIFF
--- a/src/components/icons/Icon.stories.mdx
+++ b/src/components/icons/Icon.stories.mdx
@@ -179,25 +179,29 @@ import {formatTags} from '../../docs/utils';
               ) : null
             )}
           </Flex>
-          <Headline
-            extraBold
-            transform="uppercase"
-            as="span"
-            color="text-gray-40"
-            size="medium"
-            style={{marginBottom: 10, marginLeft: 10, marginTop: 40}}
-          >
-            misc icons
-          </Headline>
-          <Flex wrap>
-            {groups['Misc'].map(type =>
-              type ? (
-                <div className="sg-icon-story-variant" key={type}>
-                  <Icon key={type} {...args} type={type} />
-                </div>
-              ) : null
-            )}
-          </Flex>
+          {groups['Misc'] ? (
+            <>
+              <Headline
+                extraBold
+                transform="uppercase"
+                as="span"
+                color="text-gray-40"
+                size="medium"
+                style={{marginBottom: 10, marginLeft: 10, marginTop: 40}}
+              >
+                misc icons
+              </Headline>
+              <Flex wrap>
+                {groups['Misc'].map(type =>
+                  type ? (
+                    <div className="sg-icon-story-variant" key={type}>
+                      <Icon key={type} {...args} type={type} />
+                    </div>
+                  ) : null
+                )}
+              </Flex>
+            </>
+          ) : null}
         </div>
       );
     }}

--- a/src/components/icons/Icon.stories.mdx
+++ b/src/components/icons/Icon.stories.mdx
@@ -179,6 +179,25 @@ import {formatTags} from '../../docs/utils';
               ) : null
             )}
           </Flex>
+          <Headline
+            extraBold
+            transform="uppercase"
+            as="span"
+            color="text-gray-40"
+            size="medium"
+            style={{marginBottom: 10, marginLeft: 10, marginTop: 40}}
+          >
+            misc icons
+          </Headline>
+          <Flex wrap>
+            {groups['Misc'].map(type =>
+              type ? (
+                <div className="sg-icon-story-variant" key={type}>
+                  <Icon key={type} {...args} type={type} />
+                </div>
+              ) : null
+            )}
+          </Flex>
         </div>
       );
     }}


### PR DESCRIPTION
In case an icon is not added to the named group, we should show "misc" section containing such an icon, otherwise we'll miss that icon during chromatic check.

![CleanShot 2023-04-29 at 13 56 27](https://user-images.githubusercontent.com/8572321/235301271-5b5bac2b-86c3-4b39-a874-f30cd561bd3c.png)
