### PR TITLE
chore: update types of AvatarPropsType

### DIFF
--- a/src/components/avatar/Avatar.tsx
+++ b/src/components/avatar/Avatar.tsx
@@ -23,6 +23,8 @@ export const ICON_SIZE = {
 } as const;
 
 export type AvatarPropsType = {
+  width?: number;
+  height?: number;
   size?: AvatarSizeType;
   border?: boolean;
   spaced?: boolean;
@@ -41,6 +43,8 @@ export type AvatarPropsType = {
   | 'link'
   | 'ariaLinkLabel'
   | 'alt'
+  | 'width'
+  | 'height'
 >;
 
 const Avatar = ({


### PR DESCRIPTION
make wight/height optional number only.
next/image v14+ don't support string for their width/height props.