### PR TITLE
Fix issue with scrolling after closing dialog

### DIFF
--- a/src/components/dialog/useBodyNoScroll.ts
+++ b/src/components/dialog/useBodyNoScroll.ts
@@ -16,12 +16,13 @@ export function useBodyNoScroll(overlayRef: {current: HTMLDivElement | null}) {
 
     const initialBodyClassList = body.classList.value;
     const initialBodyStyleTop = body.style.top;
+    const initialScrollY = window.scrollY;
 
     if (initialBodyClassList.includes(NO_SCROLL_CLASS)) {
       return;
     }
 
-    body.style.top = `-${window.scrollY}px`;
+    body.style.top = `-${initialScrollY}px`;
     body.classList.add(NO_SCROLL_CLASS);
 
     const cleanup = () => {
@@ -30,7 +31,7 @@ export function useBodyNoScroll(overlayRef: {current: HTMLDivElement | null}) {
 
       body.style.top = initialBodyStyleTop;
       body.className = initialBodyClassList;
-      window.scrollTo(0, scrollY);
+      window.scrollTo(0, initialScrollY);
     };
 
     // @ts-ignore TS2322


### PR DESCRIPTION
TS didn't show this as error because `scrollY` is a global variable 🙈 

Problem: wrong `scrollY` value was set in the cleanup function (current one instead of initial), which resulted in scrolling to the top after closing Dialog.

Before:

https://github.com/user-attachments/assets/71386203-9661-4398-a574-58f05ae04fe3

After:

https://github.com/user-attachments/assets/4bfe612f-f3b6-4e6d-93fc-6cf809589209

