### PR TITLE
Add no-wrap to chip text

### DIFF
--- a/src/components/chip/_chip.scss
+++ b/src/components/chip/_chip.scss
@@ -104,6 +104,7 @@
 
   &__text {
     margin-left: 6px;
+    white-space: nowrap;
 
     &:first-child {
       margin-left: 12px;


### PR DESCRIPTION
before:
![IMG_4917](https://github.com/brainly/style-guide/assets/8572321/6a68234d-7a94-45ff-8ede-81f516edaeaf)

after:
![IMG_4918](https://github.com/brainly/style-guide/assets/8572321/949821a1-6b86-4e91-a044-922b9909b811)

