### PR TITLE
226.0.0 stable release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brainly-style-guide",
-  "version": "226.0.0-beta.0",
+  "version": "226.0.0",
   "description": "Brainly Front-End Style Guide",
   "repository": "https://github.com/brainly/style-guide.git",
   "author": "Brainly Team",


### PR DESCRIPTION
Our release/versioning process is slightly incorrect. running standard `npm version patch` unexpectedly and automatically pushes changes and "tag" which is also against https://github.com/brainly/style-guide/blob/master/CONTRIBUTING.md#preparing-release

IMO, we should remove that and implement something like https://github.com/marketplace/actions/release-drafter or manually with tools like https://github.com/sindresorhus/np or https://github.com/release-it/release-it

Let me know, what do you think