### PR TITLE
Add overlay property to Dialog

### DIFF
--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -41,6 +41,7 @@ export type DialogPropsType = Readonly<{
   onExitTransitionEnd?: () => void;
   'data-testid'?: string;
   position?: 'center' | 'top';
+  overlay?: 'light' | 'dark';
   appearance?: 'none' | 'dialog';
 }>;
 
@@ -53,6 +54,7 @@ Dialog.defaultProps = {
   size: 'm',
   scroll: 'outside',
   position: 'center',
+  overlay: 'light',
   appearance: 'dialog',
 } as Partial<DialogPropsType>;
 
@@ -77,6 +79,7 @@ function BaseDialog({
   onExitTransitionEnd,
   'data-testid': dataTestId,
   position = 'center',
+  overlay = 'light',
   appearance = 'dialog',
 }: DialogPropsType) {
   const overlayRef = React.useRef<HTMLDivElement>(null);
@@ -185,6 +188,7 @@ function BaseDialog({
     'js-dialog',
     'sg-dialog__overlay',
     `sg-dialog__overlay--size-${size}`,
+    `sg-dialog__overlay--open--${overlay}`,
     `sg-dialog__overlay--motion-${motionPreset}`,
     {
       'sg-dialog__overlay--scroll':

--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -2,7 +2,8 @@ $dialogSmallPadding: spacing(m);
 $dialogMediumPadding: spacing(l);
 $dialogOffsetForCloseButton: 48px;
 $dialogBoxShadow: $shadowLarge;
-$dialogOverlayBackgroundColor: rgba(0, 0, 0, 0.3);
+$dialogOverlayBackgroundColorLight: rgba(0, 0, 0, 0.3);
+$dialogOverlayBackgroundColorDark: rgba(0, 0, 0, 0.7);
 
 $dialogSlideWindowDistance: 32px;
 $dialogSlideFullscreenSmallDistance: 88px;
@@ -37,7 +38,12 @@ $dialogMaxWidthMap: (
     }
 
     &--open {
-      background-color: $dialogOverlayBackgroundColor;
+      &--light {
+        background-color: $dialogOverlayBackgroundColorLight;
+      }
+      &--dark {
+        background-color: $dialogOverlayBackgroundColorDark;
+      }
     }
 
     &--scroll {


### PR DESCRIPTION
Separate two variants for overlay property:

Light:
![Screenshot 2024-01-02 at 10 29 36](https://github.com/brainly/style-guide/assets/53941885/9951f169-acb8-4d81-a33e-22edd4a5187d)

Dark:
![Screenshot 2024-01-02 at 10 29 47](https://github.com/brainly/style-guide/assets/53941885/4817f475-9077-4868-87ab-92c64ac192a6)

Business case:
Ads team want to have more focused dialogs when displaying advertisements to users.