### PR TITLE
Fix type mismatch in CardRadioGroup Story

### DIFF
--- a/src/components/card-interactive/CardRadioGroup.stories.mdx
+++ b/src/components/card-interactive/CardRadioGroup.stories.mdx
@@ -562,7 +562,6 @@ import CardCustomisation from './stories/CardCustomisation.mdx';
             width="270px"
             height="50px"
             variant="outline"
-            name="usertype"
             id={value}
             value={value}
             onMouseEnter={() => {}}


### PR DESCRIPTION
![image](https://github.com/brainly/style-guide/assets/8572321/c25f6a98-2708-425a-9e0d-abc4607756f5)
