### PR TITLE
Fix dialog removal from DOM

### DIFF
--- a/src/sass/_basics.scss
+++ b/src/sass/_basics.scss
@@ -51,11 +51,11 @@ $includeHtml: false !default;
     line-height: rhythm(1);
   }
 
-  *:not(a):not(.sg-no-focus-styles) {
+  *:not(a) {
     @include applyFocus();
   }
 
-  a:not(.sg-no-focus-styles) {
+  a {
     @include applyFocusText();
   }
 }

--- a/src/sass/_focus.scss
+++ b/src/sass/_focus.scss
@@ -73,11 +73,11 @@
 @mixin applyFocus() {
   transition: box-shadow $durationQuick1 $easingExit;
 
-  &:focus-visible {
+  &:focus-visible:not(.sg-no-focus-styles) {
     @include applyFocusStyle();
   }
 
-  &:focus {
+  &:focus:not(.sg-no-focus-styles) {
     @include applyFocusStyle();
   }
 
@@ -89,11 +89,11 @@
 }
 
 @mixin applyFocusText() {
-  &:focus-visible {
+  &:focus-visible:not(.sg-no-focus-styles) {
     @include applyFocusTextStyle();
   }
 
-  &:focus {
+  &:focus:not(.sg-no-focus-styles) {
     @include applyFocusTextStyle();
   }
 


### PR DESCRIPTION
Changes included in https://github.com/brainly/style-guide/pull/2837 introduced a bug in Dialog component - dialog wasn't removed from DOM after closing it, overlay was visible and it covered the content below.

## The Root Cause
**Box-shadow Transitions Interfering with Dialog Removal:** 
When using the :not(.sg-no-focus-styles) selector in `_basics.scss`, the CSS specificity changes. Even though we're not explicitly adding this class to elements, the change in selector impacts how and when transition events fire.
The focus styles apply box-shadow transitions to elements, which conflict with the dialog's own opacity/transform transitions that it uses to detect when to unmount itself. The dialog is looking specifically for the [lastTransitionName](https://github.com/brainly/style-guide/blob/master/src/components/dialog/Dialog.tsx#L84) property to match, but when focus styles are in play, the box-shadow transitions can fire instead, confusing the dialog component.
This is why the dialog wasn't being removed from the DOM - its transition detection mechanism was failing due to interference from the focus style transitions.

## Solution
Not to touch Dialog itself as logic there is complicated, I moved excluding `.sg-no-focus-styles` class level lover to `applyFocus` mixin. 



### Before


https://github.com/user-attachments/assets/35f008dd-0e44-405e-b8a2-28abe596f8a2

### After


https://github.com/user-attachments/assets/9194c2a6-f9b4-454d-8bc2-58672d555123

