### PR TITLE
Fix typo in Focus documentation

### DIFF
--- a/src/docs/stories/focus.stories.mdx
+++ b/src/docs/stories/focus.stories.mdx
@@ -129,6 +129,6 @@ To use custom focus style, you can override following CSS variables:
 
 ## High Contrast Mode
 
-Focus style is aligned with Windows Hight Contrast Mode, `Highlight` is used as focus color.
+Focus style is aligned with Windows High Contrast Mode, `Highlight` is used as focus color.
 
 ![In High Contrast Mode focused element has outline](/focus_hcm.png)


### PR DESCRIPTION
The goal for this PR is to fix found typo in `Focus` documentation.