### PR TITLE
chore(types): 🏷️ supress type issue

### DIFF
--- a/src/components/utils/responsive-props.ts
+++ b/src/components/utils/responsive-props.ts
@@ -43,6 +43,7 @@ export function mergeResponsiveProps(
       return (prop.length > 4 ? prop.slice(0, 4) : prop).reduce(
         (acc, next, index) => {
           if (next !== null && next !== undefined) {
+            // @ts-ignore TS7005
             acc[breakpoints[index]] = next;
           }
 


### PR DESCRIPTION
I believe we should change our build to produce `*.js` + `*.d.ts` instead of delivering `*.ts(s)` files since this causes projects using `style-guilde` to re-build ts files every time, which also triggers checks based on tsconfig of final project.
For now, this is just error suppression to resolve issue in dependent projects