### PR TITLE
Fix overriding body styles when  multiple Dialogs are open

### DIFF
--- a/src/components/dialog/useBodyNoScroll.ts
+++ b/src/components/dialog/useBodyNoScroll.ts
@@ -1,7 +1,6 @@
 import * as React from 'react';
 
 const NO_SCROLL_CLASS = 'sg-dialog-no-scroll';
-const DIALOG_SELECTOR = '.js-dialog';
 
 export function useBodyNoScroll(overlayRef: {current: HTMLDivElement | null}) {
   const cleanupRef = React.useRef(null);
@@ -11,47 +10,26 @@ export function useBodyNoScroll(overlayRef: {current: HTMLDivElement | null}) {
   }, []);
 
   React.useEffect(() => {
-    // @todo Use React Context API for detecting nested components
-    // https://github.com/brainly/style-guide/issues/2795
-    const isNestedDialog =
-      overlayRef.current?.parentElement?.closest(DIALOG_SELECTOR);
+    const body = document.body;
 
-    if (isNestedDialog) {
-      // if dialog is nested, this logic was already fired by parent dialog
-      // it prevents an issue with no cleanup when nested dialogs
+    if (!body) return;
+
+    const initialBodyClassList = body.classList.value;
+    const initialBodyStyleTop = body.style.top;
+
+    if (initialBodyClassList.includes(NO_SCROLL_CLASS)) {
       return;
     }
 
-    const body = document.body;
-    const scrollY = window.scrollY;
-
-    if (!body) return;
-    body.style.top = `-${scrollY}px`;
+    body.style.top = `-${window.scrollY}px`;
     body.classList.add(NO_SCROLL_CLASS);
 
     const cleanup = () => {
       // it can only be forced once
       cleanupRef.current = null;
 
-      const dialogsOpenCount =
-        document.querySelectorAll(DIALOG_SELECTOR).length;
-      const nestedOpenDialogsCount =
-        // @ts-ignore TS2532
-        overlayRef.current?.querySelectorAll(DIALOG_SELECTOR).length | 0;
-
-      // nested dialogs shouldn't be counted
-      // as a parent for nested dialogs, this particular one should perfrom the cleanup
-      const notNestedDialogsOpenCount =
-        dialogsOpenCount - nestedOpenDialogsCount;
-
-      const manyDialogsOpened = notNestedDialogsOpenCount > 1;
-
-      if (manyDialogsOpened) {
-        return;
-      }
-
-      body.style.top = '';
-      body.classList.remove(NO_SCROLL_CLASS);
+      body.style.top = initialBodyStyleTop;
+      body.className = initialBodyClassList;
       window.scrollTo(0, scrollY);
     };
 


### PR DESCRIPTION
Problem: when multiple Dialogs were open, body styles got overridden before all modals were closed. As a solution, every modal will keep its initial body class and `top` value and will restore it upon cleanup. 

Before:


https://github.com/user-attachments/assets/87525d00-aee0-4359-8380-68fbb3f26401


After:

Opening sibling modal and nested modal

https://github.com/user-attachments/assets/826a59b9-5ffc-4892-9e0a-fb6ac0fdb83f

Closing 2 modals at the same time (one is nested)


https://github.com/user-attachments/assets/ee5d2dd6-9861-4b91-8416-3e294489039d

Style guide examples:

Uploading Screen Recording 2024-12-04 at 11.59.17.mov…

