### PR TITLE
Exclude specific class from global focus styles

### DIFF
--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -51,11 +51,11 @@ $includeHtml: false !default;
     line-height: rhythm(1);
   }
 
-  *:not(a) {
+  *:not(a):not(.sg-no-focus-styles) {
     @include applyFocus();
   }
 
-  a {
+  a:not(.sg-no-focus-styles) {
     @include applyFocusText();
   }
 }


### PR DESCRIPTION
We can opt out from global focus styles by adding `.sg-no-focus-styles` class to element.