### PR TITLE
fix: controlled popover open on focus

### DIFF
--- a/src/components/popover/Popover.tsx
+++ b/src/components/popover/Popover.tsx
@@ -40,13 +40,21 @@ export type PopoverPropsType = {
 
   /**
    * Determine if hover should affect popover visibility.
+   * @default true
    */
   useHover?: boolean;
 
   /**
    * Determine if click should affect popover visibility.
+   * @default true
    */
   useClick?: boolean;
+
+  /**
+   * Determine if focus should affect popover visibility.
+   * @default true
+   */
+  useFocus?: boolean;
 
   /**
    * Only controlled component. Handle Popover open state change.
@@ -63,6 +71,7 @@ const Popover = ({
   id,
   useHover,
   useClick,
+  useFocus,
   defaultOpen = false,
   open,
   role,
@@ -76,6 +85,7 @@ const Popover = ({
     onOpenChange,
     useHover,
     useClick,
+    useFocus,
     role,
   });
 

--- a/src/components/popover/usePopover.ts
+++ b/src/components/popover/usePopover.ts
@@ -6,7 +6,7 @@ import {
   useClick as useFloatingClick,
   useHover as useFloatingHover,
   useRole,
-  useFocus,
+  useFocus as useFloatingFocus,
   offset,
   flip,
   arrow,
@@ -29,6 +29,7 @@ interface UsePopoverPropTypes {
   open?: boolean;
   useHover?: boolean;
   useClick?: boolean;
+  useFocus?: boolean;
   role?: PopoverRole;
   onOpenChange?: (arg0: boolean) => void;
 }
@@ -40,6 +41,7 @@ const usePopover = ({
   open,
   useHover = true,
   useClick = true,
+  useFocus = true,
   role = 'dialog',
   onOpenChange,
 }: UsePopoverPropTypes) => {
@@ -130,7 +132,9 @@ const usePopover = ({
       blockPointerEvents: true,
     }),
   });
-  const focus = useFocus(data.context);
+  const focus = useFloatingFocus(data.context, {
+    enabled: useFocus,
+  });
   const click = useFloatingClick(data.context, {
     enabled: useClick,
   });


### PR DESCRIPTION
Added param to control the popover trigger on focus. 

With "useFocus" on false, automatic visibility trigger on focus is disabled, but  when focusing on element that triggers popover and press enter it will work as before.

Integration of controlled popover with the fix:

https://github.com/user-attachments/assets/69fdb4b3-2487-488f-9842-27f6b749aca9

Before (focus changes to input of schoolbar but during first loading it triggers popover again):

https://github.com/user-attachments/assets/1cb4a93d-dfbb-4f2d-ba03-77fce22d61e9

On storybook all the states behave as before with 'useFocus' on default (unless focus + enter):

https://github.com/user-attachments/assets/5852d1af-48de-40b6-8605-1d5dee985e8f

