### PR TITLE
Fix focus styles in dialog component

### DIFF
--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -289,6 +289,7 @@ const BaseDialog = ({
         aria-label={ariaLabel}
         aria-describedby={ariaDescribedBy}
         aria-description={ariaDescription}
+        tabIndex={-1}
         data-testid={dataTestId}
         data-animating={!hasFinishedTransition}
       >

--- a/src/components/dialog/Dialog.tsx
+++ b/src/components/dialog/Dialog.tsx
@@ -289,7 +289,6 @@ const BaseDialog = ({
         aria-label={ariaLabel}
         aria-describedby={ariaDescribedBy}
         aria-description={ariaDescription}
-        tabIndex={-1}
         data-testid={dataTestId}
         data-animating={!hasFinishedTransition}
       >

--- a/src/components/dialog/_dialog.scss
+++ b/src/components/dialog/_dialog.scss
@@ -204,6 +204,10 @@ $dialogMaxWidthMap: (
     &--motion-none {
       transition-duration: 0s;
     }
+
+    &:focus:not(:focus-visible) {
+      box-shadow: $dialogBoxShadow;
+    }
   }
 
   &__header {


### PR DESCRIPTION
## Fix focus styles in dialog 
Bug: https://brainly.atlassian.net/browse/NAX-856
Because of `tabIndex: -1` dialog is programmatically focusable and styles from `applyFocus` mixin are changing box-shadow styles. I fixed that by overriding those styles.
### Before:

https://github.com/user-attachments/assets/7ce7528b-8c0d-46b4-b2fb-6f06b47511e3


### After:

https://github.com/user-attachments/assets/d68cc587-acad-4908-933f-ad49f26b2bf3

