### PR TITLE
Add suppressHydrationWarning to SelectMenu

### DIFF
--- a/src/components/select-menu/SelectMenu.tsx
+++ b/src/components/select-menu/SelectMenu.tsx
@@ -411,7 +411,12 @@ const SelectMenu = React.forwardRef<HTMLDivElement, SelectMenuPropsType>(
     const interactionsFloatingProps = interactions.getFloatingProps();
 
     return (
-      <div id={wrapperId} className={selectClass} onClick={onClick}>
+      <div
+        id={wrapperId}
+        className={selectClass}
+        onClick={onClick}
+        suppressHydrationWarning
+      >
         <div
           ref={selectRef}
           id={id}
@@ -424,6 +429,7 @@ const SelectMenu = React.forwardRef<HTMLDivElement, SelectMenuPropsType>(
           aria-expanded={isExpanded}
           aria-haspopup="listbox"
           data-status={status}
+          suppressHydrationWarning
           {...interactions.getReferenceProps({
             // Handle keyboard
             onKeyDown(event) {


### PR DESCRIPTION
to migitate to following issue:

<img width="725" alt="Screenshot 2024-03-20 at 15 58 14" src="https://github.com/brainly/style-guide/assets/1231144/9d779470-90b2-4dfc-9cc5-b2c8eb2b8f73">

we used `suppressHydrationWarning` already for some other components in similar cases

FYI - we cannot use useId to solve it, since it's not available in React version currently used here.