### PR TITLE
optimize svg paths in storybook

### DIFF
--- a/svgo-config.js
+++ b/svgo-config.js
@@ -12,15 +12,15 @@ module.exports = {
     plugins: ['removeTitle'],
   },
   subjectMonoIcons: {
-    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle'],
+    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle', 'convertPathData'],
   },
   icons: {
-    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle'],
+    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle', 'convertPathData'],
   },
   mathSymbols: {
-    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle'],
+    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle', 'convertPathData'],
   },
   mobileIcons: {
-    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle'],
+    plugins: [removeClass, removeFillNonFixedColors, 'removeTitle', 'convertPathData'],
   },
 };


### PR DESCRIPTION
Optimize svg paths for storybook views.

Unoptimized svgs may look different than svgs that were optimized using SVGO. 

## Unoptimized (svg that used to be displayed in storybook)
![image (11)](https://github.com/brainly/style-guide/assets/52164548/f2477048-f723-467a-b7c0-51dc4bca0c20)

## Optimized using SVGO (svg that is used in final build)
![image (12)](https://github.com/brainly/style-guide/assets/52164548/e89cdbbd-839c-486d-a236-96099a924e95)
