### PR TITLE
Adjust FileHandler by removing target blank attribute.

### DIFF
--- a/src/components/file-handler/FileHandler.tsx
+++ b/src/components/file-handler/FileHandler.tsx
@@ -160,8 +160,6 @@ const FileHandler = ({
       }
     : ({
         href: src,
-        target: '_blank',
-        rel: 'noopener noreferrer',
       } as const);
   const role = clickProps.onClick && 'button';
   const asLink = clickProps.onClick ? 'button' : 'a';


### PR DESCRIPTION
# Remove target blank in FileHandler
According to a11y rules, link which downloads a file should not have target blank attribute. 

Before:
<img width="169" alt="Screenshot 2024-07-19 at 12 45 37" src="https://github.com/user-attachments/assets/e9f4210c-4125-436b-a1da-0aecda02583e">


After:
<img width="169" alt="Screenshot 2024-07-19 at 12 37 07" src="https://github.com/user-attachments/assets/53460451-40a0-4b61-b1ff-a77bb677abc2">
