### PR TITLE
Dialog - useBodyOnScroll - Fix for nested dialogs case

### DIFF
--- a/src/components/dialog/Dialog.stories.mdx
+++ b/src/components/dialog/Dialog.stories.mdx
@@ -517,6 +517,10 @@ import {fireEvent, within} from '@testing-library/react';
       const handleDismissAnother = () => {
         setAnotherOpen(false);
       };
+      const handleCloseAll = () => {
+        setAnotherOpen(false);
+        setOpen(false);
+      };
       const headerId = 'dialog-header';
       const anotherHeaderId = 'another-dialog-header';
       return (
@@ -583,7 +587,9 @@ import {fireEvent, within} from '@testing-library/react';
                   <Button variant="outline" onClick={handleDismissAnother}>
                     cancel
                   </Button>
-                  <Button variant="solid">proceed</Button>
+                  <Button variant="solid" onClick={handleCloseAll}>
+                    proceed
+                  </Button>
                 </Flex>
               </DialogBody>
             </Dialog>

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -106,7 +106,7 @@ function BaseDialog({
   const [isDialogHigherThanOverlay, setIsDialogHigherThanOverlay] =
     React.useState<boolean>(false);
   const hasAnimations = supportsTransitions() && motionPreset !== 'none';
-  const cleanupBodyNoScroll = useBodyNoScroll();
+  const cleanupBodyNoScroll = useBodyNoScroll(overlayRef);
   const fireTransitionEndCallbacks = React.useCallback(() => {
     setHasFinishedTransition(true);
 

--- a/src/components/dialog/useBodyNoScroll.ts
+++ b/src/components/dialog/useBodyNoScroll.ts
@@ -15,7 +15,7 @@ export function useBodyNoScroll(overlayRef: {current: HTMLDivElement | null}) {
 
     if (isNestedDialog) {
       // if dialog is nested, this logic was already fired by parent dialog
-      // it prevents an issue with no cleanup on nested dialogs
+      // it prevents an issue with no cleanup when nested dialogs
       return;
     }
 
@@ -36,7 +36,7 @@ export function useBodyNoScroll(overlayRef: {current: HTMLDivElement | null}) {
         overlayRef.current?.querySelectorAll(DIALOG_SELECTOR).length | 0;
 
       // nested dialogs shouldn't be counted
-      // as a parent for nested dialogs, this particular can perfrom the cleanup
+      // as a parent for nested dialogs, this particular one should perfrom the cleanup
       const notNestedDialogsOpenCount =
         dialogsOpenCount - nestedOpenDialogsCount;
 

--- a/src/components/dialog/useBodyNoScroll.ts
+++ b/src/components/dialog/useBodyNoScroll.ts
@@ -53,6 +53,6 @@ export function useBodyNoScroll(overlayRef: {current: HTMLDivElement | null}) {
 
     cleanupRef.current = cleanup;
     return cleanup;
-  }, []);
+  }, [overlayRef]);
   return forceCleanup;
 }

--- a/src/components/dialog/useBodyNoScroll.ts
+++ b/src/components/dialog/useBodyNoScroll.ts
@@ -10,6 +10,8 @@ export function useBodyNoScroll(overlayRef: {current: HTMLDivElement | null}) {
   }, []);
 
   React.useEffect(() => {
+    // @todo Use React Context API for detecting nested components
+    // https://github.com/brainly/style-guide/issues/2795
     const isNestedDialog =
       overlayRef.current?.parentElement?.closest(DIALOG_SELECTOR);
 


### PR DESCRIPTION
## before

two dialogs are open. one is nested in another. both are closed at the same time.  `"sg-dialog-no-scroll"` class is not removed from the document body and the whole page cannot be scrolled (due to `manyDialogsOpened` condition).

## after

two dialogs are open. one is nested in another. both are closed at the same time.  `"sg-dialog-no-scroll"` class is removed from the document body and the whole page is working as expected.

**Note:**
An [Issue ](https://github.com/brainly/style-guide/issues/2795) created to introduce an ultimate solution for nested components

